### PR TITLE
Begin documenting `algebra::algebra`

### DIFF
--- a/ext/crates/algebra/src/algebra/bialgebra_trait.rs
+++ b/ext/crates/algebra/src/algebra/bialgebra_trait.rs
@@ -1,17 +1,27 @@
 use crate::algebra::Algebra;
 
+/// An [`Algebra`] equipped with a coproduct operation that makes it into a
+/// bialgebra.
 pub trait Bialgebra: Algebra {
-    /// This function decomposes an element of the algebra as a product of elements, each of whose
-    /// coproduct is easy to calculate. The product is laid out such that the first element of the
-    /// vector is applied to the module element first. This is to be used in conjunction with
-    /// `coproduct`.
+    /// Computes a coproduct $\Delta(x)$, expressed as
     ///
-    /// This structure is motivated by the fact that in the admissible basis for the Adem algebra,
+    /// $$ Delta(x)_i = \sum_j A_{ij} \otimes B_{ij}. $$
+    ///
+    /// The return value is a list of these pairs of basis elements.
+    ///
+    /// `x` must have been returned by [`Bialgebra::decompose()`].
+    fn coproduct(&self, op_deg: i32, op_idx: usize) -> Vec<(i32, usize, i32, usize)>;
+
+    /// Decomposes an element of the algebra into a product of elements, each of
+    /// which we can compute a coproduct on efficiently.
+    ///
+    /// The product is laid out such that the first element of the vector is
+    /// applied to a module element first when acting on it.
+    ///
+    /// This function is to be used with [`Bialgebra::coproduct()`].
+    ///
+    /// This API is motivated by the fact that, in the admissible basis for the Adem algebra,
     /// an element naturally decomposes into a product of Steenrod squares, each of which has an
     /// easy coproduct formula.
     fn decompose(&self, op_deg: i32, op_idx: usize) -> Vec<(i32, usize)>;
-
-    /// Expresses Delta(x) as sum_j (A_{ij} (x) B_{ij}). Here x must be one of the elements
-    /// returned by `decompose`.
-    fn coproduct(&self, op_deg: i32, op_idx: usize) -> Vec<(i32, usize, i32, usize)>;
 }

--- a/ext/crates/algebra/src/algebra/field.rs
+++ b/ext/crates/algebra/src/algebra/field.rs
@@ -1,12 +1,20 @@
+//! Finite fields over a prime.
+
 use crate::algebra::{Algebra, Bialgebra};
 use fp::prime::ValidPrime;
 use fp::vector::{Slice, SliceMut};
 
+/// $\mathbb{F}_p$, viewed as an [`Algebra`] over itself.
+///
+/// As an [`Algebra`], a field is one-dimensional, with basis element `1`.
+/// It is also trivially a coalgebra via the trivial diagonal comultiplication,
+/// and thus a [`Bialgebra`].
 pub struct Field {
     prime: ValidPrime,
 }
 
 impl Field {
+    /// Returns a new `Field` over the given prime `p`.
     pub fn new(p: ValidPrime) -> Self {
         Self { prime: p }
     }
@@ -19,14 +27,12 @@ impl std::fmt::Display for Field {
 }
 
 impl Algebra for Field {
-    /// Returns the prime the algebra is over.
     fn prime(&self) -> ValidPrime {
         self.prime
     }
 
     fn compute_basis(&self, _degree: i32) {}
 
-    /// Gets the dimension of the algebra in degree `degree`.
     fn dimension(&self, degree: i32, _excess: i32) -> usize {
         if degree == 0 {
             1
@@ -52,7 +58,6 @@ impl Algebra for Field {
         vec![]
     }
 
-    /// Converts a basis element into a string for display.
     fn basis_element_to_string(&self, degree: i32, _idx: usize) -> String {
         assert!(degree == 0);
         "1".to_string()

--- a/ext/crates/algebra/src/algebra/mod.rs
+++ b/ext/crates/algebra/src/algebra/mod.rs
@@ -1,21 +1,29 @@
-pub mod combinatorics;
+//! Traits describing algebras, and implementations thereof for different
+//! representations of the Steenrod algebra.
 
 pub mod adem_algebra;
-mod algebra_trait;
-mod bialgebra_trait;
-pub mod field;
-pub mod milnor_algebra;
-mod polynomial_algebra;
-mod steenrod_algebra;
-
 pub use adem_algebra::{AdemAlgebra, AdemAlgebraT};
+
+mod algebra_trait;
 #[cfg(feature = "json")]
 pub use algebra_trait::JsonAlgebra;
 pub use algebra_trait::{Algebra, GeneratedAlgebra};
+
+mod bialgebra_trait;
 pub use bialgebra_trait::Bialgebra;
+
+pub mod combinatorics;
+
+pub mod field;
 pub use field::Field;
+
+pub mod milnor_algebra;
 pub use milnor_algebra::{MilnorAlgebra, MilnorAlgebraT};
+
+mod polynomial_algebra;
 pub use polynomial_algebra::{
     PolynomialAlgebra, PolynomialAlgebraMonomial, PolynomialAlgebraTableEntry,
 };
+
+mod steenrod_algebra;
 pub use steenrod_algebra::{AlgebraType, SteenrodAlgebra, SteenrodAlgebraBorrow, SteenrodAlgebraT};

--- a/ext/crates/algebra/src/lib.rs
+++ b/ext/crates/algebra/src/lib.rs
@@ -1,8 +1,14 @@
-mod algebra;
+//! Types and traits for working with various algebras and modules, with
+//! a focus on the Steenrod algebra and its modules.
+
+// TODO: Write descriptions of each module therein.
+
 pub mod change_of_basis;
 pub mod module;
 pub mod steenrod_evaluator;
 pub mod steenrod_parser;
+
 //pub mod dense_bigraded_algebra;
 
+mod algebra;
 pub use crate::algebra::*;


### PR DESCRIPTION
I'm trying to write down comments in much of the Steenrod algebra code, since my recollection of how Steenrod computations work is the least rusty. I want to start out by documenting everything in `algebra`.

I'm contemplating adding types such as
```rust
struct BasisElem<A> {
  degree: i32,
  basis_idx: usize,
  _ph: PhantomData<A>,
}
```
to try to cut down on the number of arguments getting passed around, since that will make it easier to read the code. If that sounds good I can draft a followup that does that!