### PR TITLE
Fix all lints

### DIFF
--- a/ext/benches/resolve.rs
+++ b/ext/benches/resolve.rs
@@ -22,7 +22,7 @@ fn benchmark(module_name: &str, max_degree: i32, algebra: &str, n_times: u128) {
     }
     let dur = start.elapsed();
 
-    println!("{} ms / iter", dur.as_millis() / n_times as u128);
+    println!("{} ms / iter", dur.as_millis() / n_times);
 }
 
 fn benchmark_pair(module_name: &str, max_degree: i32, n_times: u128) {

--- a/ext/crates/algebra/src/algebra/adem_algebra.rs
+++ b/ext/crates/algebra/src/algebra/adem_algebra.rs
@@ -181,9 +181,9 @@ impl Algebra for AdemAlgebra {
 
     fn magic(&self) -> u32 {
         if self.unstable_enabled {
-            1 + ((*self.prime() as u32) << 16)
+            1 + (*self.prime() << 16)
         } else {
-            (*self.prime() as u32) << 16
+            *self.prime() << 16
         }
     }
 
@@ -427,14 +427,14 @@ impl GeneratedAlgebra for AdemAlgebra {
                     let idx = self.basis_element_to_index(&AdemBasisElement {
                         degree,
                         ps: if j == 0 {
-                            vec![(x + y) as u32]
+                            vec![x + y]
                         } else {
-                            vec![(x + y - j) as u32, j as u32]
+                            vec![x + y - j, j]
                         },
-                        bocksteins: e1 as u32 | ((e2 as u32) << 1),
+                        bocksteins: e1 | (e2 << 1),
                         p_or_sq: *self.prime() != 2,
                     });
-                    relation.push((c as u32, (degree, idx), (0, 0)));
+                    relation.push((c, (degree, idx), (0, 0)));
                 }
             }
             result.push(relation);
@@ -580,7 +580,7 @@ impl AdemAlgebra {
     fn generate_basis2(&self, max_degree: i32) {
         self.generate_basis_even(max_degree);
         self.basis_table.extend(max_degree as usize, |n| {
-            let mut table = self.even_basis_table[n as usize].clone();
+            let mut table = self.even_basis_table[n].clone();
             if self.unstable_enabled {
                 table.sort_by_cached_key(|e| e.excess(fp::prime::TWO));
             }
@@ -646,7 +646,7 @@ impl AdemAlgebra {
     fn generate_basis_element_to_index_map(&self, max_degree: i32) {
         self.basis_element_to_index_map
             .extend(max_degree as usize, |n| {
-                let basis = &self.basis_table[n as usize];
+                let basis = &self.basis_table[n];
                 let mut map = HashMap::default();
                 map.reserve(basis.len());
                 for (i, basis) in basis.iter().enumerate() {
@@ -700,7 +700,7 @@ impl AdemAlgebra {
 
         // degree -> first_square -> admissibile sequence idx -> result vector
         self.multiplication_table.extend(max_degree as usize, |n| {
-            let mut table: Vec<Vec<FpVector>> = Vec::with_capacity((n + 1) as usize);
+            let mut table: Vec<Vec<FpVector>> = Vec::with_capacity(n + 1);
             let n = n as i32;
 
             table.push(Vec::with_capacity(0));
@@ -1523,7 +1523,7 @@ mod tests {
                     relation_string.pop();
                     relation_string.pop();
                     relation_string.pop();
-                    let value_string = algebra.element_to_string(i as i32, output_vec.as_slice());
+                    let value_string = algebra.element_to_string(i, output_vec.as_slice());
                     panic!(
                         "{}",
                         ModuleFailedRelationError {

--- a/ext/crates/algebra/src/algebra/combinatorics.rs
+++ b/ext/crates/algebra/src/algebra/combinatorics.rs
@@ -228,8 +228,8 @@ impl<'a> PartitionIterator<'a> {
             };
         }
 
-        let idx = if parts.len() == 1 { 0 } else { 1 };
-        partition[idx] = num_parts as u32;
+        let idx = (parts.len() != 1) as usize;
+        partition[idx] = num_parts;
         remaining -= num_parts as i32 * parts[idx];
         Self {
             remaining,

--- a/ext/crates/algebra/src/algebra/field.rs
+++ b/ext/crates/algebra/src/algebra/field.rs
@@ -34,11 +34,7 @@ impl Algebra for Field {
     fn compute_basis(&self, _degree: i32) {}
 
     fn dimension(&self, degree: i32) -> usize {
-        if degree == 0 {
-            1
-        } else {
-            0
-        }
+        usize::from(degree == 0)
     }
 
     fn multiply_basis_elements(

--- a/ext/crates/algebra/src/algebra/milnor_algebra.rs
+++ b/ext/crates/algebra/src/algebra/milnor_algebra.rs
@@ -113,12 +113,7 @@ impl Default for MilnorProfile {
     }
 }
 
-#[cfg(feature = "odd-primes")]
 pub type PPartEntry = u32;
-
-#[cfg(not(feature = "odd-primes"))]
-pub type PPartEntry = u16;
-
 pub type PPart = Vec<PPartEntry>;
 
 #[derive(Debug, Clone, Default)]
@@ -139,9 +134,9 @@ impl MilnorBasisElement {
 
     fn excess(&self, p: ValidPrime) -> u32 {
         if *p == 2 {
-            self.p_part.iter().sum::<PPartEntry>() as u32
+            self.p_part.iter().sum::<PPartEntry>()
         } else {
-            self.q_part.count_ones() + 2 * self.p_part.iter().sum::<PPartEntry>() as u32
+            self.q_part.count_ones() + 2 * self.p_part.iter().sum::<PPartEntry>()
         }
     }
 
@@ -370,7 +365,7 @@ impl Algebra for MilnorAlgebra {
     }
 
     fn magic(&self) -> u32 {
-        ((*self.p as u32) << 16)
+        (*self.p << 16)
             + if self.profile.is_trivial() {
                 0x8000
             } else {
@@ -863,9 +858,8 @@ impl MilnorAlgebra {
         let mut profile_list = Vec::with_capacity(xi_degrees.len());
         for i in 0..xi_degrees.len() {
             if i < self.profile.p_part.len() {
-                profile_list.push(
-                    (integer_power(*self.prime(), self.profile.p_part[i] as u32) - 1) as PPartEntry,
-                );
+                profile_list
+                    .push((integer_power(*self.prime(), self.profile.p_part[i]) - 1) as PPartEntry);
             } else if self.profile.truncated {
                 profile_list.push(0);
             } else {
@@ -907,7 +901,7 @@ impl MilnorAlgebra {
     }
 
     fn generate_basis_generic(&self, max_degree: i32) {
-        let q = (2 * (*self.prime()) - 2) as u32;
+        let q = 2 * (*self.prime()) - 2;
         let tau_degrees = combinatorics::tau_degrees(self.prime());
 
         self.basis_table.extend(max_degree as usize, |d| {
@@ -992,7 +986,7 @@ impl MilnorAlgebra {
 impl MilnorAlgebra {
     fn try_beps_pn(&self, e: u32, x: PPartEntry) -> Option<(i32, usize)> {
         let q = self.q() as u32;
-        let degree = (q * x as u32 + e) as i32;
+        let degree = (q * x + e) as i32;
         self.compute_basis(degree);
         self.try_basis_element_to_index(&MilnorBasisElement {
             degree,
@@ -1480,7 +1474,7 @@ impl<'a, const MOD4: bool> Iterator for PPartMultiplier<'a, MOD4> {
                 while let Some(0) = self.ans.p_part.last() {
                     self.ans.p_part.pop();
                 }
-                return Some(coef as u32);
+                return Some(coef);
             } else if self.update() {
                 self.ans.p_part.reserve(self.diag_num);
                 for diag_idx in 1..=self.diag_num {
@@ -1540,7 +1534,7 @@ impl<'a, const MOD4: bool> Iterator for PPartMultiplier<'a, MOD4> {
                     self.ans.p_part.pop();
                 }
 
-                return Some(coef as u32);
+                return Some(coef);
             } else {
                 return None;
             }
@@ -1633,7 +1627,7 @@ impl MilnorAlgebra {
             if b.p_part[0..len - 1].iter().all(|&x| x == 0) {
                 // There is only one entry
                 let entry = b.p_part[len - 1];
-                let (k, m) = factor_pk(*p, entry as u32);
+                let (k, m) = factor_pk(*p, entry);
 
                 // This is a power of p
                 if m == 1 {
@@ -1688,8 +1682,8 @@ impl MilnorAlgebra {
                     elt.degree = entry_deg * elt.p_part[len - 1] as i32;
                     let second = (elt.degree, self.basis_element_to_index(&elt));
 
-                    let coef = *p
-                        - fp::prime::inverse(p, PPartEntry::binomial(p, pk + rem_entry, pk) as u32);
+                    let coef =
+                        *p - fp::prime::inverse(p, PPartEntry::binomial(p, pk + rem_entry, pk));
                     buffer.extend([(coef, first, second)])
                 }
             } else {
@@ -1862,7 +1856,7 @@ mod tests {
                     relation_string.pop();
                     relation_string.pop();
                     relation_string.pop();
-                    let value_string = algebra.element_to_string(i as i32, output_vec.as_slice());
+                    let value_string = algebra.element_to_string(i, output_vec.as_slice());
                     panic!(
                         "{}",
                         ModuleFailedRelationError {

--- a/ext/crates/algebra/src/module/finite_dimensional_module.rs
+++ b/ext/crates/algebra/src/module/finite_dimensional_module.rs
@@ -350,7 +350,7 @@ impl<A: Algebra> FiniteDimensionalModule<A> {
         for (i, v) in self.gen_names.iter_enum() {
             for (j, n) in v.iter().enumerate() {
                 if n == string {
-                    return Some((i as i32, j));
+                    return Some((i, j));
                 }
             }
         }
@@ -589,8 +589,7 @@ impl<A: GeneratedAlgebra> FiniteDimensionalModule<A> {
                         relation_string.pop();
                     }
 
-                    let value_string =
-                        self.element_to_string(output_deg as i32, output_vec.as_slice());
+                    let value_string = self.element_to_string(output_deg, output_vec.as_slice());
                     return Err(ModuleFailedRelationError {
                         relation: relation_string,
                         value: value_string,
@@ -654,7 +653,7 @@ impl<A: GeneratedAlgebra> FiniteDimensionalModule<A> {
     fn actions_to_json(&self) -> Value {
         let algebra = self.algebra();
         let min_degree = self.min_degree();
-        let max_degree = self.graded_dimension.len() as i32;
+        let max_degree = self.graded_dimension.len();
         let mut actions = Vec::new();
         for input_degree in min_degree..max_degree {
             for output_degree in (input_degree + 1)..max_degree {

--- a/ext/crates/algebra/src/module/homomorphism/full_module_homomorphism.rs
+++ b/ext/crates/algebra/src/module/homomorphism/full_module_homomorphism.rs
@@ -79,7 +79,7 @@ impl<S: Module, T: Module<Algebra = S::Algebra>> ModuleHomomorphism
     }
 
     fn compute_auxiliary_data_through_degree(&self, degree: i32) {
-        let degree = std::cmp::min(degree, self.matrices.len() as i32 - 1);
+        let degree = std::cmp::min(degree, self.matrices.len() - 1);
         self.kernels.extend(degree, |i| {
             let (image, kernel, qi) = self.auxiliary_data(i);
             self.images.push_checked(image, i);

--- a/ext/crates/algebra/src/steenrod_evaluator.rs
+++ b/ext/crates/algebra/src/steenrod_evaluator.rs
@@ -266,9 +266,9 @@ impl SteenrodEvaluator {
             return;
         }
         let mut t: Vec<u32> = vec![0; elt.p_part.len()];
-        t[elt.p_part.len() - 1] = elt.p_part[elt.p_part.len() - 1] as u32;
+        t[elt.p_part.len() - 1] = elt.p_part[elt.p_part.len() - 1];
         for i in (0..elt.p_part.len() - 1).rev() {
-            t[i] = elt.p_part[i] as u32 + 2 * t[i + 1];
+            t[i] = elt.p_part[i] + 2 * t[i + 1];
         }
         let t_idx = self.adem.basis_element_to_index(&AdemBasisElement {
             degree,
@@ -304,14 +304,14 @@ impl SteenrodEvaluator {
         );
         let mut t = vec![0; t_len];
         let last_p_part = if t_len <= elt.p_part.len() {
-            elt.p_part[t_len - 1] as u32
+            elt.p_part[t_len - 1]
         } else {
             0
         };
         t[t_len - 1] = last_p_part + ((elt.q_part >> (t_len)) & 1);
         for i in (0..t_len - 1).rev() {
             let p_part = if i < elt.p_part.len() {
-                elt.p_part[i] as u32
+                elt.p_part[i]
             } else {
                 0
             };

--- a/ext/crates/algebra/src/steenrod_parser.rs
+++ b/ext/crates/algebra/src/steenrod_parser.rs
@@ -207,6 +207,7 @@ fn module_term(i: &str) -> IResult<&str, ModuleNode> {
     .unwrap();
 
     match space(module_generator)(i) {
+        #[allow(clippy::or_fun_call)] // Otherwise it triggers clippy::unnecessary_lazy_evaluations
         Ok((i, gen)) => return Ok((i, vec![(prefix.unwrap_or(Scalar(1)), gen)])),
         Err(nom::Err::Error(_)) => (),
         Err(e) => return Err(e),

--- a/ext/crates/fp/src/constants.rs
+++ b/ext/crates/fp/src/constants.rs
@@ -18,7 +18,7 @@ pub(crate) const INVERSE_TABLE: [[u32; MAX_PRIME]; NUM_PRIMES] = {
     const_for! { i in 0 .. NUM_PRIMES {
         let p = PRIMES[i];
         const_for! { k in 1 .. p {
-            result[i as usize][k as usize] = crate::prime::power_mod(p, k, p - 2);
+            result[i][k as usize] = crate::prime::power_mod(p, k, p - 2);
         }}
     }};
     result

--- a/ext/crates/fp/src/prime.rs
+++ b/ext/crates/fp/src/prime.rs
@@ -524,8 +524,8 @@ mod tests {
 
         for entry in &entries {
             assert_eq!(
-                entry[3] as u32,
-                u32::binomial(ValidPrime::new(entry[0] as u32), entry[1], entry[2])
+                entry[3],
+                u32::binomial(ValidPrime::new(entry[0]), entry[1], entry[2])
             );
         }
     }

--- a/ext/crates/once/src/lib.rs
+++ b/ext/crates/once/src/lib.rs
@@ -19,10 +19,10 @@ const USIZE_LEN: u32 = 0usize.count_zeros();
 /// MAX_OUTER_LENGTH is relatively small, so we picked an arbitrary number.
 const MAX_OUTER_LENGTH: usize = 32;
 
-/// This is a wrapper around our out-of-order push tracker. We put it in a box to make it smaller
-/// in size. See [`OnceVec`] documentation for more details.
+/// This is a wrapper around our out-of-order push tracker. See [`OnceVec`] documentation for
+/// more details.
 #[derive(Clone, Default)]
-pub struct OooTracker(Box<BTreeSet<usize>>);
+pub struct OooTracker(BTreeSet<usize>);
 
 const fn inner_index(index: usize) -> (usize, usize) {
     let page = (USIZE_LEN - 1 - (index + 1).leading_zeros()) as usize;

--- a/ext/examples/define_module.rs
+++ b/ext/examples/define_module.rs
@@ -105,7 +105,7 @@ pub fn interactive_module_define_fdmodule(
 
     for (i, deg_i_gens) in gens.iter_enum() {
         for (j, gen) in deg_i_gens.iter().enumerate() {
-            module.set_basis_element_name(i as i32, j, gen.to_string());
+            module.set_basis_element_name(i, j, gen.to_string());
         }
     }
 
@@ -113,7 +113,7 @@ pub fn interactive_module_define_fdmodule(
 
     let len = gens.len();
     for input_deg in gens.range().rev() {
-        for output_deg in (input_deg + 1)..len as i32 {
+        for output_deg in (input_deg + 1)..len {
             let op_deg = output_deg - input_deg;
             if gens[output_deg].is_empty() {
                 continue;

--- a/ext/examples/steenrod.rs
+++ b/ext/examples/steenrod.rs
@@ -55,7 +55,7 @@ fn main() -> anyhow::Result<()> {
     square.compute_through_bidegree(2 * s, 2 * t);
     for s in 0..=2 * s {
         square
-            .differential(s as u32)
+            .differential(s)
             .compute_auxiliary_data_through_degree(2 * t);
     }
     timer.end(format_args!("Computed quasi-inverses"));
@@ -124,7 +124,7 @@ fn main() -> anyhow::Result<()> {
             let dtarget_module = square.module(s + i - 1);
 
             let d_res = resolution.differential(s);
-            let d_target = square.differential(s + i as u32);
+            let d_target = square.differential(s + i);
 
             let map = Arc::clone(&delta[i as usize][s as usize]);
             let prev_map = match s {
@@ -186,7 +186,7 @@ fn main() -> anyhow::Result<()> {
                             let prevd = m.output(t, j);
 
                             // τ Δ_{i-1}x
-                            square.swap(&mut result, prevd, s + i as u32 - 1, t);
+                            square.swap(&mut result, prevd, s + i - 1, t);
                             result += prevd;
                         }
 
@@ -897,7 +897,7 @@ mod tensor_product_chain_complex {
                 let mut index = 0;
                 let mut row = 0;
                 for s in 0..self.source_s as usize {
-                    let target_module = &self.target.modules[s as usize]; // C_s (x) D_{source_s - s - 1}
+                    let target_module = &self.target.modules[s]; // C_s (x) D_{source_s - s - 1}
 
                     let target_right_dim = target_module.right.dimension(right_t);
                     let target_left_dim = target_module.left.dimension(left_t);

--- a/ext/src/secondary.rs
+++ b/ext/src/secondary.rs
@@ -551,7 +551,7 @@ pub trait SecondaryLift: Sync {
         let source = self.source().module(s);
         let target = self.target();
         let num_gens = source.number_of_gens_in_degree(t);
-        let target_dim = target.module(s as u32 - shift_s).dimension(t - shift_t - 1);
+        let target_dim = target.module(s - shift_s).dimension(t - shift_t - 1);
 
         if let Some(dir) = self.save_dir() {
             let save_file = SaveFile {
@@ -600,14 +600,14 @@ pub trait SecondaryLift: Sync {
 
         assert!(target.apply_quasi_inverse(
             &mut results,
-            s as u32 - shift_s,
+            s - shift_s,
             t - shift_t - 1,
             &intermediates,
         ));
 
         if s == shift_s + 1 {
             // Check that we indeed had a lift
-            let d = target.differential(s as u32 - shift_s);
+            let d = target.differential(s - shift_s);
             for (src, tgt) in std::iter::zip(&results, &mut intermediates) {
                 d.apply(tgt.as_slice_mut(), *p - 1, t - shift_t - 1, src.as_slice());
                 assert!(
@@ -734,7 +734,7 @@ where
     }
 
     fn max_s(&self) -> u32 {
-        self.underlying.next_homological_degree() as u32
+        self.underlying.next_homological_degree()
     }
 
     fn max_t(&self, s: u32) -> i32 {
@@ -1063,7 +1063,7 @@ where
         } else {
             1
         };
-        let filtration_one_sign = if (t as i32 % 2) == 1 { *p - 1 } else { 1 };
+        let filtration_one_sign = if (t % 2) == 1 { *p - 1 } else { 1 };
 
         let page_data = sseq.map(|sseq| {
             let d = sseq.page_data(source_t - source_s as i32, source_s as i32 + 1);

--- a/ext/src/yoneda.rs
+++ b/ext/src/yoneda.rs
@@ -624,7 +624,7 @@ where
     let first_image_row = matrix.find_first_row_in_block(matrix.start[1]);
     let image_rows = matrix.rows() - first_image_row;
 
-    let matrix = matrix.into_tail_segment(first_kernel_row as usize, source_dimension, 1);
+    let matrix = matrix.into_tail_segment(first_kernel_row, source_dimension, 1);
 
     let mut image_matrix = Matrix::new(p, image_rows, source_orig_dimension);
     for (target, source) in std::iter::zip(

--- a/web_ext/sseq_gui/src/main.rs
+++ b/web_ext/sseq_gui/src/main.rs
@@ -223,6 +223,7 @@ impl Server {
         }
     }
 
+    #[allow(unknown_lints)] // `result_large_err` only introduced in 1.64
     #[allow(clippy::result_large_err)]
     pub fn serve_files(&self, request_path: &str) -> WsResult<Response> {
         println!("Request path: {}", request_path);

--- a/web_ext/sseq_gui/src/main.rs
+++ b/web_ext/sseq_gui/src/main.rs
@@ -223,6 +223,7 @@ impl Server {
         }
     }
 
+    #[allow(clippy::result_large_err)]
     pub fn serve_files(&self, request_path: &str) -> WsResult<Response> {
         println!("Request path: {}", request_path);
         let request_path = request_path.split('?').collect::<Vec<&str>>()[0]; // Ignore ?...


### PR DESCRIPTION
It's been a few months so there were a few new lints to fix. Most importantly:

 - `OooTracker` is now a `BTreeSet` instead of a `Box<BTreeSet>`. This shouldn't make a difference since a `BTreeSet` is already heap-allocated.
 - `PPart` is now u32, no longer either u16 or u32 depending on features. This solves the numerous superfluous cast lints that clippy was upset about, and benchmarking shows that there is no measurable hit in performance.
