### PR TITLE
Fix rare UB in `once` crate when panicking

### DIFF
--- a/ext/Makefile
+++ b/ext/Makefile
@@ -75,5 +75,5 @@ examples/benchmarks/%-concurrent: dummy
 	fi
 
 miri:
-	cargo miri test -p once
+	MIRIFLAGS="-Zmiri-ignore-leaks" cargo miri test -p once
 	MIRIFLAGS="-Zmiri-ignore-leaks -Zmiri-disable-isolation" cargo miri test -p once --features concurrent

--- a/ext/crates/once/src/lib.rs
+++ b/ext/crates/once/src/lib.rs
@@ -904,4 +904,15 @@ mod tests {
         v.push_ooo(6, 7);
         drop(v);
     }
+
+    // This is just so that MIRI can check for UB when we panic
+    #[test]
+    #[should_panic]
+    fn test_drop_panic() {
+        let v: OnceVec<u32> = OnceVec::new();
+        v.push(4);
+        v.push(3);
+        v.push_ooo(6, 7);
+        panic!();
+    }
 }


### PR DESCRIPTION
We're hitting some UB, in the form of segfaults and illegal instructions, and I tracked it down to that `unsafe` block. Some invariants aren't satisfied if we are panicking, so we just leak all the memory in that case