### PR TITLE
Clean up gating on `concurrent` feature

### DIFF
--- a/ext/Cargo.toml
+++ b/ext/Cargo.toml
@@ -19,6 +19,7 @@ algebra = { path = "crates/algebra", default-features = false, features = [
 bivec = { path = "crates/bivec" }
 chart = { path = "crates/chart" }
 fp = { path = "crates/fp", default-features = false }
+maybe-rayon = { path = "crates/maybe-rayon" }
 once = { path = "crates/once" }
 query = { path = "crates/query" }
 sseq = { path = "crates/sseq", default-features = false }
@@ -30,7 +31,6 @@ dashmap = "4.0.0"
 itertools = { version = "0.10.0", default-features = false, features = [
     "use_alloc",
 ] }
-rayon = { version = "1.5", optional = true }
 rustc-hash = "1.1.0"
 serde_json = { version = "1.0.0", features = ["preserve_order"] }
 
@@ -54,9 +54,9 @@ cache-multiplication = ["algebra/cache-multiplication"]
 concurrent = [
     "algebra/concurrent",
     "fp/concurrent",
+    "maybe-rayon/concurrent",
     "once/concurrent",
     "sseq/concurrent",
-    "rayon",
 ]
 odd-primes = ["fp/odd-primes", "algebra/odd-primes", "sseq/odd-primes"]
 logging = []
@@ -68,7 +68,9 @@ members = [
     "crates/bivec",
     "crates/chart",
     "crates/fp",
+    "crates/maybe-rayon",
     "crates/once",
+    "crates/query",
     "crates/sseq",
 ]
 

--- a/ext/crates/algebra/Cargo.toml
+++ b/ext/crates/algebra/Cargo.toml
@@ -13,6 +13,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 bivec = { path = "../bivec" }
 fp = { path = "../fp", default-features = false }
+maybe-rayon = { path = "../maybe-rayon" }
 once = { path = "../once" }
 
 anyhow = "1.0.0"
@@ -26,8 +27,6 @@ rustc-hash = "1.1.0"
 serde = { version = "1.0.0", features = ["derive"], optional = true }
 serde_json = { version = "1.0.0", optional = true }
 
-rayon = { version = "1.5", optional = true }
-
 [dev-dependencies]
 bencher = "0.1.5"
 expect-test = "1.1.0"
@@ -36,7 +35,7 @@ rstest = "0.17.0"
 [features]
 default = ["odd-primes", "json"]
 cache-multiplication = []
-concurrent = ["rayon", "fp/concurrent"]
+concurrent = ["fp/concurrent", "maybe-rayon/concurrent"]
 json = ["serde", "serde_json", "bivec/json", "fp/json"]
 odd-primes = ["fp/odd-primes"]
 

--- a/ext/crates/fp/Cargo.toml
+++ b/ext/crates/fp/Cargo.toml
@@ -13,7 +13,7 @@ itertools = { version = "0.10.0", default-features = false }
 serde = { version = "1.0.0", optional = true }
 serde_json = { version = "1.0.0", optional = true }
 
-rayon = { version = "1.5", optional = true }
+maybe-rayon = { path = "../maybe-rayon" }
 
 [dev-dependencies]
 criterion = { version = "0.3.5", features = ["html_reports"] }
@@ -28,7 +28,7 @@ build_const = "0.2.2"
 
 [features]
 default = ["odd-primes"]
-concurrent = ["rayon"]
+concurrent = ["maybe-rayon/concurrent"]
 json = ["serde_json", "serde"]
 odd-primes = []
 

--- a/ext/crates/fp/src/matrix/matrix_inner.rs
+++ b/ext/crates/fp/src/matrix/matrix_inner.rs
@@ -8,8 +8,8 @@ use std::io::{Read, Write};
 use std::ops::{Index, IndexMut};
 
 use itertools::Itertools;
-#[cfg(feature = "concurrent")]
-use rayon::prelude::*;
+
+use maybe_rayon::prelude::*;
 
 /// A matrix! In particular, a matrix with values in F_p. The way we store matrices means it is
 /// easier to perform row operations than column operations, and the way we use matrices means we
@@ -281,9 +281,10 @@ impl Matrix {
         self.vectors.iter_mut()
     }
 
-    #[cfg(feature = "concurrent")]
-    pub fn par_iter_mut(&mut self) -> impl IndexedParallelIterator<Item = &mut FpVector> + '_ {
-        self.vectors.par_iter_mut()
+    pub fn maybe_par_iter_mut(
+        &mut self,
+    ) -> impl MaybeIndexedParallelIterator<Item = &mut FpVector> + '_ {
+        self.vectors.maybe_par_iter_mut()
     }
 }
 
