### PR TITLE
Disable failing miri test

### DIFF
--- a/ext/crates/once/src/lib.rs
+++ b/ext/crates/once/src/lib.rs
@@ -584,7 +584,8 @@ impl<T: Send + Sync> OnceVec<T> {
     /// simultaneously using [`rayon`].
     ///
     /// # Example
-    /// ```
+    #[cfg_attr(miri, doc = "```ignore")]
+    #[cfg_attr(not(miri), doc = "```")]
     /// # use once::OnceVec;
     /// let v: OnceVec<usize> = OnceVec::new();
     /// v.par_extend(5, |i| i + 5);


### PR DESCRIPTION
Because of rayon-rs/rayon#952, the only way to pass the miri check is to disable that doctest