### PR TITLE
Add IO logging for Nassau quasi-inverses

### DIFF
--- a/ext/Cargo.toml
+++ b/ext/Cargo.toml
@@ -26,6 +26,7 @@ chart = { path = "crates/chart" }
 dashmap = "4.0.0"
 byteorder = "1.4.3"
 
+count-write = { version = "0.1.0", optional = true }
 zstd = { version = "0.9.0", optional = true }
 
 [target.'cfg(unix)'.dependencies]
@@ -45,7 +46,7 @@ default = ["odd-primes"]
 cache-multiplication = ["algebra/cache-multiplication"]
 concurrent = ["rayon", "once/concurrent", "fp/concurrent", "algebra/concurrent"]
 odd-primes = ["fp/odd-primes", "algebra/odd-primes", "sseq/odd-primes"]
-logging = []
+logging = ["count-write"]
 nassau = []
 
 [workspace]

--- a/ext/Cargo.toml
+++ b/ext/Cargo.toml
@@ -26,7 +26,6 @@ chart = { path = "crates/chart" }
 dashmap = "4.0.0"
 byteorder = "1.4.3"
 
-count-write = { version = "0.1.0", optional = true }
 zstd = { version = "0.9.0", optional = true }
 
 [target.'cfg(unix)'.dependencies]
@@ -46,7 +45,7 @@ default = ["odd-primes"]
 cache-multiplication = ["algebra/cache-multiplication"]
 concurrent = ["rayon", "once/concurrent", "fp/concurrent", "algebra/concurrent"]
 odd-primes = ["fp/odd-primes", "algebra/odd-primes", "sseq/odd-primes"]
-logging = ["count-write"]
+logging = []
 nassau = []
 
 [workspace]

--- a/ext/src/nassau.rs
+++ b/ext/src/nassau.rs
@@ -20,8 +20,8 @@ use std::sync::{Arc, Mutex};
 use crate::chain_complex::{
     AugmentedChainComplex, ChainComplex, FiniteChainComplex, FreeChainComplex,
 };
-use crate::save::SaveKind;
 use crate::utils::Timer;
+use crate::{save::SaveKind, utils::LogWriter};
 use algebra::combinatorics;
 use algebra::milnor_algebra::{MilnorAlgebra, PPartEntry};
 use algebra::module::homomorphism::{
@@ -481,6 +481,9 @@ impl<M: ZeroModule<Algebra = MilnorAlgebra>> Resolution<M> {
 
     fn write_qi(
         f: &mut Option<impl Write>,
+        s: u32,
+        t: i32,
+        subalgebra: &MilnorSubalgebra,
         scratch: &mut FpVector,
         signature: &[PPartEntry],
         next_mask: &[usize],
@@ -491,6 +494,9 @@ impl<M: ZeroModule<Algebra = MilnorAlgebra>> Resolution<M> {
             Some(f) => f,
             None => return Ok(()),
         };
+
+        let mut own_f = LogWriter::new(f);
+        let f = &mut own_f;
 
         let pivots = &masked_matrix.pivots()[0..masked_matrix.end[0]];
         if !pivots.iter().any(|&x| x >= 0) {
@@ -521,6 +527,10 @@ impl<M: ZeroModule<Algebra = MilnorAlgebra>> Resolution<M> {
             scratch.to_bytes(f)?;
         }
 
+        own_f.finalize(format_args!(
+            "Written quasi-inverse for bidegree ({n}, {s}) and signature {signature:?}, with {subalgebra}",
+            n = t - s as i32,
+        ));
         Ok(())
     }
 
@@ -586,6 +596,9 @@ impl<M: ZeroModule<Algebra = MilnorAlgebra>> Resolution<M> {
 
         Self::write_qi(
             &mut f,
+            s,
+            t,
+            &subalgebra,
             &mut scratch,
             &zero_sig,
             &next_mask,
@@ -667,6 +680,9 @@ impl<M: ZeroModule<Algebra = MilnorAlgebra>> Resolution<M> {
             }
             Self::write_qi(
                 &mut f,
+                s,
+                t,
+                &subalgebra,
                 &mut scratch,
                 &signature,
                 &next_mask,

--- a/ext/src/utils.rs
+++ b/ext/src/utils.rs
@@ -615,7 +615,6 @@ mod logging {
         pub fn end(self, _msg: std::fmt::Arguments) {}
     }
 
-    #[repr(transparent)]
     pub struct LogWriter<T>(T);
 
     impl<T: Write> Write for LogWriter<T> {


### PR DESCRIPTION
I have a feeling the main bottleneck on the grid is IO, so I added a log entry. It also gives a more granular overview of the progress in a single bidegree, since there's one line for every signature now. I feel this is important now that every bidegree takes several hours. It's also future-proof w.r.t. #99, since we are generic over a `T: Write`