### PR TITLE
More robust saving

### DIFF
--- a/ext/src/save.rs
+++ b/ext/src/save.rs
@@ -313,7 +313,7 @@ impl<A: Algebra> SaveFile<A> {
 
     pub fn open_file(&self, dir: PathBuf) -> Option<Box<dyn Read>> {
         let mut f = open_file(self.get_save_path(dir))?;
-        self.validate_header(&mut f).unwrap();
+        self.validate_header(&mut f).ok()?;
         Some(f)
     }
 

--- a/ext/src/save.rs
+++ b/ext/src/save.rs
@@ -347,7 +347,8 @@ impl<A: Algebra> SaveFile<A> {
 
         let f = std::fs::OpenOptions::new()
             .write(true)
-            .create_new(true)
+            .create(true)
+            .truncate(true)
             .open(&p)
             .with_context(|| format!("Failed to create save file {p:?}"))
             .unwrap();


### PR DESCRIPTION
I was having some issues on the grid due to malformed save files. I submitted the job in a queue where tasks could be preempted, and it messed up the computation when the process was killed while writing to disk. I suggest we ignore save files that have invalid headers, and overwrite them when writing to disk. `create_file` is only ever called after checking if a save exists so that's a safe assumption.