### PR TITLE
Fix tests

### DIFF
--- a/chart/chart/Makefile
+++ b/chart/chart/Makefile
@@ -26,6 +26,7 @@ $(JAVASCRIPT):
 javascript/dist/sseq_chart_node.js : javascript/src/*.ts
 	cd javascript && \
 		./node_modules/esbuild/bin/esbuild \
+			--keep-names \
 			--outfile=dist/sseq_chart_node.js \
 			--platform=node src/lib.ts \
 			--format=cjs \


### PR DESCRIPTION
This extends #128 .

I split them into two PRs because I wasn't confident I could fix the chart test any time soon, but I tracked it down to a breaking change in esbuild 0.18 that renamed classes. Adding --keep-names to the command in the Makefile did the trick