### PR TITLE
Replace most `fp::vector` tests by proptests

### DIFF
--- a/ext/crates/fp/src/vector/mod.rs
+++ b/ext/crates/fp/src/vector/mod.rs
@@ -101,18 +101,14 @@ mod test {
     }
 
     /// An arbitrary `ValidPrime`
-    fn arb_prime() -> impl Strategy<Value = ValidPrime> {
+    fn arb_prime_dim() -> impl Strategy<Value = (ValidPrime, usize)> {
         prop_oneof![
             Just(ValidPrime::new(2)),
             Just(ValidPrime::new(3)),
             Just(ValidPrime::new(5)),
             Just(ValidPrime::new(7)),
         ]
-    }
-
-    /// An arbitrary number of dimensions. This makes the functions that create vectors DRY.
-    fn arb_dim() -> impl Strategy<Value = usize> {
-        0usize..=10_000
+        .prop_flat_map(|p| (Just(p), 0usize..=10_000))
     }
 
     /// An arbitrary pair of dimensions, where the second dimension is bigger than or equal to the

--- a/ext/crates/fp/src/vector/mod.rs
+++ b/ext/crates/fp/src/vector/mod.rs
@@ -133,7 +133,7 @@ mod test {
     /// An arbitrary pair of slices of a vector of length `dimension` _that have the same length_
     fn arb_slice_pair(dimension: usize) -> impl Strategy<Value = [(usize, usize); 2]> {
         // Similarly to `arb_slice`, we triplicate the entries because we want to also test the case
-        // where two values or all three values coincide.
+        // where two or all three values coincide.
         let all_indices: Vec<_> = (0..=dimension).flat_map(|i| [i, i, i]).collect();
         proptest::sample::subsequence(all_indices, 3)
             .prop_map(|v| [(v[0], v[1]), (v[2] - (v[1] - v[0]), v[2])])
@@ -146,6 +146,8 @@ mod test {
     }
 
     prop_compose! {
+        /// A pair of a prime `p` and a vector containing values in the range `0..p`. In other
+        /// words, a vector over Fp.
         fn arb_vec()(p in arb_prime(), dimension in arb_dim())
         (v in arb_vec_u32(p, dimension), p in Just(p)) -> (ValidPrime, Vec<u32>) {
             (p, v)
@@ -153,6 +155,7 @@ mod test {
     }
 
     prop_compose! {
+        /// An Fp vector together with valid slice indices
         fn arb_vec_and_slice()(p in arb_prime(), dimension in arb_dim())
         (v in arb_vec_u32(p, dimension), (start, end) in arb_slice(dimension), p in Just(p))
             -> (ValidPrime, Vec<u32>, usize, usize)
@@ -162,6 +165,7 @@ mod test {
     }
 
     prop_compose! {
+        /// An Fp vector together with a scalar (in Fp)
         fn arb_vec_and_scalar()(p in arb_prime(), dimension in arb_dim())
         (c in 0u32..*p, v in arb_vec_u32(p, dimension), p in Just(p)) -> (ValidPrime, Vec<u32>, u32) {
             (p, v, c)
@@ -169,6 +173,7 @@ mod test {
     }
 
     prop_compose! {
+        /// An Fp vector together with valid slice indices and a scalar
         fn arb_vec_and_slice_and_scalar()(p in arb_prime(), dimension in arb_dim())
         (c in 0u32..*p, v in arb_vec_u32(p, dimension), (start, end) in arb_slice(dimension), p in Just(p))
             -> (ValidPrime, Vec<u32>, usize, usize, u32)
@@ -178,6 +183,7 @@ mod test {
     }
 
     prop_compose! {
+        /// An Fp vector together with a valid number of entries to skip
         fn arb_vec_and_skip()(p in arb_prime(), dimension in arb_dim())
         (v in arb_vec_u32(p, dimension), skip in 0usize..=dimension, p in Just(p))
             -> (ValidPrime, Vec<u32>, usize)
@@ -187,6 +193,7 @@ mod test {
     }
 
     prop_compose! {
+        /// A pair of Fp vectors of the same length over the same prime
         fn arb_vec_pair()(p in arb_prime(), dimension in arb_dim())
         (v in arb_vec_u32(p, dimension), w in arb_vec_u32(p, dimension), p in Just(p))
             -> (ValidPrime, Vec<u32>, Vec<u32>)
@@ -196,6 +203,8 @@ mod test {
     }
 
     prop_compose! {
+        /// A pair of Fp vectors of the same length over the same prime, together with valid slice
+        /// indices
         fn arb_vec_pair_and_slice()(p in arb_prime(), dimension in arb_dim())
         (v in arb_vec_u32(p, dimension),
          w in arb_vec_u32(p, dimension),
@@ -208,6 +217,8 @@ mod test {
     }
 
     prop_compose! {
+        /// A pair of Fp vectors of the same length over the same prime, together with two slice
+        /// index pairs that are valid and have the same length
         fn arb_vec_pair_and_slice_pair()(p in arb_prime(), dimension in arb_dim())
         (v in arb_vec_u32(p, dimension),
          w in arb_vec_u32(p, dimension),
@@ -220,6 +231,8 @@ mod test {
     }
 
     prop_compose! {
+        /// A pair of Fp vectors of the same length over the same prime, together with a mask (in
+        /// the sense of [`FpVector::add_masked`] and [`FpVector::add_unmasked`])
         fn arb_vec_pair_and_mask()(p in arb_prime(), (dim_small, dim_big) in arb_dim_pair())
         (v_small in arb_vec_u32(p, dim_small),
          v_big in arb_vec_u32(p, dim_big),
@@ -233,7 +246,7 @@ mod test {
 
     proptest! {
         #![proptest_config(ProptestConfig {
-            cases: 16384,
+            cases: 1024,
             max_shrink_time: 30_000,
             max_shrink_iters: 1_000_000,
             .. ProptestConfig::default()

--- a/ext/crates/fp/src/vector/mod.rs
+++ b/ext/crates/fp/src/vector/mod.rs
@@ -117,14 +117,14 @@ mod test {
 
     /// The start and end positions of an arbitrary slice of a vector of length `dimension`
     fn arb_slice(dimension: usize) -> impl Strategy<Value = (usize, usize)> {
-        (0..dimension).prop_flat_map(move |first| (Just(first), first..dimension))
+        (0..=dimension).prop_flat_map(move |first| (Just(first), first..=dimension))
     }
 
     prop_compose! {
         /// An arbitrary pair of slices of a vector of length `dimension` _that have the same length_
         fn arb_slice_pair(dimension: usize)
-            (len in 0..dimension)
-            (len in Just(len), first in 0..dimension - len, second in 0..dimension - len)
+            (len in 0..=dimension)
+            (len in Just(len), first in 0..=dimension - len, second in 0..=dimension - len)
             -> [(usize, usize); 2]
         {
             [(first, first + len), (second, second + len)]

--- a/ext/crates/fp/src/vector/mod.rs
+++ b/ext/crates/fp/src/vector/mod.rs
@@ -131,7 +131,9 @@ mod test {
         }
     }
 
-    /// An arbitrary vector of length `dimension` containing values in the range `0..p`
+    /// An arbitrary vector of length `dimension` containing values in the range `0..p`. The tests
+    /// take in a `Vec<u32>` instead of an `FpVector` directly because they will usually apply some
+    /// operation on both the `FpVector` and the original `Vec<u32>` and then compare the results.
     fn arb_vec_u32(p: ValidPrime, dimension: usize) -> impl Strategy<Value = Vec<u32>> {
         proptest::collection::vec(0..*p, dimension)
     }

--- a/ext/crates/fp/src/vector/mod.rs
+++ b/ext/crates/fp/src/vector/mod.rs
@@ -120,19 +120,17 @@ mod test {
 
     /// The start and end positions of an arbitrary slice of a vector of length `dimension`
     fn arb_slice(dimension: usize) -> impl Strategy<Value = (usize, usize)> {
-        // We have every integer twice because `subsequence` returns distinct values, but we want to
-        // also test the case where the slices have the same start and end positions.
-        let all_indices: Vec<_> = (0..=dimension).flat_map(|i| [i, i]).collect();
-        proptest::sample::subsequence(all_indices, 2).prop_map(|v| (v[0], v[1]))
+        (0..dimension).prop_flat_map(move |first| (Just(first), first..dimension))
     }
 
-    /// An arbitrary pair of slices of a vector of length `dimension` _that have the same length_
     prop_compose! {
+        /// An arbitrary pair of slices of a vector of length `dimension` _that have the same length_
         fn arb_slice_pair(dimension: usize)
-            (len in 0..max_integer)
-            (len in Just(len), first in 0..max_integer-len, second in 0..max_integer-len)
-            -> [(usize, usize); 2] {
-            [(first, first+len), (second, second+len)]
+            (len in 0..dimension)
+            (len in Just(len), first in 0..dimension - len, second in 0..dimension - len)
+            -> [(usize, usize); 2]
+        {
+            [(first, first + len), (second, second + len)]
         }
     }
 

--- a/ext/crates/fp/src/vector/mod.rs
+++ b/ext/crates/fp/src/vector/mod.rs
@@ -131,13 +131,13 @@ mod test {
     }
 
     /// An arbitrary pair of slices of a vector of length `dimension` _that have the same length_
-    fn arb_slice_pair(dimension: usize) -> impl Strategy<Value = [(usize, usize); 2]> {
-        // Similarly to `arb_slice`, we triplicate the entries because we want to also test the case
-        // where two or all three values coincide.
-        let all_indices: Vec<_> = (0..=dimension).flat_map(|i| [i, i, i]).collect();
-        proptest::sample::subsequence(all_indices, 3)
-            .prop_map(|v| [(v[0], v[1]), (v[2] - (v[1] - v[0]), v[2])])
-            .prop_shuffle()
+    prop_compose! {
+        fn arb_slice_pair(dimension: usize)
+            (len in 0..max_integer)
+            (len in Just(len), first in 0..max_integer-len, second in 0..max_integer-len)
+            -> [(usize, usize); 2] {
+            [(first, first+len), (second, second+len)]
+        }
     }
 
     /// An arbitrary vector of length `dimension` containing values in the range `0..p`


### PR DESCRIPTION
Similar to #133, but with a broader scope. I believe the new tests are strictly more general