### PR TITLE
Fix bruner nassau crash

### DIFF
--- a/ext/examples/bruner.rs
+++ b/ext/examples/bruner.rs
@@ -230,6 +230,14 @@ fn main() {
     let save_dir = query::optional("Save directory", |x| {
         core::result::Result::<PathBuf, std::convert::Infallible>::Ok(PathBuf::from(x))
     });
+
+    #[cfg(feature = "nassau")]
+    if save_dir.is_none() {
+        panic!(
+            "A save directory is required for comparison between Bruner and Nassau resolutions."
+        );
+    }
+
     let resolution = ext::utils::construct("S_2@milnor", save_dir).unwrap();
 
     resolution.compute_through_stem(max_s, max_n);

--- a/ext/examples/bruner.rs
+++ b/ext/examples/bruner.rs
@@ -30,7 +30,7 @@ use fp::{matrix::Matrix, prime::TWO, vector::FpVector};
 use std::{
     fs::File,
     io::{BufRead, BufReader},
-    path::Path,
+    path::{Path, PathBuf},
     str::FromStr,
     sync::Arc,
 };
@@ -227,7 +227,10 @@ fn main() {
     let (max_s, cc) = read_bruner_resolution(&data_dir, max_n).unwrap();
     let cc = Arc::new(cc);
 
-    let resolution = ext::utils::construct("S_2@milnor", None).unwrap();
+    let save_dir = query::optional("Save directory", |x| {
+        core::result::Result::<PathBuf, std::convert::Infallible>::Ok(PathBuf::from(x))
+    });
+    let resolution = ext::utils::construct("S_2@milnor", save_dir).unwrap();
 
     resolution.compute_through_stem(max_s, max_n);
 


### PR DESCRIPTION
It turns out the bug wasn't very deep at all. Constructing the map requires quasi-inverses, and those only exist for Nassau resolutions when they have a save directory. I added the option to specify one, and now it looks like everything works.

Fixes #108