### PR TITLE
Optionally save homomorphisms and homotopies

### DIFF
--- a/ext/src/chain_complex/chain_homotopy.rs
+++ b/ext/src/chain_complex/chain_homotopy.rs
@@ -43,7 +43,16 @@ impl<
         left: Arc<ResolutionHomomorphism<S, T>>,
         right: Arc<ResolutionHomomorphism<T, U>>,
     ) -> Self {
-        let save_dir = if left.source.save_dir().is_some()
+        Self::new_with_save(left, right, true)
+    }
+
+    pub fn new_with_save(
+        left: Arc<ResolutionHomomorphism<S, T>>,
+        right: Arc<ResolutionHomomorphism<T, U>>,
+        save: bool,
+    ) -> Self {
+        let save_dir = if save
+            && left.source.save_dir().is_some()
             && !left.name().is_empty()
             && !right.name().is_empty()
         {

--- a/ext/src/chain_complex/chain_homotopy.rs
+++ b/ext/src/chain_complex/chain_homotopy.rs
@@ -1,6 +1,9 @@
-use crate::chain_complex::{ChainComplex, FreeChainComplex};
 use crate::resolution_homomorphism::ResolutionHomomorphism;
 use crate::save::SaveKind;
+use crate::{
+    chain_complex::{ChainComplex, FreeChainComplex},
+    save::SaveOption,
+};
 use algebra::module::homomorphism::{FreeModuleHomomorphism, ModuleHomomorphism};
 use algebra::module::Module;
 use fp::prime::ValidPrime;
@@ -31,6 +34,7 @@ pub struct ChainHomotopy<
     /// Homotopies, indexed by the filtration of the target of f - g.
     homotopies: OnceBiVec<Arc<FreeModuleHomomorphism<U::Module>>>,
     save_dir: Option<PathBuf>,
+    save_option: SaveOption,
 }
 
 impl<
@@ -43,23 +47,29 @@ impl<
         left: Arc<ResolutionHomomorphism<S, T>>,
         right: Arc<ResolutionHomomorphism<T, U>>,
     ) -> Self {
-        Self::new_with_save(left, right, true)
+        Self::new_with_save_option(left, right, Default::default())
     }
 
-    pub fn new_with_save(
+    pub fn new_with_save_option(
         left: Arc<ResolutionHomomorphism<S, T>>,
         right: Arc<ResolutionHomomorphism<T, U>>,
-        save: bool,
+        save_option: SaveOption,
     ) -> Self {
-        let save_dir = if save
-            && left.source.save_dir().is_some()
+        if save_option.required() {
+            assert!(
+                left.source.save_dir().is_some(),
+                "Saving is required but no path was provided"
+            );
+        }
+        let save_dir = if left.source.save_dir().is_some()
             && !left.name().is_empty()
             && !right.name().is_empty()
         {
             let mut path = left.source.save_dir().unwrap().to_owned();
-            path.push(format!("massey/{},{}/", left.name(), right.name(),));
-
-            SaveKind::ChainHomotopy.create_dir(&path).unwrap();
+            if save_option.write() {
+                path.push(format!("massey/{},{}/", left.name(), right.name(),));
+                SaveKind::ChainHomotopy.create_dir(&path).unwrap();
+            }
 
             Some(path)
         } else {
@@ -73,6 +83,7 @@ impl<
             right,
             lock: Mutex::new(()),
             save_dir,
+            save_option,
         }
     }
 
@@ -291,7 +302,8 @@ impl<
             &scratches,
         ));
 
-        if let Some(dir) = &self.save_dir {
+        if self.save_option.write() && self.save_dir.is_some() {
+            let dir = self.save_dir.as_ref().unwrap();
             let mut f = self
                 .left
                 .source

--- a/ext/src/resolution_homomorphism.rs
+++ b/ext/src/resolution_homomorphism.rs
@@ -4,10 +4,11 @@ use std::ops::Range;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use crate::chain_complex::{
-    AugmentedChainComplex, BoundedChainComplex, ChainComplex, FreeChainComplex,
-};
 use crate::save::SaveKind;
+use crate::{
+    chain_complex::{AugmentedChainComplex, BoundedChainComplex, ChainComplex, FreeChainComplex},
+    save::SaveOption,
+};
 use algebra::module::homomorphism::{ModuleHomomorphism, MuFreeModuleHomomorphism};
 use algebra::module::Module;
 use algebra::MuAlgebra;
@@ -38,6 +39,7 @@ where
     pub shift_s: u32,
     pub shift_t: i32,
     save_dir: Option<PathBuf>,
+    save_option: SaveOption,
 }
 
 impl<const U: bool, CC1, CC2> MuResolutionHomomorphism<U, CC1, CC2>
@@ -53,21 +55,30 @@ where
         shift_s: u32,
         shift_t: i32,
     ) -> Self {
-        Self::new_with_save(name, source, target, shift_s, shift_t, true)
+        Self::new_with_save_option(name, source, target, shift_s, shift_t, Default::default())
     }
 