@@ -1160,12 +1161,13 @@ impl<'a> MatrixSliceMut<'a> {
             .map(move |x| x.slice_mut(start, end))
     }
 
-    #[cfg(feature = "concurrent")]
-    pub fn par_iter_mut(&mut self) -> impl IndexedParallelIterator<Item = SliceMut> + '_ {
+    pub fn maybe_par_iter_mut(
+        &mut self,
+    ) -> impl MaybeIndexedParallelIterator<Item = SliceMut> + '_ {
         let start = self.col_start;
         let end = self.col_end;
         self.vectors
-            .par_iter_mut()
+            .maybe_par_iter_mut()
             .map(move |x| x.slice_mut(start, end))
     }
 

--- a/ext/crates/maybe-rayon/Cargo.toml
+++ b/ext/crates/maybe-rayon/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "maybe-rayon"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+rayon = { version = "1.8.0", optional = true }
+
+[features]
+default = []
+concurrent = ["rayon"]

--- a/ext/crates/maybe-rayon/src/concurrent.rs
+++ b/ext/crates/maybe-rayon/src/concurrent.rs
@@ -1,0 +1,64 @@
+pub mod prelude {
+    use rayon::prelude::*;
+
+    pub use rayon::iter::{IndexedParallelIterator, ParallelIterator};
+
+    pub trait MaybeParallelIterator: ParallelIterator {}
+
+    pub trait MaybeIndexedParallelIterator: IndexedParallelIterator {}
+
+    pub trait MaybeIntoParallelIterator: IntoParallelIterator {
+        fn maybe_into_par_iter(self) -> Self::Iter;
+    }
+
+    pub trait MaybeIntoParallelRefMutIterator<'data>: IntoParallelRefMutIterator<'data> {
+        fn maybe_par_iter_mut(&'data mut self) -> Self::Iter;
+    }
+
+    // Implementations
+
+    impl<I: ParallelIterator> MaybeParallelIterator for I {}
+
+    impl<I: IndexedParallelIterator> MaybeIndexedParallelIterator for I {}
+
+    impl<I: IntoParallelIterator> MaybeIntoParallelIterator for I {
+        fn maybe_into_par_iter(self) -> Self::Iter {
+            self.into_par_iter()
+        }
+    }
+
+    impl<'data, I: IntoParallelRefMutIterator<'data> + ?Sized>
+        MaybeIntoParallelRefMutIterator<'data> for I
+    {
+        fn maybe_par_iter_mut(&'data mut self) -> Self::Iter {
+            self.par_iter_mut()
+        }
+    }
+}
+
+pub fn join<A, B, RA, RB>(oper_a: A, oper_b: B) -> (RA, RB)
+where
+    A: FnOnce() -> RA + Send,
+    B: FnOnce() -> RB + Send,
+    RA: Send,
+    RB: Send,
+{
+    rayon::join(oper_a, oper_b)
+}
+
+pub type Scope<'scope> = rayon::Scope<'scope>;
+
+pub fn scope<'scope, OP, R>(op: OP) -> R
+where
+    OP: FnOnce(&Scope<'scope>) -> R + Send,
+    R: Send,
+{
+    rayon::scope(op)
+}
+
+pub fn in_place_scope<'scope, OP, R>(op: OP) -> R
+where
+    OP: FnOnce(&Scope<'scope>) -> R,
+{
+    rayon::in_place_scope(op)
+}

--- a/ext/crates/maybe-rayon/src/lib.rs
+++ b/ext/crates/maybe-rayon/src/lib.rs
@@ -1,0 +1,9 @@
+#[cfg(feature = "concurrent")]
+pub mod concurrent;
+#[cfg(feature = "concurrent")]
+pub use concurrent::*;
+
+#[cfg(not(feature = "concurrent"))]
+pub mod sequential;
+#[cfg(not(feature = "concurrent"))]
+pub use sequential::*;

--- a/ext/crates/maybe-rayon/src/sequential.rs
+++ b/ext/crates/maybe-rayon/src/sequential.rs
@@ -1,0 +1,78 @@
+pub mod prelude {
+    pub trait MaybeParallelIterator: Iterator {}
+
+    pub trait MaybeIndexedParallelIterator: Iterator {}
+
+    pub trait MaybeIntoParallelIterator: IntoIterator {
+        type Iter;
+
+        fn maybe_into_par_iter(self) -> Self::Iter;
+    }
+
+    pub trait MaybeIntoParallelRefMutIterator<'data> {
+        type Iter;
+
+        fn maybe_par_iter_mut(&'data mut self) -> Self::Iter;
+    }
+
+    // Implementations
+
+    impl<I: Iterator> MaybeParallelIterator for I {}
+
+    impl<I: Iterator> MaybeIndexedParallelIterator for I {}
+
+    impl<I: IntoIterator> MaybeIntoParallelIterator for I {
+        type Iter = Self::IntoIter;
+
+        fn maybe_into_par_iter(self) -> Self::Iter {
+            self.into_iter()
+        }
+    }
+
+    impl<'data, I: 'data + ?Sized> MaybeIntoParallelRefMutIterator<'data> for I
+    where
+        &'data mut I: IntoIterator,
+    {
+        type Iter = <&'data mut I as IntoIterator>::IntoIter;
+
+        fn maybe_par_iter_mut(&'data mut self) -> Self::Iter {
+            self.into_iter()
+        }
+    }
+}
+
+pub struct Scope<'scope>(&'scope ());
+
+impl<'scope> Scope<'scope> {
+    pub fn spawn<BODY>(&self, body: BODY)
+    where
+        BODY: FnOnce(&Scope<'scope>) + Send + 'scope,
+    {
+        body(self)
+    }
+}
+
+pub fn join<A, B, RA, RB>(oper_a: A, oper_b: B) -> (RA, RB)
+where
+    A: FnOnce() -> RA + Send,
+    B: FnOnce() -> RB + Send,
+    RA: Send,
+    RB: Send,
+{
+    (oper_a(), oper_b())
+}
+
+pub fn scope<'scope, OP, R>(op: OP) -> R
+where
+    OP: FnOnce(&Scope<'scope>) -> R + Send,
+    R: Send,
+{
+    op(&Scope(&()))
+}
+
+pub fn in_place_scope<'scope, OP, R>(op: OP) -> R
+where
+    OP: FnOnce(&Scope<'scope>) -> R,
+{
+    op(&Scope(&()))
+}

--- a/ext/crates/once/Cargo.toml
+++ b/ext/crates/once/Cargo.toml
@@ -10,15 +10,14 @@ edition = "2021"
 
 [dependencies]
 bivec = { path = "../bivec" }
-
-rayon = { version = "1", optional = true }
+maybe-rayon = { path = "../maybe-rayon" }
 
 [dev-dependencies]
 criterion = "0.3"
 
 [features]
 default = []
-concurrent = ["rayon"]
+concurrent = ["maybe-rayon/concurrent"]
 
 [[bench]]
 name = "criterion"

--- a/ext/crates/sseq/Cargo.toml
+++ b/ext/crates/sseq/Cargo.toml
@@ -10,9 +10,9 @@ algebra = { path = "../algebra/", default-features = false }
 bivec = { path = "../bivec/" }
 chart = { path = "../chart/" }
 fp = { path = "../fp/", default-features = false }
+maybe-rayon = { path = "../maybe-rayon" }
 once = { path = "../once/" }
 
-rayon = { version = "1.5", optional = true }
 serde = { version = "1.0.0", optional = true }
 serde_json = { version = "1.0.0", optional = true }
 
@@ -22,6 +22,6 @@ rand = "0.8"
 
 [features]
 default = ["odd-primes"]
-concurrent = ["rayon"]
+concurrent = ["maybe-rayon/concurrent"]
 json = ["serde_json", "serde"]
 odd-primes = ["fp/odd-primes"]


### PR DESCRIPTION
I was able to contain all the gates in a new `maybe-rayon` crate. When concurrency is enabled, it is a thin wrapper around the rayon API, or at least the part of the API that the rest of the codebase uses. When it is disabled, the crate provides the same API except that the implementation is completely serial, and doesn't depend on rayon.

Every feature gate is now either in `maybe-rayon`, in some comments in the `steenrod` example, or in the `resolve_concurrent` benchmark.

By unifying some parts of the code, it happens that serial operations now needlessly communicate via mpsc channels. Also, secondary computations now unconditionally compute intermediates upfront, but that's simply a reordering of the same operations as previously. As far as I can tell, performance is unchanged.
