### PR TITLE
Fix selenium but only partially

### DIFF
--- a/web_ext/sseq_gui/Makefile
+++ b/web_ext/sseq_gui/Makefile
@@ -51,8 +51,8 @@ lint-selenium:
 	black --diff --check tests
 
 selenium:
-	python3 -m pytest tests --driver firefox
-	python3 -m pytest tests --driver chrome
+	python3 -m pytest -s tests --driver firefox
+	python3 -m pytest -s tests --driver chrome
 
 selenium-update:
 	python3 -m pytest tests --driver firefox --update

--- a/web_ext/sseq_gui/tests/test_s_2.py
+++ b/web_ext/sseq_gui/tests/test_s_2.py
@@ -120,6 +120,7 @@ def test_history(driver):
 
     timeout = 0.1
     while True:
+        print(f"Waiting for {timeout} seconds")
         time.sleep(timeout)
 
         try:
@@ -127,6 +128,7 @@ def test_history(driver):
                 file_contents = f.read()
                 if file_contents == "":
                     # The driver hasn't finished saving the file yet, wait a bit longer
+                    print("Waiting for driver to finish")
                     raise FileNotFoundError
                 driver.check_file("s_2.save", file_contents)
             break

--- a/web_ext/sseq_gui/tests/test_s_2.py
+++ b/web_ext/sseq_gui/tests/test_s_2.py
@@ -1,4 +1,6 @@
 import time
+from pathlib import Path
+
 from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
 
@@ -119,23 +121,17 @@ def test_history(driver):
     driver.send_keys(Keys.ENTER)
 
     timeout = 0.1
+    save_path = Path(driver.tempdir) / "s_2.save"
     while True:
         print(f"Waiting for {timeout} seconds")
         time.sleep(timeout)
-
-        try:
-            with open(f"{driver.tempdir}/s_2.save") as f:
-                file_contents = f.read()
-                if file_contents == "":
-                    # The driver hasn't finished saving the file yet, wait a bit longer
-                    print("Waiting for driver to finish")
-                    raise FileNotFoundError
-                driver.check_file("s_2.save", file_contents)
+        file_contents = save_path.read_text() if save_path.exists() else None
+        if file_contents:
             break
-        except FileNotFoundError:
-            timeout *= 2
-            if timeout > 10:
-                raise TimeoutError
+        timeout *= 2
+        if timeout > 10:
+            raise TimeoutError
+    driver.check_file("s_2.save", file_contents)
 
     driver.go("/")
     driver.driver.find_element(By.ID, "history-upload").send_keys(

--- a/web_ext/sseq_gui/tests/test_s_2.py
+++ b/web_ext/sseq_gui/tests/test_s_2.py
@@ -124,7 +124,11 @@ def test_history(driver):
 
         try:
             with open(f"{driver.tempdir}/s_2.save") as f:
-                driver.check_file("s_2.save", f.read())
+                file_contents = f.read()
+                if file_contents == "":
+                    # The driver hasn't finished saving the file yet, wait a bit longer
+                    raise FileNotFoundError
+                driver.check_file("s_2.save", file_contents)
             break
         except FileNotFoundError:
             timeout *= 2


### PR DESCRIPTION
This fixes #121 but in an unsatisfying way. This seems to fix the flakiness of the selenium tests, but while inspecting the logs I noticed that the wasm/local/local-concurrent steps were actually all testing the wasm server. The servers compiled by cargo would exit when they noticed that port 8080 was busy, because the previous `make serve-wasm` was still running. Adding a `kill %1` to `ext.yaml`, so that the servers are stopped in between steps, only made more issues crop up. I feel like this should be fixed but as a separate PR