### PR TITLE
Fix beta lints in ext

### DIFF
--- a/ext/crates/algebra/src/algebra/adem_algebra.rs
+++ b/ext/crates/algebra/src/algebra/adem_algebra.rs
@@ -2,6 +2,9 @@
 
 use std::fmt;
 
+#[allow(unused_imports)]
+use std::fmt::Write as _; // Needed for write! macro for String
+
 use itertools::Itertools;
 use rustc_hash::FxHashMap as HashMap;
 
@@ -1509,12 +1512,13 @@ mod tests {
                 if !output_vec.is_zero() {
                     let mut relation_string = String::new();
                     for (coeff, (deg_1, idx_1), (deg_2, idx_2)) in &relation {
-                        relation_string.push_str(&format!(
+                        let _ = write!(
+                            relation_string,
                             "{} * {} * {}  +  ",
                             *coeff,
                             &algebra.basis_element_to_string(*deg_1, *idx_1),
                             &algebra.basis_element_to_string(*deg_2, *idx_2)
-                        ));
+                        );
                     }
                     relation_string.pop();
                     relation_string.pop();

--- a/ext/crates/algebra/src/algebra/adem_algebra.rs
+++ b/ext/crates/algebra/src/algebra/adem_algebra.rs
@@ -2,9 +2,6 @@
 
 use std::fmt;
 
-#[allow(unused_imports)]
-use std::fmt::Write as _; // Needed for write! macro for String
-
 use itertools::Itertools;
 use rustc_hash::FxHashMap as HashMap;
 
@@ -1435,6 +1432,7 @@ impl Bialgebra for AdemAlgebra {
 mod tests {
     use super::*;
     use rstest::rstest;
+    use std::fmt::Write as _; // Needed for write! macro for String
 
     #[rstest(p, max_degree, case(2, 32), case(3, 120))]
     #[trace]

--- a/ext/crates/algebra/src/algebra/algebra_trait.rs
+++ b/ext/crates/algebra/src/algebra/algebra_trait.rs
@@ -1,7 +1,6 @@
 use fp::prime::ValidPrime;
 use fp::vector::{Slice, SliceMut};
 
-#[allow(unused_imports)]
 use std::fmt::Write as _; // Needed for write! macro for String
 
 #[cfg(doc)]

--- a/ext/crates/algebra/src/algebra/algebra_trait.rs
+++ b/ext/crates/algebra/src/algebra/algebra_trait.rs
@@ -1,6 +1,9 @@
 use fp::prime::ValidPrime;
 use fp::vector::{Slice, SliceMut};
 
+#[allow(unused_imports)]
+use std::fmt::Write as _; // Needed for write! macro for String
+
 #[cfg(doc)]
 use fp::vector::FpVector;
 
@@ -171,10 +174,10 @@ pub trait Algebra: std::fmt::Display + Send + Sync + 'static {
         for (idx, value) in element.iter_nonzero() {
             zero = false;
             if value != 1 {
-                result.push_str(&format!("{} * ", value));
+                let _ = write!(result, "{} * ", value);
             }
             let b = self.basis_element_to_string(degree, idx);
-            result.push_str(&format!("{} + ", b));
+            let _ = write!(result, "{} + ", b);
         }
         if zero {
             result.push('0');

--- a/ext/crates/algebra/src/algebra/milnor_algebra.rs
+++ b/ext/crates/algebra/src/algebra/milnor_algebra.rs
@@ -8,9 +8,6 @@ use fp::prime::{factor_pk, integer_power, Binomial, BitflagIterator, ValidPrime}
 use fp::vector::{FpVector, Slice, SliceMut};
 use once::OnceVec;
 
-#[allow(unused_imports)]
-use std::fmt::Write as _; // Needed for write! macro for String
-
 #[cfg(feature = "json")]
 use {serde::Deserialize, serde::Serialize};
 
@@ -1739,6 +1736,7 @@ mod tests {
 
     use expect_test::expect;
     use rstest::rstest;
+    use std::fmt::Write as _; // Needed for write! macro for String
 
     #[rstest]
     #[trace]

--- a/ext/crates/algebra/src/algebra/milnor_algebra.rs
+++ b/ext/crates/algebra/src/algebra/milnor_algebra.rs
@@ -8,6 +8,9 @@ use fp::prime::{factor_pk, integer_power, Binomial, BitflagIterator, ValidPrime}
 use fp::vector::{FpVector, Slice, SliceMut};
 use once::OnceVec;
 
+#[allow(unused_imports)]
+use std::fmt::Write as _; // Needed for write! macro for String
+
 #[cfg(feature = "json")]
 use {serde::Deserialize, serde::Serialize};
 
@@ -1848,12 +1851,13 @@ mod tests {
                 if !output_vec.is_zero() {
                     let mut relation_string = String::new();
                     for (coeff, (deg_1, idx_1), (deg_2, idx_2)) in &relation {
-                        relation_string.push_str(&format!(
+                        let _ = write!(
+                            relation_string,
                             "{} * {} * {}  +  ",
                             *coeff,
                             &algebra.basis_element_to_string(*deg_1, *idx_1),
                             &algebra.basis_element_to_string(*deg_2, *idx_2)
-                        ));
+                        );
                     }
                     relation_string.pop();
                     relation_string.pop();

--- a/ext/crates/algebra/src/module/finite_dimensional_module.rs
+++ b/ext/crates/algebra/src/module/finite_dimensional_module.rs
@@ -2,6 +2,8 @@ use crate::algebra::Algebra;
 use crate::module::{Module, ZeroModule};
 use bivec::BiVec;
 use fp::vector::{FpVector, SliceMut};
+
+use std::fmt::Write as _;
 use std::sync::Arc;
 
 #[cfg(feature = "json")]
@@ -108,13 +110,14 @@ impl<A: Algebra> FiniteDimensionalModule<A> {
             if !disagreements.is_empty() {
                 let mut err_string = "Actions disagree.\n".to_string();
                 for x in disagreements {
-                    err_string.push_str(&format!(
+                    let _ = write!(
+                        err_string,
                         "  {} * {} disagreement.\n    Left: {}\n    Right: {}\n",
                         self.algebra.basis_element_to_string(x.1 - x.0, x.2),
                         self.basis_element_to_string(x.0, x.3),
                         self.element_to_string(x.1, x.4.as_slice()),
                         self.element_to_string(x.1, x.5.as_slice())
-                    ))
+                    );
                 }
                 return Err(err_string);
             }
@@ -574,12 +577,13 @@ impl<A: GeneratedAlgebra> FiniteDimensionalModule<A> {
                 if !output_vec.is_zero() {
                     let mut relation_string = String::new();
                     for (coef, (deg_1, idx_1), (deg_2, idx_2)) in &relation {
-                        relation_string.push_str(&format!(
+                        let _ = write!(
+                            relation_string,
                             "{} * {} * {}  +  ",
                             *coef,
                             &algebra.basis_element_to_string(*deg_1, *idx_1),
                             &algebra.basis_element_to_string(*deg_2, *idx_2)
-                        ));
+                        );
                     }
                     for _ in 0..5 {
                         relation_string.pop();

--- a/ext/crates/fp/src/vector.rs
+++ b/ext/crates/fp/src/vector.rs
@@ -20,9 +20,6 @@ use std::convert::TryInto;
 use std::io::{Read, Write};
 use std::mem::size_of;
 
-#[allow(unused_imports)]
-use std::fmt::Write as _; // Needed for write! macro for String
-
 macro_rules! dispatch_vector_inner {
     // other is a type, but marking it as a :ty instead of :tt means we cannot use it to access its
     // enum variants.
@@ -488,6 +485,7 @@ mod test {
     use crate::limb;
     use rand::Rng;
     use rstest::rstest;
+    use std::fmt::Write as _; // Needed for write! macro for String
 
     pub struct VectorDiffEntry {
         pub index: usize,

--- a/ext/crates/fp/src/vector.rs
+++ b/ext/crates/fp/src/vector.rs
@@ -15,9 +15,13 @@ use crate::vector_inner::{
 use itertools::Itertools;
 #[cfg(feature = "json")]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
 use std::convert::TryInto;
 use std::io::{Read, Write};
 use std::mem::size_of;
+
+#[allow(unused_imports)]
+use std::fmt::Write as _; // Needed for write! macro for String
 
 macro_rules! dispatch_vector_inner {
     // other is a type, but marking it as a :ty instead of :tt means we cannot use it to access its
@@ -956,16 +960,18 @@ mod test {
             while i < result.len() && j < comparison_result.len() {
                 if result[i] != comparison_result[j] {
                     if result[i].0 < comparison_result[j].0 {
-                        diffs_str.push_str(&format!(
-                                "\n({:?}) present in result, missing from comparison_result",
-                                result[i]
-                                ));
+                        let _ = write!(
+                            diffs_str,
+                            "\n({:?}) present in result, missing from comparison_result",
+                            result[i]
+                        );
                         i += 1;
                     } else {
-                        diffs_str.push_str(&format!(
-                                "\n({:?}) present in comparison_result, missing from result",
-                                comparison_result[j]
-                                ));
+                        let _ = write!(
+                            diffs_str,
+                            "\n({:?}) present in comparison_result, missing from result",
+                            comparison_result[j]
+                        );
                         j += 1;
                     }
                 } else {
@@ -1046,10 +1052,11 @@ mod test {
         for i in 0..dim {
             if vec_result[i] != comparison_result[i] {
                 diffs.push((i, comparison_result[i], vec_result[i]));
-                diffs_str.push_str(&format!(
+                let _ = write!(
+                    diffs_str,
                     "\nIn position {} expected {} got {}. v[i] = {}, w[i] = {}.",
                     i, comparison_result[i], vec_result[i], v_arr[i], w_arr[i]
-                ));
+                );
             }
         }
         assert!(diffs.is_empty(), "{}", diffs_str);


### PR DESCRIPTION
A new clippy lint was complaining about unnecessary allocations when appending to Strings using `format!`. There's still one failure in sseq/web_ext/sseq_gui/tests/test_3.py, where somehow `test_calpha` fails on line 42 but only in beta; stable and nightly are fine.

Edit: Apparently that test_calpha is pretty hit-or-miss because it passed just now...