### PR TITLE
Support writing compressed save data

### DIFF
--- a/ext/src/save.rs
+++ b/ext/src/save.rs
@@ -366,12 +366,12 @@ impl<A: Algebra> SaveFile<A> {
             .write(true)
             .create_new(true)
             .open(&p)
-            .unwrap_or_else(|_| panic!("Failed to create save file {p:?}"));
+            .unwrap_or_else(|e| panic!("Failed to create save file {p:?}: {e}"));
 
         #[cfg(feature = "zstd")]
         // We hardcode the compression level to 10 for now
         let f = zstd::Encoder::new(f, 10)
-            .unwrap_or_else(|_| panic!("Failed to create zstd stream for file {p:?}"))
+            .unwrap_or_else(|e| panic!("Failed to create zstd stream for file {p:?}: {e}"))
             .auto_finish();
 
         let mut f = ChecksumWriter::new(BufWriter::new(f));

--- a/ext/src/save.rs
+++ b/ext/src/save.rs
@@ -355,8 +355,8 @@ impl<A: Algebra> SaveFile<A> {
         }
     }
 
-    #[allow(unused_mut)]
     pub fn create_file(&self, dir: PathBuf) -> impl Write {
+        #[allow(unused_mut)]
         let mut p = self.get_save_path(dir);
 
         #[cfg(feature = "zstd")]


### PR DESCRIPTION
It works but is much slower for low stems (7x). I would expect it to be asymptotically negligible. Already going from stem 100 to stem 101 takes only 61% longer.

One idea would be to have a `static ext::save::COMPRESSION_LEVEL: AtomicI32` that would control the compression level dynamically, and we could adjust it as the stems get larger.

Resolves #82 