### PR TITLE
Fix rust-analyzer

### DIFF
--- a/ext/src/chain_complex/chain_homotopy.rs
+++ b/ext/src/chain_complex/chain_homotopy.rs
@@ -274,7 +274,8 @@ impl<
         #[cfg(feature = "concurrent")]
         let scratches: Vec<FpVector> = (0..num_gens).into_par_iter().map(f).collect();
 
-        assert!(self.right.target.apply_quasi_inverse(
+        assert!(U::apply_quasi_inverse(
+            &*self.right.target,
             &mut outputs,
             target_s,
             target_t,

--- a/ext/src/nassau.rs
+++ b/ext/src/nassau.rs
@@ -936,7 +936,6 @@ impl<M: ZeroModule<Algebra = MilnorAlgebra>> Resolution<M> {
                 if self.has_computed_bidegree(s, t) {
                     SenderData::send(s, t, sender);
                 } else {
-                    let sender = sender.clone();
                     scope.spawn(move |_| {
                         self.step_resolution(s, t);
                         SenderData::send(s, t, sender);

--- a/ext/src/resolution.rs
+++ b/ext/src/resolution.rs
@@ -818,7 +818,6 @@ where
                 if self.has_computed_bidegree(s, t) {
                     SenderData::send(s, t, false, sender);
                 } else {
-                    let sender = sender.clone();
                     scope.spawn(move |_| {
                         self.step_resolution(s, t);
                         SenderData::send(s, t, true, sender);

--- a/ext/src/resolution_homomorphism.rs
+++ b/ext/src/resolution_homomorphism.rs
@@ -329,7 +329,8 @@ where
             .collect();
 
         if !fdx_vectors.is_empty() {
-            assert!(self.target.apply_quasi_inverse(
+            assert!(CC2::apply_quasi_inverse(
+                &*self.target,
                 &mut qi_outputs,
                 output_s,
                 output_t,

--- a/ext/src/utils.rs
+++ b/ext/src/utils.rs
@@ -518,12 +518,12 @@ pub fn iter_s_t(
             || {
                 (min_t..max_t(min_s))
                     .into_par_iter()
-                    .for_each(|t| run(&scope, f, max_s, max_t, min_s, t))
+                    .for_each(|t| run(scope, f, max_s, max_t, min_s, t))
             },
             || {
                 (min_s + 1..max_s)
                     .into_par_iter()
-                    .for_each(|s| run(&scope, f, max_s, max_t, s, min_t))
+                    .for_each(|s| run(scope, f, max_s, max_t, s, min_t))
             },
         );
     });


### PR DESCRIPTION
Rust-analyzer didn't understand which `apply_quasi_inverse` was being called, which is annoying. I also fixed some lints that show up when concurrency is enabled.