### PR TITLE
Update chart dependencies

### DIFF
--- a/chart/chart/display/package.json
+++ b/chart/chart/display/package.json
@@ -6,25 +6,23 @@
     "author": "",
     "license": "ISC",
     "scripts": {
-        "build": "webpack",
-        "serve": "webpack-dev-server"
+        "build": "webpack"
     },
     "devDependencies": {
         "@types/eventemitter3": "^2.0.2",
         "@types/node": "^14.6.0",
         "@types/uuid": "^8.0.0",
-        "@wasm-tool/wasm-pack-plugin": "1.0.1",
+        "@wasm-tool/wasm-pack-plugin": "^1.6.0",
         "css-loader": "^5.0.0",
         "ee-ts": "^1.0.2",
         "html-webpack-plugin": "^5.5.0",
-        "source-map-loader": "^1.0.1",
+        "source-map-loader": "^3.0.1",
         "style-loader": "^2.0.0",
         "text-encoding": "^0.7.0",
         "ts-node": "^8.10.2",
-        "typescript": "^4.0.3",
+        "typescript": "^4.5.5",
         "uuid": "^8.2.0",
-        "webpack": "^5.68.0",
-        "webpack-dev-server": "^3.1.0"
+        "webpack": "^5.68.0"
     },
     "dependencies": {
         "@types/resize-observer-browser": "^0.1.4",

--- a/chart/chart/display_backend/package.json
+++ b/chart/chart/display_backend/package.json
@@ -6,15 +6,13 @@
     "author": "",
     "license": "ISC",
     "scripts": {
-        "build": "webpack",
-        "serve": "webpack-dev-server"
+        "build": "webpack"
     },
     "devDependencies": {
-        "@wasm-tool/wasm-pack-plugin": "1.0.1",
-        "text-encoding": "^0.7.0",
+        "@wasm-tool/wasm-pack-plugin": "^1.6.0",
         "html-webpack-plugin": "^3.2.0",
-        "webpack": "^4.29.4",
-        "webpack-dev-server": "^3.1.0"
+        "text-encoding": "^0.7.0",
+        "webpack": "^5.68.0"
     },
     "dependencies": {
         "webpack-cli": "^4.9.2"

--- a/chart/chart/javascript/package.json
+++ b/chart/chart/javascript/package.json
@@ -12,12 +12,12 @@
         "@types/uuid": "^8.0.0",
         "ee-ts": "^1.0.2",
         "ts-node": "^8.10.2",
-        "typescript": "^3.9.7",
+        "typescript": "^4.5.5",
         "uglifyify": "^5.0.0",
         "webpack": "^5.68.0"
     },
     "dependencies": {
-        "css-loader": "^3.5.3",
+        "css-loader": "^6.5.1",
         "source-map-loader": "^1.0.1",
         "ts-loader": "~8.2.0",
         "uuid": "^8.2.0",

--- a/chart/repl/package.json
+++ b/chart/repl/package.json
@@ -4,13 +4,12 @@
     "description": "Pyodide Repl",
     "main": "index.js",
     "scripts": {
-        "build": "webpack --config library.webpack.config.js && webpack",
-        "start": "webpack-dev-server"
+        "build": "webpack --config library.webpack.config.js && webpack"
     },
     "author": "",
     "license": "ISC",
     "dependencies": {
-        "css-loader": "^4.0.0",
+        "css-loader": "^6.5.1",
         "eventemitter3": "^4.0.4",
         "file-loader": "^6.0.0",
         "monaco-editor": "^0.20.0",
@@ -25,15 +24,14 @@
         "to-string-loader": "^1.1.6",
         "ts-loader": "^9.2.6",
         "url-loader": "^4.1.0",
+        "uuid": "^8.3.2",
         "webpack": "^5.68.0",
         "webpack-cli": "^4.9.2"
     },
     "devDependencies": {
         "@types/resize-observer-browser": "^0.1.4",
-        "awesome-typescript-loader": "^5.2.1",
         "raw-loader": "^4.0.1",
-        "typescript": "^4.0.5",
-        "webpack-dev-server": "^3.11.0",
+        "typescript": "^4.5.5",
         "webpack-zip-files-plugin": "^1.0.0"
     }
 }


### PR DESCRIPTION
Fix security and deprecation warnings and get rid of some unused stuff.

Probably should commit the lock files and switch to using `npm ci` in CI.