-    pub fn new_with_save(
+    pub fn new_with_save_option(
         name: String,
         source: Arc<CC1>,
         target: Arc<CC2>,
         shift_s: u32,
         shift_t: i32,
-        save: bool,
+        save_option: SaveOption,
     ) -> Self {
-        let save_dir = if save && source.save_dir().is_some() && !name.is_empty() {
+        if save_option.required() {
+            assert!(
+                source.save_dir().is_some(),
+                "Saving is required but no path was provided"
+            );
+        }
+
+        let save_dir = if source.save_dir().is_some() && !name.is_empty() {
             let mut path = source.save_dir().unwrap().to_owned();
-            path.push(format!("products/{name}"));
-            SaveKind::ChainMap.create_dir(&path).unwrap();
+            if save_option.write() {
+                path.push(format!("products/{name}"));
+                SaveKind::ChainMap.create_dir(&path).unwrap();
+            }
             Some(path)
         } else {
             None
@@ -81,6 +92,7 @@ where
             shift_s,
             shift_t,
             save_dir,
+            save_option,
         }
     }
 
@@ -268,14 +280,16 @@ where
             let outputs =
                 extra_images.unwrap_or_else(|| vec![FpVector::new(p, fx_dimension); num_gens]);
 
-            if let Some(dir) = &self.save_dir {
-                let mut f = self
-                    .source
-                    .save_file(SaveKind::ChainMap, input_s, input_t)
-                    .create_file(dir.clone(), false);
-                f.write_u64::<LittleEndian>(fx_dimension as u64).unwrap();
-                for row in &outputs {
-                    row.to_bytes(&mut f).unwrap();
+            if self.save_option.write() {
+                if let Some(dir) = &self.save_dir {
+                    let mut f = self
+                        .source
+                        .save_file(SaveKind::ChainMap, input_s, input_t)
+                        .create_file(dir.clone(), false);
+                    f.write_u64::<LittleEndian>(fx_dimension as u64).unwrap();
+                    for row in &outputs {
+                        row.to_bytes(&mut f).unwrap();
+                    }
                 }
             }
 
@@ -346,14 +360,16 @@ where
             ));
         }
 
-        if let Some(dir) = &self.save_dir {
-            let mut f = self
-                .source
-                .save_file(SaveKind::ChainMap, input_s, input_t)
-                .create_file(dir.clone(), false);
-            f.write_u64::<LittleEndian>(fx_dimension as u64).unwrap();
-            for row in &outputs {
-                row.to_bytes(&mut f).unwrap();
+        if self.save_option.write() {
+            if let Some(dir) = &self.save_dir {
+                let mut f = self
+                    .source
+                    .save_file(SaveKind::ChainMap, input_s, input_t)
+                    .create_file(dir.clone(), false);
+                f.write_u64::<LittleEndian>(fx_dimension as u64).unwrap();
+                for row in &outputs {
+                    row.to_bytes(&mut f).unwrap();
+                }
             }
         }
         f_cur.add_generators_from_rows_ooo(input_t, outputs)
@@ -374,7 +390,28 @@ where
         shift_t: i32,
         class: &[u32],
     ) -> Self {
-        let result = Self::new(name, source, target, shift_s, shift_t);
+        Self::from_class_with_save_option(
+            name,
+            source,
+            target,
+            shift_s,
+            shift_t,
+            class,
+            Default::default(),
+        )
+    }
+
+    pub fn from_class_with_save_option(
+        name: String,
+        source: Arc<CC1>,
+        target: Arc<CC2>,
+        shift_s: u32,
+        shift_t: i32,
+        class: &[u32],
+        save_option: SaveOption,
+    ) -> Self {
+        let result =
+            Self::new_with_save_option(name, source, target, shift_s, shift_t, save_option);
 
         let num_gens = result
             .source

--- a/ext/src/resolution_homomorphism.rs
+++ b/ext/src/resolution_homomorphism.rs
@@ -53,7 +53,18 @@ where
         shift_s: u32,
         shift_t: i32,
     ) -> Self {
-        let save_dir = if source.save_dir().is_some() && !name.is_empty() {
+        Self::new_with_save(name, source, target, shift_s, shift_t, true)
+    }
+
+    pub fn new_with_save(
+        name: String,
+        source: Arc<CC1>,
+        target: Arc<CC2>,
+        shift_s: u32,
+        shift_t: i32,
+        save: bool,
+    ) -> Self {
+        let save_dir = if save && source.save_dir().is_some() && !name.is_empty() {
             let mut path = source.save_dir().unwrap().to_owned();
             path.push(format!("products/{name}"));
             SaveKind::ChainMap.create_dir(&path).unwrap();

--- a/ext/src/save.rs
+++ b/ext/src/save.rs
@@ -418,3 +418,50 @@ impl<A: Algebra> SaveFile<A> {
         f
     }
 }
+
+/// Decides whether the structure will be stored to disk.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[non_exhaustive]
+pub enum SaveOption {
+    /// Save to disk if a save path was provided.
+    #[default]
+    Yes,
+    /// Do not save to disk even if a save path was provided.
+    No,
+    /// Save to disk. Not providing a save path will cause an error.
+    Force,
+    /// Only read from disk if the structure has already been computed, but don't write. Note that
+    /// the directories will still be created if they don't already exist, but they won't be
+    /// populated.
+    ReadOnly,
+}
+
+impl SaveOption {
+    pub fn required(&self) -> bool {
+        matches!(self, SaveOption::Force)
+    }
+
+    pub fn write(&self) -> bool {
+        match self {
+            SaveOption::Yes => true,
+            SaveOption::No => false,
+            SaveOption::Force => true,
+            SaveOption::ReadOnly => false,
+        }
+    }
+}
+
+impl std::str::FromStr for SaveOption {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "" | "default" => Ok(Default::default()),
+            "yes" | "y" | "Y" => Ok(SaveOption::Yes),
+            "no" | "n" | "N" => Ok(SaveOption::No),
+            "force" | "f" | "F" => Ok(SaveOption::Force),
+            "readonly" | "r" | "ro" | "R" | "RO" => Ok(SaveOption::ReadOnly),
+            _ => Err(anyhow::anyhow!("Invalid save option")),
+        }
+    }
+}


### PR DESCRIPTION
I think it's a good idea to give the option of not saving homomorphisms and homotopies even when the source has a save directory. It makes quick operations faster since they are less IO-intensive. It will also make it easier to compute Massey products in the future, since right now computing homotopies is limited by IO, and they are only used once anyway