### PR TITLE
Bugfix: Incorrect bitshifts in algebra selection

### DIFF
--- a/ext/src/nassau.rs
+++ b/ext/src/nassau.rs
@@ -139,16 +139,16 @@ impl MilnorSubalgebra {
     fn top_degree(&self) -> i32 {
         self.profile
             .iter()
-            .map(|&entry| (2 << entry) - 1)
+            .map(|&entry| (1 << entry) - 1)
             .enumerate()
-            .map(|(idx, entry)| ((2 << (idx + 1)) - 1) * entry)
+            .map(|(idx, entry)| ((1 << (idx + 1)) - 1) * entry)
             .sum()
     }
 
     fn optimal_for(s: u32, t: i32) -> MilnorSubalgebra {
         let mut result = MilnorSubalgebra::zero_algebra();
         for subalgebra in SubalgebraIterator::new() {
-            let coeff = (2 << subalgebra.profile.len()) - 1;
+            let coeff = (1 << subalgebra.profile.len()) - 1;
             if t < coeff * (s as i32 + 1) + subalgebra.top_degree() {
                 // (s,t) is not in the vanishing region of `subalgebra` or any further subalgebra
                 break;


### PR DESCRIPTION
I was wondering why the algorithm was running so much slower all of a sudden, and it's because all my bitshifts were off by a factor of two. It's easy to forget that 2^i and 2 << i aren't the same.