### PR TITLE
More restrictive `rustfmt`

### DIFF
--- a/.github/workflows/ext.yaml
+++ b/.github/workflows/ext.yaml
@@ -91,13 +91,8 @@ jobs:
     env:
       RUST_BACKTRACE: 1
       RUSTFLAGS: "-D warnings"
-      RUSTUP_TOOLCHAIN: ${{ matrix.toolchain }}
+      RUSTUP_TOOLCHAIN: nightly
 
-    strategy:
-      matrix:
-        toolchain: ["stable", "beta", "nightly"]
-
-    continue-on-error: ${{ matrix.toolchain != 'stable' }}
     steps:
       - uses: actions/checkout@v2
 
@@ -105,7 +100,7 @@ jobs:
         id: rustup
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: ${{ matrix.toolchain }}
+          toolchain: nightly
           components: clippy, rustfmt
 
       # Install black from pip3 to ensure latest version

--- a/chart/chart/display_backend/src/arrow.rs
+++ b/chart/chart/display_backend/src/arrow.rs
@@ -1,19 +1,17 @@
-use uuid::Uuid;
 use std::rc::Rc;
 
+use lyon::{
+    geom::math::{point, vector, Angle, Point, Transform, Vector},
+    path::Path,
+    tessellation::{
+        geometry_builder, FillOptions, FillTessellator, LineCap, LineJoin, StrokeOptions,
+        StrokeTessellator, VertexBuffers,
+    },
+};
+use uuid::Uuid;
 use wasm_bindgen::prelude::*;
 
-use lyon::geom::math::{point, Point, Vector, vector, Angle, Transform};
-use lyon::path::{Path};
-
-use lyon::tessellation::{
-    geometry_builder,
-    StrokeTessellator, StrokeOptions, LineCap, LineJoin,
-    FillTessellator, FillOptions, VertexBuffers,
-};
-
-use crate::error::convert_tessellation_error;
-use crate::webgl_wrapper::WebGlWrapper;
+use crate::{error::convert_tessellation_error, webgl_wrapper::WebGlWrapper};
 // pub struct ArrowSettings {
 //     length : ArrowLength,
 //     width : ArrowDimension,
@@ -58,28 +56,34 @@ pub struct ArrowId(Uuid);
 #[wasm_bindgen]
 #[derive(Clone, Debug)]
 pub struct Arrow {
-    pub(crate) tip_end : f32,
-    pub(crate) back_end : f32,
-    pub(crate) visual_tip_end : f32,
-    pub(crate) visual_back_end : f32,
-    pub(crate) line_end : f32,
-    pub(crate) path : Rc<Path>,
-    pub(crate) stroke : Option<StrokeOptions>,
-    pub(crate) fill : Option<FillOptions>,
-    pub(crate) uuid : ArrowId,
+    pub(crate) tip_end: f32,
+    pub(crate) back_end: f32,
+    pub(crate) visual_tip_end: f32,
+    pub(crate) visual_back_end: f32,
+    pub(crate) line_end: f32,
+    pub(crate) path: Rc<Path>,
+    pub(crate) stroke: Option<StrokeOptions>,
+    pub(crate) fill: Option<FillOptions>,
+    pub(crate) uuid: ArrowId,
 }
 
 impl Arrow {
-    pub fn tesselate_into_buffers(&self, buffers : &mut VertexBuffers<Point, u16>) -> Result<(), JsValue> {
+    pub fn tesselate_into_buffers(
+        &self,
+        buffers: &mut VertexBuffers<Point, u16>,
+    ) -> Result<(), JsValue> {
         let mut vertex_builder = geometry_builder::simple_builder(buffers);
         let mut fill = FillTessellator::new();
         let mut stroke = StrokeTessellator::new();
 
         if let Some(fill_options) = &self.fill {
-            fill.tessellate(self.path.iter(), fill_options, &mut vertex_builder).map_err(convert_tessellation_error)?;
+            fill.tessellate(self.path.iter(), fill_options, &mut vertex_builder)
+                .map_err(convert_tessellation_error)?;
         }
         if let Some(stroke_options) = &self.stroke {
-            stroke.tessellate(self.path.iter(), stroke_options, &mut vertex_builder).map_err(convert_tessellation_error)?;
+            stroke
+                .tessellate(self.path.iter(), stroke_options, &mut vertex_builder)
+                .map_err(convert_tessellation_error)?;
         }
         Ok(())
     }
@@ -103,7 +107,6 @@ impl Arrow {
     // {\pgfqpoint{-0.81731\pgfutil@tempdima}{-.2\pgfutil@tempdimb}}
     // {\pgfqpoint{-\pgfutil@tempdima}{-.5\pgfutil@tempdimb}}
 
-
     // \ifpgfarrowroundjoin%
     // \else%
     //   \pgfmathdivide@{\pgf@sys@tonumber\pgfutil@tempdima}{\pgf@sys@tonumber\pgfutil@tempdimb}%
@@ -120,56 +123,60 @@ impl Arrow {
     // \fi%
     // \pgfarrowssettipend{\ifpgfarrowroundjoin.5\pgfarrowlinewidth\else\pgf@xc\ifpgfarrowharpoon\advance\pgf@x by\pgf@xa\fi\fi}
 
-    pub fn normal_arrow(line_width : f32, round_join : bool, round_cap : bool, harpoon : bool, reversed : bool) -> Self {
+    pub fn normal_arrow(
+        line_width: f32,
+        round_join: bool,
+        round_cap: bool,
+        harpoon: bool,
+        reversed: bool,
+    ) -> Self {
         let length = line_width * 2.2 + WebGlWrapper::point_to_pixels(1.6);
         let width = 2.096774 * length;
         let length = length - line_width;
         let width = width - line_width;
 
-
         let mut tip_end = if round_join {
-                line_width / 2.0
+            line_width / 2.0
+        } else {
+            let miter = ((length / width) * (length / width) * 49.44662 + 1.0).sqrt() * line_width;
+            if harpoon {
+                let extra_harpoon_miter = 3.51591 * (length / width) * line_width;
+                miter + extra_harpoon_miter
             } else {
-                let miter = ((length / width) * (length / width) * 49.44662 + 1.0).sqrt() * line_width;
-                if harpoon {
-                    let extra_harpoon_miter = 3.51591 * (length / width) * line_width;
-                    miter + extra_harpoon_miter
-                } else {
-                    miter
-                }
-            };
+                miter
+            }
+        };
         let mut visual_tip_end = tip_end;
 
-        let mut visual_back_end = - line_width / 2.0;
-        let mut back_end = - length - line_width / 2.0;
+        let mut visual_back_end = -line_width / 2.0;
+        let mut back_end = -length - line_width / 2.0;
 
-    //     \ifpgfarrowreversed%
-    //     \ifpgfarrowharpoon%
-    //       \pgfarrowssetlineend{.5\pgfarrowlinewidth}%
-    //     \else%
-    //       \pgfarrowssetlineend{-.5\pgfarrowlinewidth}%
-    //     \fi%
-    //   \else%
-    //     \pgfarrowssetlineend{-.5\pgfarrowlinewidth}%
-    //   \fi%
+        //     \ifpgfarrowreversed%
+        //     \ifpgfarrowharpoon%
+        //       \pgfarrowssetlineend{.5\pgfarrowlinewidth}%
+        //     \else%
+        //       \pgfarrowssetlineend{-.5\pgfarrowlinewidth}%
+        //     \fi%
+        //   \else%
+        //     \pgfarrowssetlineend{-.5\pgfarrowlinewidth}%
+        //   \fi%
         let line_end = if reversed {
             if harpoon {
-                line_width/2.0
+                line_width / 2.0
             } else {
-                - line_width/2.0
+                -line_width / 2.0
             }
         } else {
-            - line_width/2.0
+            -line_width / 2.0
         };
 
-
         let mut path_builder = Path::builder();
-        path_builder.move_to(point(-length, width/2.0));
+        path_builder.move_to(point(-length, width / 2.0));
 
         path_builder.cubic_bezier_to(
             point(-0.81731 * length, 0.2 * width),
             point(-0.41019 * length, 0.05833333 * width),
-            point(0.0, 0.0)
+            point(0.0, 0.0),
         );
         if harpoon {
             path_builder.line_to(point(if reversed { 0.5 } else { -1.0 } * line_width, 0.0));
@@ -177,7 +184,7 @@ impl Arrow {
             path_builder.cubic_bezier_to(
                 point(-0.41019 * length, -0.05833333 * width),
                 point(-0.81731 * length, -0.2 * width),
-                point(-length, -width/2.0)
+                point(-length, -width / 2.0),
             );
         }
         let path = Rc::new(path_builder.build());
@@ -189,13 +196,17 @@ impl Arrow {
         // });
 
         let stroke_options = StrokeOptions::DEFAULT
-            .with_line_join(
-                if round_join { LineJoin::Round } else { LineJoin::MiterClip }
-            ).with_line_cap(
-                if round_cap { LineCap::Round } else { LineCap::Butt }
-            ).with_line_width(
-                line_width
-            );
+            .with_line_join(if round_join {
+                LineJoin::Round
+            } else {
+                LineJoin::MiterClip
+            })
+            .with_line_cap(if round_cap {
+                LineCap::Round
+            } else {
+                LineCap::Butt
+            })
+            .with_line_width(line_width);
 
         if reversed {
             std::mem::swap(&mut visual_back_end, &mut visual_tip_end);
@@ -209,9 +220,9 @@ impl Arrow {
             visual_back_end,
             line_end,
             path,
-            stroke : Some(stroke_options),
-            fill : None,
-            uuid : ArrowId(Uuid::new_v4())
+            stroke: Some(stroke_options),
+            fill: None,
+            uuid: ArrowId(Uuid::new_v4()),
         }
     }
 
@@ -221,79 +232,94 @@ impl Arrow {
     //     line width = +0pt 1 1,
     //   },
 
-    pub fn hook_arrow(line_width : f32, angle : f32, round_join : bool, round_cap : bool, harpoon : bool, reversed : bool) -> Self {
-    //     % Adjust width and length: Take line thickness into account:
-    //     \advance\pgfarrowlength by-.5\pgfarrowlinewidth
-    //     \advance\pgfarrowwidth by-\pgfarrowlinewidth
+    pub fn hook_arrow(
+        line_width: f32,
+        angle: f32,
+        round_join: bool,
+        round_cap: bool,
+        harpoon: bool,
+        reversed: bool,
+    ) -> Self {
+        //     % Adjust width and length: Take line thickness into account:
+        //     \advance\pgfarrowlength by-.5\pgfarrowlinewidth
+        //     \advance\pgfarrowwidth by-\pgfarrowlinewidth
         let length = line_width * 1.25 + WebGlWrapper::point_to_pixels(0.75);
         let width = 4.0 * length - line_width;
         let length = length - line_width / 2.0;
         let width = width - line_width;
         let angle = Angle::degrees(angle);
 
-
-
-    //     \ifpgfarrowreversed
-    //       \ifpgfarrowroundjoin
-    //         \pgfarrowssetbackend{-.5\pgfarrowlinewidth}
-    //       \fi
-    //     \fi
-
+        //     \ifpgfarrowreversed
+        //       \ifpgfarrowroundjoin
+        //         \pgfarrowssetbackend{-.5\pgfarrowlinewidth}
+        //       \fi
+        //     \fi
 
         let (sin_angle, _) = angle.sin_cos();
-        let tip_end = line_width / 2.0 + length * if reversed {
-            if angle > Angle::frac_pi_2() * 3.0 { 1.0 } else if angle > Angle::pi() { -sin_angle } else { 0.0 }
-        } else {
-            if angle < Angle::frac_pi_2() { sin_angle } else { 1.0 }
-        };
+        let tip_end = line_width / 2.0
+            + length
+                * if reversed {
+                    if angle > Angle::frac_pi_2() * 3.0 {
+                        1.0
+                    } else if angle > Angle::pi() {
+                        -sin_angle
+                    } else {
+                        0.0
+                    }
+                } else {
+                    if angle < Angle::frac_pi_2() {
+                        sin_angle
+                    } else {
+                        1.0
+                    }
+                };
 
         //     % There are four different intervals for the values of
-    //     % \pgfarrowsarc that give rise to four different settings of tip
-    //     % ends and so on:
-    //     %
-    //     % Case 1: 0 <= Angle < 90
-    //     %
+        //     % \pgfarrowsarc that give rise to four different settings of tip
+        //     % ends and so on:
+        //     %
+        //     % Case 1: 0 <= Angle < 90
+        //     %
 
-        let back_end = - line_width / 2.0 + if angle < Angle::frac_pi_2() {
-            if reversed && round_join {
-                0.0
+        let back_end = -line_width / 2.0
+            + if angle < Angle::frac_pi_2() {
+                if reversed && round_join {
+                    0.0
+                } else {
+                    line_width / 2.0
+                }
+            } else if angle < Angle::pi() {
+                if round_cap {
+                    0.0
+                } else {
+                    line_width / 2.0
+                }
+            } else if angle < Angle::frac_pi_2() * 3.0 {
+                sin_angle * length
             } else {
-                line_width / 2.0
-            }
-        } else if angle < Angle::pi() {
-            if round_cap {
-                0.0
-            } else {
-                line_width / 2.0
-            }
-        } else if angle < Angle::frac_pi_2() * 3.0 {
-            sin_angle * length
-        } else {
-            - length
-        };
+                -length
+            };
 
-    //     \ifdim\pgfarrowarc pt<90pt%
-    //     \else\ifdim\pgfarrowarc pt<180pt%
-    //       \ifpgfarrowroundcap\pgfarrowssetbackend{-.5\pgfarrowlinewidth}\fi%
-    //     \else\ifdim\pgfarrowarc pt<270pt%
-    //         % Back end is given by sin(pgfarrowarc)*length
-    //         \pgfmathsin@{\pgfarrowarc}
-    //         \pgfarrowssetbackend{\pgfmathresult\pgfarrowlength\advance\pgf@x by-.5\pgfarrowlinewidth}%
-    //     \else%
-    //       \pgfarrowssetbackend{-\pgfarrowlength\advance\pgf@x by-.5\pgfarrowlinewidth}%
-    //     \fi\fi\fi%
+        //     \ifdim\pgfarrowarc pt<90pt%
+        //     \else\ifdim\pgfarrowarc pt<180pt%
+        //       \ifpgfarrowroundcap\pgfarrowssetbackend{-.5\pgfarrowlinewidth}\fi%
+        //     \else\ifdim\pgfarrowarc pt<270pt%
+        //         % Back end is given by sin(pgfarrowarc)*length
+        //         \pgfmathsin@{\pgfarrowarc}
+        //         \pgfarrowssetbackend{\pgfmathresult\pgfarrowlength\advance\pgf@x by-.5\pgfarrowlinewidth}%
+        //     \else%
+        //       \pgfarrowssetbackend{-\pgfarrowlength\advance\pgf@x by-.5\pgfarrowlinewidth}%
+        //     \fi\fi\fi%
 
-
-
-    //     \ifpgfarrowreversed
-    //       \pgfarrowssetlineend{.5\pgfarrowlinewidth}
-    //     \else%
-    //       \ifpgfarrowharpoon
-    //         \pgfarrowssetlineend{0pt}
-    //       \else
-    //         \pgfarrowssetlineend{.25\pgfarrowlinewidth}
-    //       \fi
-    //     \fi
+        //     \ifpgfarrowreversed
+        //       \pgfarrowssetlineend{.5\pgfarrowlinewidth}
+        //     \else%
+        //       \ifpgfarrowharpoon
+        //         \pgfarrowssetlineend{0pt}
+        //       \else
+        //         \pgfarrowssetlineend{.25\pgfarrowlinewidth}
+        //       \fi
+        //     \fi
 
         let line_end = if reversed {
             line_width / 2.0
@@ -308,13 +334,17 @@ impl Arrow {
         // \ifpgfarrowroundcap\pgfsetroundcap\else\pgfsetbuttcap\fi
         // \ifdim\pgfarrowlinewidth=\pgflinewidth\else\pgfsetlinewidth{+\pgfarrowlinewidth}\fi
         let stroke_options = StrokeOptions::DEFAULT
-            .with_line_join(
-                if round_join { LineJoin::Round } else { LineJoin::MiterClip }
-            ).with_line_cap(
-                if round_cap { LineCap::Round } else { LineCap::Butt }
-            ).with_line_width(
-                line_width
-            );
+            .with_line_join(if round_join {
+                LineJoin::Round
+            } else {
+                LineJoin::MiterClip
+            })
+            .with_line_cap(if round_cap {
+                LineCap::Round
+            } else {
+                LineCap::Butt
+            })
+            .with_line_width(line_width);
 
         // {%
         //   \pgftransformxscale{+\pgfarrowlength}
@@ -331,9 +361,10 @@ impl Arrow {
         // \fi\fi
         // \pgfusepathqstroke
 
-
         let mut path_builder = Path::builder();
-        path_builder.move_to(point(0.0, 1.0) + Vector::from_angle_and_length(angle-Angle::frac_pi_2(), 1.0));
+        path_builder.move_to(
+            point(0.0, 1.0) + Vector::from_angle_and_length(angle - Angle::frac_pi_2(), 1.0),
+        );
         path_builder.arc(point(0.0, 1.0), vector(1.0, 1.0), -angle, Angle::zero());
         if !harpoon {
             path_builder.arc(point(0.0, -1.0), vector(1.0, 1.0), -angle, Angle::zero());
@@ -341,25 +372,23 @@ impl Arrow {
         if harpoon && reversed {
             path_builder.line_to(point(line_width / length, 0.0));
         }
-        let path = Rc::new(path_builder.build().transformed(
-            &Transform::scale(length * if reversed { -1.0 } else { 1.0 }, width/4.0))
-        );
-
+        let path = Rc::new(path_builder.build().transformed(&Transform::scale(
+            length * if reversed { -1.0 } else { 1.0 },
+            width / 4.0,
+        )));
 
         Self {
             tip_end,
             back_end,
-            visual_tip_end : tip_end,
-            visual_back_end : back_end,
+            visual_tip_end: tip_end,
+            visual_back_end: back_end,
             line_end,
             path,
-            stroke : Some(stroke_options),
-            fill : None,
-            uuid : ArrowId(Uuid::new_v4())
+            stroke: Some(stroke_options),
+            fill: None,
+            uuid: ArrowId(Uuid::new_v4()),
         }
     }
-
-
 
     //     % Adjust arc:
     //     \pgf@x\pgfarrowarc pt%
@@ -396,17 +425,17 @@ impl Arrow {
         let length = 30.0;
         let width = 2.096774 * length;
         let mut path_builder = Path::builder();
-        path_builder.move_to(point(-length, width/2.0));
+        path_builder.move_to(point(-length, width / 2.0));
         path_builder.line_to(point(0.0, 0.0));
-        path_builder.line_to(point(-length, -width/2.0));
-        path_builder.line_to(point(-length/2.0, 0.0));
+        path_builder.line_to(point(-length, -width / 2.0));
+        path_builder.line_to(point(-length / 2.0, 0.0));
         path_builder.close();
         let path = Rc::new(path_builder.build());
         let tip_end = 0.0;
         let visual_tip_end = 0.0;
         let back_end = -length;
-        let visual_back_end = - length/2.0;
-        let line_end = -length/3.0;
+        let visual_back_end = -length / 2.0;
+        let line_end = -length / 3.0;
         Self {
             tip_end,
             back_end,
@@ -415,10 +444,10 @@ impl Arrow {
             line_end,
             path,
             // fill : Some(FillOptions::DEFAULT),
-            fill : None,
-            stroke : Some(StrokeOptions::DEFAULT),
+            fill: None,
+            stroke: Some(StrokeOptions::DEFAULT),
             // stroke : None,
-            uuid : ArrowId(Uuid::new_v4())
+            uuid: ArrowId(Uuid::new_v4()),
         }
     }
 }

--- a/chart/chart/display_backend/src/console_log.rs
+++ b/chart/chart/display_backend/src/console_log.rs
@@ -1,6 +1,5 @@
 use wasm_bindgen::prelude::*;
 
-
 #[wasm_bindgen]
 extern "C" {
     // Use `js_namespace` here to bind `console.log(..)` instead of just `log(..)`

--- a/chart/chart/display_backend/src/convex_hull.rs
+++ b/chart/chart/display_backend/src/convex_hull.rs
@@ -1,103 +1,112 @@
 // Stolen from: https://github.com/jobtalle/ConvexHull/tree/master/src/convexHull
 // use crate::log;
 
-use std::cmp::Ordering;
-use std::borrow::Borrow;
+use std::{borrow::Borrow, cmp::Ordering};
 
 use euclid::default::Box2D;
-
-use lyon::geom::math::{Point, Vector, Angle};
-
-use footile::{Path2D, PathOp, Plotter, FillRule, Transform};
-use pix::{Raster, el::Pixel, chan::Channel, matte::Matte8};
-
+use footile::{FillRule, Path2D, PathOp, Plotter, Transform};
+use lyon::geom::math::{Angle, Point, Vector};
+use pix::{chan::Channel, el::Pixel, matte::Matte8, Raster};
 
 // Must be the same as the angle_resolution constants defined in edge.vert and hit_canvas.vert.
-pub const ANGLE_RESOLUTION : usize = 180;
-const RASTER_SCALE_FACTOR : f32 = 100.0;
+pub const ANGLE_RESOLUTION: usize = 180;
+const RASTER_SCALE_FACTOR: f32 = 100.0;
 
-fn raster_midpoint<P: Pixel>(raster : &Raster<P>) -> Point {
-	Point::new((raster.width()/2) as f32, (raster.height()/2) as f32)
+fn raster_midpoint<P: Pixel>(raster: &Raster<P>) -> Point {
+    Point::new((raster.width() / 2) as f32, (raster.height() / 2) as f32)
 }
 
-fn raster_contains_point<P: Pixel>(raster : &Raster<P>, point : Point) -> bool {
-	raster.pixel(point.x as i32, point.y as i32).alpha() != P::Chan::MIN
+fn raster_contains_point<P: Pixel>(raster: &Raster<P>, point: Point) -> bool {
+    raster.pixel(point.x as i32, point.y as i32).alpha() != P::Chan::MIN
 }
 
-
-fn raster_to_convex_hull_polygon<P: Pixel>(raster : &Raster<P>, precision : f32) -> Vec<Vector> {
-	let mut convex_hull = sample_raster_outline(raster, Point::origin(), ANGLE_RESOLUTION);
-	average_nearby_points(&mut convex_hull, precision);
-	graham_scan(&mut convex_hull);
-	// convex_hull.shrink_to_fit();
-	convex_hull
+fn raster_to_convex_hull_polygon<P: Pixel>(raster: &Raster<P>, precision: f32) -> Vec<Vector> {
+    let mut convex_hull = sample_raster_outline(raster, Point::origin(), ANGLE_RESOLUTION);
+    average_nearby_points(&mut convex_hull, precision);
+    graham_scan(&mut convex_hull);
+    // convex_hull.shrink_to_fit();
+    convex_hull
 }
 
-
-fn scan_ray_for_nontransparent_pixel<P: Pixel>(raster : &Raster<P>, start_position : Point, direction : Vector, radius : i32) -> Point {
-	// Scan for pixel with nonzero value on color channel "channel"
-	for i in 0 .. radius {
-		let current_position = start_position - direction * i as f32;
-		// Check channel
-		if raster_contains_point(raster, current_position) {
-			return current_position;
-		}
-	}
-	start_position - direction * radius as f32
+fn scan_ray_for_nontransparent_pixel<P: Pixel>(
+    raster: &Raster<P>,
+    start_position: Point,
+    direction: Vector,
+    radius: i32,
+) -> Point {
+    // Scan for pixel with nonzero value on color channel "channel"
+    for i in 0..radius {
+        let current_position = start_position - direction * i as f32;
+        // Check channel
+        if raster_contains_point(raster, current_position) {
+            return current_position;
+        }
+    }
+    start_position - direction * radius as f32
 }
 
+fn sample_raster_outline<P: Pixel>(
+    raster: &Raster<P>,
+    pivot: Point,
+    point_count: usize,
+) -> Vec<Vector> {
+    let angle_step = Angle::two_pi() / (point_count as f32);
+    let half_dim = raster_midpoint(raster);
 
-fn sample_raster_outline<P: Pixel>(raster : &Raster<P>, pivot : Point, point_count : usize) -> Vec<Vector> {
-	let angle_step = Angle::two_pi() / (point_count as f32);
-	let half_dim = raster_midpoint(raster);
+    let mut result = Vec::with_capacity(point_count);
+    for i in 0..point_count {
+        let angle = angle_step * (i as f32);
+        let direction = Vector::from_angle_and_length(angle, 1.0);
 
-	let mut result = Vec::with_capacity(point_count);
-	for i in 0 .. point_count {
-		let angle = angle_step * (i as f32);
-		let direction = Vector::from_angle_and_length(angle, 1.0);
+        // Create edge points
+        let abscos = direction.x.abs();
+        let abssin = direction.y.abs();
 
-		// Create edge points
-		let abscos = direction.x.abs();
-		let abssin = direction.y.abs();
+        let radius = f32::min(half_dim.x / abscos, half_dim.y / abssin) - 1.0;
+        let position = scan_ray_for_nontransparent_pixel(
+            raster,
+            half_dim + direction * radius,
+            direction,
+            f32::ceil(radius) as i32,
+        );
 
-		let radius = f32::min(half_dim.x / abscos, half_dim.y / abssin) - 1.0;
-		let position = scan_ray_for_nontransparent_pixel(raster, half_dim + direction * radius, direction, f32::ceil(radius) as i32);
-
-		result.push(position - pivot);
-	}
-	result
+        result.push(position - pivot);
+    }
+    result
 }
-
 
 // Average together collections of nearby points. In place.
-fn average_nearby_points(points : &mut Vec<Vector>, trim_distance : f32) {
-	let mut input_idx = 0;
-	let mut output_idx = 0;
-	while input_idx < points.len() {
-		// Average the current point with as many later points as are closer than trim_distance to it.
-		let current = points[input_idx];
-		let (total, num_points) = points[input_idx + 1 ..].iter().take_while(|&&p| {
-			(p - current).length() < trim_distance
-		}).fold((current, 1), |(total, num_points), &point| (total + point, num_points + 1));
-		let average = total / (num_points as f32);
-		// Put new average into input list
-		points[output_idx] = average;
-		output_idx += 1;
-		input_idx += num_points;
-	}
-	// Shrink list to new length (panic if somehow output_idx > points.len())
-	points.resize_with(output_idx, || unreachable!());
+fn average_nearby_points(points: &mut Vec<Vector>, trim_distance: f32) {
+    let mut input_idx = 0;
+    let mut output_idx = 0;
+    while input_idx < points.len() {
+        // Average the current point with as many later points as are closer than trim_distance to it.
+        let current = points[input_idx];
+        let (total, num_points) = points[input_idx + 1..]
+            .iter()
+            .take_while(|&&p| (p - current).length() < trim_distance)
+            .fold((current, 1), |(total, num_points), &point| {
+                (total + point, num_points + 1)
+            });
+        let average = total / (num_points as f32);
+        // Put new average into input list
+        points[output_idx] = average;
+        output_idx += 1;
+        input_idx += num_points;
+    }
+    // Shrink list to new length (panic if somehow output_idx > points.len())
+    points.resize_with(output_idx, || unreachable!());
 }
 
-fn orientation(p : Vector, q : Vector, r : Vector) -> f32 {
-	Vector::cross(r - q, q - p)
+fn orientation(p: Vector, q: Vector, r: Vector) -> f32 {
+    Vector::cross(r - q, q - p)
 }
 
-fn compare_magnitudes(p : Vector, q : Vector) -> Ordering {
-	p.length().partial_cmp(&q.length()).unwrap()
+fn compare_magnitudes(p: Vector, q: Vector) -> Ordering {
+    p.length().partial_cmp(&q.length()).unwrap()
 }
 
-#[derive(PartialEq,PartialOrd)]
+#[derive(PartialEq, PartialOrd)]
 struct NonNan(f32);
 
 impl NonNan {
@@ -118,99 +127,120 @@ impl Ord for NonNan {
     }
 }
 
+fn graham_scan(points: &mut Vec<Vector>) {
+    // Find minimum Y
+    let (min_idx, _) = points
+        .iter()
+        .enumerate()
+        .min_by_key(|(_idx, v)| NonNan::new(v.y).unwrap())
+        .unwrap();
 
-fn graham_scan(points : &mut Vec<Vector>) {
+    // Put minimum at zero
+    points.swap(0, min_idx);
 
-	// Find minimum Y
-	let (min_idx, _) = points.iter().enumerate().min_by_key(|(_idx, v)| NonNan::new(v.y).unwrap()).unwrap();
-
-	// Put minimum at zero
-	points.swap(0, min_idx);
-
-	let compare_point = points[0];
-	points.sort_by(
+    let compare_point = points[0];
+    points.sort_by(
 		move |&p1, &p2| // sort first by the handedness of (compare_point, p1, p2) then by distance from compare_pt.
 		orientation(compare_point, p1, p2).partial_cmp(&0.0).unwrap().then_with(|| compare_magnitudes(p1 - compare_point, p2 - compare_point))
 	);
 
-	// Create & initialize stack
-	let mut stack_length : usize = 3;
-	for i in 3 .. points.len() {
-		// Seems like this could lead to an infinite loop here...
-		// Luckily, Rust will panic if stack_index becomes less than 2
-		while orientation(points[stack_length - 2], points[stack_length - 1], points[i]) >= 0.0 {
-			stack_length -= 1;
-		}
-		points[stack_length] = points[i];
-		stack_length += 1;
-	}
-	// Shrink list to new length (panic if somehow output_idx > points.len())
-	points.resize_with(stack_length, || unreachable!());
+    // Create & initialize stack
+    let mut stack_length: usize = 3;
+    for i in 3..points.len() {
+        // Seems like this could lead to an infinite loop here...
+        // Luckily, Rust will panic if stack_index becomes less than 2
+        while orientation(
+            points[stack_length - 2],
+            points[stack_length - 1],
+            points[i],
+        ) >= 0.0
+        {
+            stack_length -= 1;
+        }
+        points[stack_length] = points[i];
+        stack_length += 1;
+    }
+    // Shrink list to new length (panic if somehow output_idx > points.len())
+    points.resize_with(stack_length, || unreachable!());
 }
 
-fn rasterize_polygon(polygon : &[Vector], width : u32, height : u32) -> Raster<Matte8> {
-	let mut path_builder = Path2D::default();
-	path_builder = path_builder.absolute().move_to(polygon[0].x, polygon[0].y);
-	for v in &polygon[1..] {
-		path_builder = path_builder.line_to(v.x, v.y);
-	}
-	let path = path_builder.close().finish();
-	let mut p = Plotter::new(Raster::<Matte8>::with_clear(width, height));
+fn rasterize_polygon(polygon: &[Vector], width: u32, height: u32) -> Raster<Matte8> {
+    let mut path_builder = Path2D::default();
+    path_builder = path_builder.absolute().move_to(polygon[0].x, polygon[0].y);
+    for v in &polygon[1..] {
+        path_builder = path_builder.line_to(v.x, v.y);
+    }
+    let path = path_builder.close().finish();
+    let mut p = Plotter::new(Raster::<Matte8>::with_clear(width, height));
     p.fill(FillRule::NonZero, path.iter(), Matte8::new(255));
     p.raster()
 }
 
-
-
 pub struct ConvexHull {
-	pub outline : Vec<Vector>,
-	pub inner_radius : f32,
-	pub outer_radius : f32,
-	bounding_box : Box2D<f32>
+    pub outline: Vec<Vector>,
+    pub inner_radius: f32,
+    pub outer_radius: f32,
+    bounding_box: Box2D<f32>,
 }
 
 impl ConvexHull {
+    pub fn from_path<T>(path: T, bounding_box: Box2D<f32>) -> Self
+    where
+        T: IntoIterator,
+        T::Item: Borrow<PathOp>,
+    {
+        let width_and_height = bounding_box.max - bounding_box.min;
+        let raster_scale = RASTER_SCALE_FACTOR / f32::min(width_and_height.x, width_and_height.y);
+        let width_and_height = (width_and_height * raster_scale).ceil();
+        let width = width_and_height.x as u32;
+        let height = width_and_height.y as u32;
 
-	pub fn from_path<T>(path : T, bounding_box : Box2D<f32>) -> Self
-	where T: IntoIterator, T::Item: Borrow<PathOp>,
-	{
-		let width_and_height = bounding_box.max - bounding_box.min;
-		let raster_scale = RASTER_SCALE_FACTOR / f32::min(width_and_height.x, width_and_height.y);
-		let width_and_height = (width_and_height * raster_scale).ceil();
-		let width = width_and_height.x as u32;
-		let height = width_and_height.y as u32;
+        let transform = Transform::with_translate(-bounding_box.min.x, -bounding_box.min.y)
+            .scale(raster_scale, raster_scale);
 
+        let mut p = Plotter::new(Raster::<Matte8>::with_clear(width, height));
+        p.set_transform(transform)
+            .fill(FillRule::NonZero, path, Matte8::new(255));
+        let raster = p.raster();
+        let polygon = raster_to_convex_hull_polygon(&raster, 0.1);
+        let convex_raster = rasterize_polygon(&polygon, width, height);
+        let mut outline = sample_raster_outline(
+            &convex_raster,
+            raster_midpoint(&convex_raster),
+            ANGLE_RESOLUTION,
+        );
+        for v in &mut outline {
+            *v /= raster_scale;
+        }
+        let inner_radius = outline
+            .iter()
+            .map(|p| NonNan::new(p.length()))
+            .min()
+            .unwrap()
+            .unwrap()
+            .0;
+        let outer_radius = outline
+            .iter()
+            .map(|p| NonNan::new(p.length()))
+            .max()
+            .unwrap()
+            .unwrap()
+            .0;
+        Self {
+            outline,
+            bounding_box,
+            inner_radius,
+            outer_radius,
+        }
+    }
 
-		let transform = Transform::with_translate(-bounding_box.min.x, - bounding_box.min.y).scale(raster_scale, raster_scale);
+    #[allow(dead_code)]
+    pub fn find_boundary_point(&self, angle: Angle) -> Vector {
+        let index = ((ANGLE_RESOLUTION as f32) * (angle.positive() / Angle::two_pi())) as usize;
+        self.outline[index]
+    }
 
-		let mut p = Plotter::new(Raster::<Matte8>::with_clear(width, height));
-		p.set_transform(transform).fill(FillRule::NonZero, path, Matte8::new(255));
-		let raster = p.raster();
-		let polygon = raster_to_convex_hull_polygon(&raster, 0.1);
-		let convex_raster = rasterize_polygon(&polygon, width, height);
-		let mut outline = sample_raster_outline(
-			&convex_raster, raster_midpoint(&convex_raster), ANGLE_RESOLUTION
-		);
-		for v in &mut outline {
-			*v /= raster_scale;
-		}
-		let inner_radius = outline.iter().map(|p| NonNan::new(p.length())).min().unwrap().unwrap().0;
-		let outer_radius = outline.iter().map(|p| NonNan::new(p.length())).max().unwrap().unwrap().0;
-		Self {
-			outline,
-			bounding_box,
-			inner_radius,
-			outer_radius
-		}
-	}
-
-	#[allow(dead_code)]
-	pub fn find_boundary_point(&self, angle : Angle) -> Vector {
-		let index = ((ANGLE_RESOLUTION as f32) * (angle.positive()/Angle::two_pi())) as usize;
-		self.outline[index]
-	}
-
-	pub fn center(&self) -> Point {
-		self.bounding_box.max.lerp(self.bounding_box.min,  0.5)
-	}
+    pub fn center(&self) -> Point {
+        self.bounding_box.max.lerp(self.bounding_box.min, 0.5)
+    }
 }

--- a/chart/chart/display_backend/src/coordinate_system.rs
+++ b/chart/chart/display_backend/src/coordinate_system.rs
@@ -1,6 +1,6 @@
-use lyon::geom::math::{Point, point, Vector, vector, Transform};
 use std::cmp::Ordering;
 
+use lyon::geom::math::{point, vector, Point, Transform, Vector};
 use wasm_bindgen::prelude::*;
 
 #[allow(unused_imports)]
@@ -9,29 +9,33 @@ use crate::vector::JsPoint;
 
 #[derive(Clone, Copy, PartialEq, Debug)]
 pub struct BufferDimensions {
-	width : i32,
-	height : i32,
-	density : f64
+    width: i32,
+    height: i32,
+    density: f64,
 }
 
 impl BufferDimensions {
-	pub fn new(width : i32, height : i32, density : f64) -> Self {
-		Self { width, height, density }
-	}
+    pub fn new(width: i32, height: i32, density: f64) -> Self {
+        Self {
+            width,
+            height,
+            density,
+        }
+    }
 
-	pub fn width(&self) -> i32 {
-		self.width
-	}
+    pub fn width(&self) -> i32 {
+        self.width
+    }
 
-	pub fn height(&self) -> i32 {
-		self.height
-	}
+    pub fn height(&self) -> i32 {
+        self.height
+    }
 
-	pub fn density(&self) -> f64 {
-		self.density
-	}
+    pub fn density(&self) -> f64 {
+        self.density
+    }
 
-	pub fn pixel_width(&self) -> i32 {
+    pub fn pixel_width(&self) -> i32 {
         (self.width as f64 * self.density) as i32
     }
 
@@ -40,102 +44,97 @@ impl BufferDimensions {
     }
 }
 
-
 #[derive(Clone, Copy, Debug)]
 pub struct CoordinateSystem {
-	pub(crate) origin : Point,
-    pub(crate) scale : Vector,
-    pub(crate) glyph_scale : f32,
+    pub(crate) origin: Point,
+    pub(crate) scale: Vector,
+    pub(crate) glyph_scale: f32,
 
-    pub(crate) left_margin : i32,
-    pub(crate) right_margin : i32,
-    pub(crate) bottom_margin : i32,
-    pub(crate) top_margin : i32,
+    pub(crate) left_margin: i32,
+    pub(crate) right_margin: i32,
+    pub(crate) bottom_margin: i32,
+    pub(crate) top_margin: i32,
 
-    padding : f32,
+    padding: f32,
     // Prevent padding jagging when scale is maxed
-    max_scaled_padding : Vector,
+    max_scaled_padding: Vector,
 
     // pixel coordinates to WebGl coordinates [-1, 1] x [-1, 1]
-    pub(crate) transform : Transform,
+    pub(crate) transform: Transform,
     // dimensions of screen
-    pub(crate) buffer_dimensions : BufferDimensions,
+    pub(crate) buffer_dimensions: BufferDimensions,
 
-
-    natural_scale_ratio : f32,
-    max_scale : f32,
-    min_xy_boundary : Point,
-    max_xy_boundary : Point,
+    natural_scale_ratio: f32,
+    max_scale: f32,
+    min_xy_boundary: Point,
+    max_xy_boundary: Point,
 }
 
 impl CoordinateSystem {
     pub fn new() -> Self {
         CoordinateSystem {
             // user affine coordinate transformation
-            origin : point(0.0, 0.0),
-            scale : vector(100.0, 100.0),
+            origin: point(0.0, 0.0),
+            scale: vector(100.0, 100.0),
 
             // pixel coordinates to WebGl coordinates [-1, 1] x [-1, 1]
-            transform : Transform::identity(),
+            transform: Transform::identity(),
 
-            left_margin : 10,
-            right_margin : 10,
-            bottom_margin : 10,
-            top_margin : 10,
+            left_margin: 10,
+            right_margin: 10,
+            bottom_margin: 10,
+            top_margin: 10,
 
-            padding : 20.0,
-            max_scaled_padding : vector(0.0, 0.0),
+            padding: 20.0,
+            max_scaled_padding: vector(0.0, 0.0),
 
-            buffer_dimensions : BufferDimensions::new(1, 1, 0.0),
+            buffer_dimensions: BufferDimensions::new(1, 1, 0.0),
 
             // bounds on user affine coordinate transform
-            natural_scale_ratio : 1.0,
-            max_scale : 1000.0,
-            min_xy_boundary : point(f32::NEG_INFINITY, f32::NEG_INFINITY),
-            max_xy_boundary : point(f32::INFINITY, f32::INFINITY),
-            glyph_scale : 1.0,
+            natural_scale_ratio: 1.0,
+            max_scale: 1000.0,
+            min_xy_boundary: point(f32::NEG_INFINITY, f32::NEG_INFINITY),
+            max_xy_boundary: point(f32::INFINITY, f32::INFINITY),
+            glyph_scale: 1.0,
         }
     }
 
-
-    pub fn transform_point(&self, point : Point) -> Point {
-        let Point {x, y, ..} = point;
+    pub fn transform_point(&self, point: Point) -> Point {
+        let Point { x, y, .. } = point;
         Point::new(self.transform_x(x), self.transform_y(y))
     }
 
-    pub fn transform_x(&self, x : f32) -> f32 {
+    pub fn transform_x(&self, x: f32) -> f32 {
         self.origin.x + x * self.scale.x
     }
 
-    pub fn transform_y(&self, y : f32) -> f32 {
+    pub fn transform_y(&self, y: f32) -> f32 {
         self.origin.y - y * self.scale.y
     }
 
-    pub fn glyph_position(&self, position : Point, offset : Vector) -> Point {
+    pub fn glyph_position(&self, position: Point, offset: Vector) -> Point {
         self.transform_point(position) + offset * self.glyph_scale
     }
 
-    pub fn inverse_transform_point(&self, point : Point) -> Point {
-        let Point {x, y, ..} = point;
-        Point::new(
-            self.inverse_transform_x(x),
-            self.inverse_transform_y(y)
-        )
+    pub fn inverse_transform_point(&self, point: Point) -> Point {
+        let Point { x, y, .. } = point;
+        Point::new(self.inverse_transform_x(x), self.inverse_transform_y(y))
     }
 
-    pub fn inverse_transform_x(&self, x : f32) -> f32 {
-        (x - self.origin.x)/self.scale.x
+    pub fn inverse_transform_x(&self, x: f32) -> f32 {
+        (x - self.origin.x) / self.scale.x
     }
 
-    pub fn inverse_transform_y(&self, y : f32) -> f32 {
+    pub fn inverse_transform_y(&self, y: f32) -> f32 {
         -(y - self.origin.y) / self.scale.y
     }
 
-    pub fn set_margins(&mut self,
-        left_margin : i32,
-        right_margin : i32,
-        bottom_margin : i32,
-        top_margin : i32,
+    pub fn set_margins(
+        &mut self,
+        left_margin: i32,
+        right_margin: i32,
+        bottom_margin: i32,
+        top_margin: i32,
     ) {
         self.left_margin = left_margin;
         self.right_margin = right_margin;
@@ -143,12 +142,12 @@ impl CoordinateSystem {
         self.top_margin = top_margin;
     }
 
-    pub fn set_padding(&mut self, padding : f32) {
+    pub fn set_padding(&mut self, padding: f32) {
         self.padding = padding;
         self.update_max_scaled_padding();
     }
 
-    pub fn set_glyph_scale(&mut self, glyph_scale : f32){
+    pub fn set_glyph_scale(&mut self, glyph_scale: f32) {
         let cur_xy_range = self.current_max_xy() - self.current_min_xy();
         let max_xy_range = self.max_xy_bounds() - self.min_xy_bounds();
         self.glyph_scale = glyph_scale;
@@ -166,18 +165,20 @@ impl CoordinateSystem {
         self.enforce_scale_out_bounds();
     }
 
-
     // Because the padding is dependent on the scale and the max scale depends on the padding, there is a feedback loop.
     // This causes jagging when zoomed all the way out. To prevent this, cap the padding at the max that would be obtained
     // when the padding is 0.
-    fn update_max_scaled_padding(&mut self){
+    fn update_max_scaled_padding(&mut self) {
         let (xmin, ymin) = self.min_xy_boundary.to_tuple();
         let (xmax, ymax) = self.max_xy_boundary.to_tuple();
         let (screen_x_min, screen_x_max) = self.screen_x_range();
         let (screen_y_min, screen_y_max) = self.screen_y_range();
         let approx_max_x_scale = (screen_x_max - screen_x_min) / (xmax - xmin);
         let approx_max_y_scale = (screen_y_max - screen_y_min) / (ymax - ymin);
-        self.max_scaled_padding = vector(self.padding / approx_max_x_scale, self.padding / approx_max_y_scale);
+        self.max_scaled_padding = vector(
+            self.padding / approx_max_x_scale,
+            self.padding / approx_max_y_scale,
+        );
     }
 
     fn scaled_x_padding(&self) -> f32 {
@@ -188,17 +189,26 @@ impl CoordinateSystem {
         (self.padding / self.scale.y).min(self.max_scaled_padding.y) * self.glyph_scale
     }
 
-    pub fn reset_transform(&mut self){
-        self.transform = Transform::scale(2.0/ (self.buffer_dimensions.width() as f32), -2.0/(self.buffer_dimensions.height() as f32))
-            .then_translate(vector(-1.0, 1.0));
+    pub fn reset_transform(&mut self) {
+        self.transform = Transform::scale(
+            2.0 / (self.buffer_dimensions.width() as f32),
+            -2.0 / (self.buffer_dimensions.height() as f32),
+        )
+        .then_translate(vector(-1.0, 1.0));
     }
 
     pub(crate) fn screen_x_range(&self) -> (f32, f32) {
-        (self.left_margin as f32, (self.buffer_dimensions.width() - self.right_margin) as f32)
+        (
+            self.left_margin as f32,
+            (self.buffer_dimensions.width() - self.right_margin) as f32,
+        )
     }
 
     pub(crate) fn screen_y_range(&self) -> (f32, f32) {
-        (self.top_margin as f32, (self.buffer_dimensions.height() - self.bottom_margin) as f32)
+        (
+            self.top_margin as f32,
+            (self.buffer_dimensions.height() - self.bottom_margin) as f32,
+        )
     }
 
     pub(crate) fn current_min_xy(&self) -> Point {
@@ -221,76 +231,80 @@ impl CoordinateSystem {
         (self.current_min_xy().y, self.current_max_xy().y)
     }
 
-    pub fn set_current_xrange(&mut self, xmin : f32, xmax : f32){
+    pub fn set_current_xrange(&mut self, xmin: f32, xmax: f32) {
         let padded_x_min = xmin - self.scaled_x_padding();
         let padded_x_max = xmax + self.scaled_x_padding();
         self.set_current_xrange_no_padding(padded_x_min, padded_x_max);
     }
 
-    pub fn set_current_yrange(&mut self, ymin : f32, ymax : f32){
+    pub fn set_current_yrange(&mut self, ymin: f32, ymax: f32) {
         let padded_y_min = ymin - self.scaled_y_padding();
         let padded_y_max = ymax + self.scaled_y_padding();
         self.set_current_yrange_no_padding(padded_y_min, padded_y_max);
     }
 
-    pub fn update_natural_ratio(&mut self){
+    pub fn update_natural_ratio(&mut self) {
         self.natural_scale_ratio = self.scale.y / self.scale.x;
     }
 
-    fn set_current_xrange_no_padding(&mut self, xmin : f32, xmax : f32){
+    fn set_current_xrange_no_padding(&mut self, xmin: f32, xmax: f32) {
         let (screen_x_min, screen_x_max) = self.screen_x_range();
         self.scale.x = (screen_x_max - screen_x_min) / (xmax - xmin);
         self.origin.x = screen_x_min - xmin * self.scale.x;
     }
 
-    fn set_current_yrange_no_padding(&mut self, ymin : f32, ymax : f32){
+    fn set_current_yrange_no_padding(&mut self, ymin: f32, ymax: f32) {
         let (screen_y_min, screen_y_max) = self.screen_y_range();
         self.scale.y = (screen_y_max - screen_y_min) / (ymax - ymin);
         self.origin.y = screen_y_min + ymax * self.scale.y;
     }
 
-    pub fn set_max_xrange(&mut self, xmin : f32, xmax : f32){
+    pub fn set_max_xrange(&mut self, xmin: f32, xmax: f32) {
         self.min_xy_boundary.x = xmin;
         self.max_xy_boundary.x = xmax;
         self.update_max_scaled_padding();
         self.enforce_scale_out_bounds();
     }
 
-    pub fn set_max_yrange(&mut self, ymin : f32, ymax : f32){
+    pub fn set_max_yrange(&mut self, ymin: f32, ymax: f32) {
         self.min_xy_boundary.y = ymin;
         self.max_xy_boundary.y = ymax;
         self.update_max_scaled_padding();
         self.enforce_scale_out_bounds();
     }
 
-    pub fn translate(&mut self, delta : JsPoint) {
-        let delta : Vector = delta.into();
+    pub fn translate(&mut self, delta: JsPoint) {
+        let delta: Vector = delta.into();
         self.origin += delta;
         self.enforce_translation_bounds();
     }
 
-    pub fn scale_around(&mut self, scale : f32, center : JsPoint) -> Result<(), JsValue> {
+    pub fn scale_around(&mut self, scale: f32, center: JsPoint) -> Result<(), JsValue> {
         // ensure maximum scale
         let mut scale = f32::min(scale, self.max_scale / f32::max(self.scale.x, self.scale.y));
         // Now if we scale in we have to ensure that we restore the natural aspect ratio before scaling both directions.
         if scale > 1.0 {
             let scale_ratio = self.scale.y / self.scale.x;
             match scale_ratio.partial_cmp(&self.natural_scale_ratio) {
-                None => { return Err("NaN occurred somehow?".into()); },
-                Some(Ordering::Equal) => {},
-                Some(Ordering::Less) => { // stretched in the y direction
+                None => {
+                    return Err("NaN occurred somehow?".into());
+                }
+                Some(Ordering::Equal) => {}
+                Some(Ordering::Less) => {
+                    // stretched in the y direction
                     // How much would we have to scale by to correct the stretch?
-                    let correction_ratio = self.natural_scale_ratio/scale_ratio;
+                    let correction_ratio = self.natural_scale_ratio / scale_ratio;
                     let yscale = scale.min(correction_ratio);
                     self.scale_around_y_raw(yscale, center);
                     scale /= yscale;
-                },
-                Some(Ordering::Greater) => { // stretched in the x direction
-                    let correction_ratio = scale_ratio/self.natural_scale_ratio;
+                }
+                Some(Ordering::Greater) => {
+                    // stretched in the x direction
+                    let correction_ratio = scale_ratio / self.natural_scale_ratio;
                     let xscale = scale.min(correction_ratio);
                     self.scale_around_x_raw(xscale, center);
                     scale /= xscale;
-                },
+                }
             }
         }
         self.scale_around_raw(scale, center);
@@ -298,14 +312,13 @@ impl CoordinateSystem {
         Ok(())
     }
 
-
-    fn scale_around_raw(&mut self, scale : f32, center : JsPoint){
-        let center : Point = center.into();
+    fn scale_around_raw(&mut self, scale: f32, center: JsPoint) {
+        let center: Point = center.into();
         self.origin += (center - self.origin) * (1.0 - scale);
         self.scale *= scale;
     }
 
-    fn scale_around_x_raw(&mut self, scale : f32, center : JsPoint){
+    fn scale_around_x_raw(&mut self, scale: f32, center: JsPoint) {
         let y = self.origin.y;
         let yscale = self.scale.y;
         self.scale_around_raw(scale, center);
@@ -313,7 +326,7 @@ impl CoordinateSystem {
         self.scale.y = yscale;
     }
 
-    fn scale_around_y_raw(&mut self, scale : f32, center : JsPoint){
+    fn scale_around_y_raw(&mut self, scale: f32, center: JsPoint) {
         let x = self.origin.x;
         let xscale = self.scale.x;
         self.scale_around_raw(scale, center);
@@ -330,7 +343,7 @@ impl CoordinateSystem {
     }
 
     // Ensure that we don't scroll off sides of region
-    fn enforce_translation_bounds(&mut self){
+    fn enforce_translation_bounds(&mut self) {
         let cur_min = self.current_min_xy();
         let cur_max = self.current_max_xy();
         let bound_min = self.min_xy_bounds();
@@ -343,7 +356,7 @@ impl CoordinateSystem {
         self.origin -= correction;
     }
 
-    fn enforce_scale_out_bounds(&mut self){
+    fn enforce_scale_out_bounds(&mut self) {
         // Fix scale before doing translation bounds to prevent thrashing / weird behavior when range is too big.
         let cur_xy_range = self.current_max_xy() - self.current_min_xy();
         let min_xy_bounds = self.min_xy_bounds();
@@ -357,5 +370,4 @@ impl CoordinateSystem {
         }
         self.enforce_translation_bounds();
     }
-
 }

--- a/chart/chart/display_backend/src/error.rs
+++ b/chart/chart/display_backend/src/error.rs
@@ -1,7 +1,6 @@
+use lyon::tessellation::TessellationError;
 use wasm_bindgen::JsValue;
 
-use lyon::tessellation::TessellationError;
-
-pub fn convert_tessellation_error(err : TessellationError) -> JsValue {
+pub fn convert_tessellation_error(err: TessellationError) -> JsValue {
     JsValue::from_str(&format!("{:?}", err))
 }

--- a/chart/chart/display_backend/src/glyph.rs
+++ b/chart/chart/display_backend/src/glyph.rs
@@ -1,63 +1,58 @@
+use std::rc::Rc;
+
+use arrayvec::ArrayVec;
+use euclid::default::Box2D;
+use fonterator::{self as font, Font}; // For parsing font file.
+use footile::{Path2D, PathOp, Pt};
+use lazy_static::lazy_static;
+use lyon::{
+    geom::math::{point, vector, Angle, Point, Transform, Vector},
+    path::{iterator::PathIterator, Path, PathEvent},
+    tessellation::{
+        geometry_builder, FillOptions, FillTessellator, StrokeOptions, StrokeTessellator,
+        VertexBuffers,
+    },
+};
+use uuid::Uuid;
+use wasm_bindgen::prelude::*;
+
 #[allow(unused_imports)]
 use crate::log;
-use crate::error::convert_tessellation_error;
-
-use lazy_static::lazy_static;
-use arrayvec::ArrayVec;
-
-use std::rc::Rc;
-use uuid::Uuid;
-
-use wasm_bindgen::prelude::*;
-use euclid::default::Box2D;
-use footile::{Pt, PathOp, Path2D};
-use fonterator::{self as font, Font}; // For parsing font file.
-use lyon::geom::math::{point, Point, vector, Vector, Angle, Transform};
-use lyon::path::{Path, PathEvent, iterator::PathIterator};
-use lyon::tessellation::{
-    geometry_builder,
-    StrokeTessellator, StrokeOptions,
-    FillTessellator, FillOptions, VertexBuffers
-};
-
-
-
-use crate::vector::{Vec4};
-use crate::convex_hull::{ConvexHull};
 #[allow(unused_imports)]
 use crate::stroke_tessellation::{PositionNormal, PositionNormalConstructor};
+use crate::{convex_hull::ConvexHull, error::convert_tessellation_error, vector::Vec4};
 
 const FONT_SIZE: f32 = 32.0;
-const SCALE_FACTOR : f32 = 100.0; // TODO: what/why is SCALE_FACTOR? What are the units here?
+const SCALE_FACTOR: f32 = 100.0; // TODO: what/why is SCALE_FACTOR? What are the units here?
 
-lazy_static!{
-    static ref STIX_FONT : Font<'static> = {
-        font::Font::new().push(include_bytes!("../fonts/STIX2Math.otf") as &[u8]).expect("Failed to parse font file")
+lazy_static! {
+    static ref STIX_FONT: Font<'static> = {
+        font::Font::new()
+            .push(include_bytes!("../fonts/STIX2Math.otf") as &[u8])
+            .expect("Failed to parse font file")
     };
 }
 
-
-
-fn pt_to_euclid(p : Pt) -> Point {
+fn pt_to_euclid(p: Pt) -> Point {
     point(p.0, p.1)
 }
 
-fn euclid_pt_to_footile_pt(p : Point) -> Pt {
+fn euclid_pt_to_footile_pt(p: Point) -> Pt {
     Pt(p.x, p.y)
 }
 
-fn pathop_bounding_box<'a, T : Iterator<Item=&'a PathOp>>(path : T) -> Box2D<f32> {
-    Box2D::from_points(path.flat_map(|path_op|{
+fn pathop_bounding_box<'a, T: Iterator<Item = &'a PathOp>>(path: T) -> Box2D<f32> {
+    Box2D::from_points(path.flat_map(|path_op| {
         let mut result = ArrayVec::<[_; 3]>::new();
         match path_op {
-            PathOp::Close() => {},
+            PathOp::Close() => {}
             PathOp::Move(to) => result.push(pt_to_euclid(*to)),
             PathOp::Line(to) => result.push(pt_to_euclid(*to)),
             PathOp::Quad(ctrl, to) => {
                 result.push(pt_to_euclid(*ctrl));
                 result.push(pt_to_euclid(*to));
             }
-            PathOp::Cubic(ctrl1, ctrl2, to) =>{
+            PathOp::Cubic(ctrl1, ctrl2, to) => {
                 result.push(pt_to_euclid(*ctrl1));
                 result.push(pt_to_euclid(*ctrl2));
                 result.push(pt_to_euclid(*to));
@@ -68,18 +63,24 @@ fn pathop_bounding_box<'a, T : Iterator<Item=&'a PathOp>>(path : T) -> Box2D<f32
     }))
 }
 
-fn footile_path_to_lyon_path<T : Iterator<Item=PathOp>>(path : T) -> impl Iterator<Item=PathEvent> {
+fn footile_path_to_lyon_path<T: Iterator<Item = PathOp>>(
+    path: T,
+) -> impl Iterator<Item = PathEvent> {
     let mut first = point(0.0, 0.0);
     let mut from = point(0.0, 0.0);
     path.filter_map(move |path_op| {
         let result; //= None;
         match path_op {
             PathOp::Close() => {
-                result = Some(PathEvent::End { last : from, first, close : true});
+                result = Some(PathEvent::End {
+                    last: from,
+                    first,
+                    close: true,
+                });
             }
             PathOp::Move(to) => {
                 let to = pt_to_euclid(to);
-                result = Some(PathEvent::Begin { at : to });
+                result = Some(PathEvent::Begin { at: to });
                 first = to;
                 from = to;
             }
@@ -98,49 +99,56 @@ fn footile_path_to_lyon_path<T : Iterator<Item=PathOp>>(path : T) -> impl Iterat
                 let ctrl1 = pt_to_euclid(ctrl1);
                 let ctrl2 = pt_to_euclid(ctrl2);
                 let to = pt_to_euclid(to);
-                result = Some(PathEvent::Cubic { from, ctrl1, ctrl2, to });
+                result = Some(PathEvent::Cubic {
+                    from,
+                    ctrl1,
+                    ctrl2,
+                    to,
+                });
                 from = to;
             }
-            PathOp::PenWidth(_) => {unimplemented!()}
+            PathOp::PenWidth(_) => {
+                unimplemented!()
+            }
         }
         result
     })
 }
 
-fn scale_lyon_path<T : Iterator<Item=PathEvent>>(path : T, scale : f32) -> impl Iterator<Item=PathEvent>{
+fn scale_lyon_path<T: Iterator<Item = PathEvent>>(
+    path: T,
+    scale: f32,
+) -> impl Iterator<Item = PathEvent> {
     path.map(move |event| event.transformed(&Transform::scale(scale, scale)))
 }
 
-fn lyon_path_to_footile_path<T : Iterator<Item=PathEvent>>(path : T) -> Vec<PathOp> {
-    path.filter_map(move |path_event| {
-        match path_event {
-            PathEvent::End { close : false, ..} => {
-                None
-            }
-            PathEvent::End { close : true, ..} => {
-                Some(PathOp::Close())
-            }
-            PathEvent::Begin { at : to } => {
-                let to = euclid_pt_to_footile_pt(to);
-                Some(PathOp::Move(to))
-            }
-            PathEvent::Line { to, .. } => {
-                let to = euclid_pt_to_footile_pt(to);
-                Some(PathOp::Line(to))
-            }
-            PathEvent::Quadratic { ctrl, to, .. } => {
-                let ctrl = euclid_pt_to_footile_pt(ctrl);
-                let to = euclid_pt_to_footile_pt(to);
-                Some(PathOp::Quad(ctrl, to))
-            }
-            PathEvent::Cubic { ctrl1, ctrl2, to, .. } => {
-                let ctrl1 = euclid_pt_to_footile_pt(ctrl1);
-                let ctrl2 = euclid_pt_to_footile_pt(ctrl2);
-                let to = euclid_pt_to_footile_pt(to);
-                Some(PathOp::Cubic(ctrl1, ctrl2, to))
-            }
+fn lyon_path_to_footile_path<T: Iterator<Item = PathEvent>>(path: T) -> Vec<PathOp> {
+    path.filter_map(move |path_event| match path_event {
+        PathEvent::End { close: false, .. } => None,
+        PathEvent::End { close: true, .. } => Some(PathOp::Close()),
+        PathEvent::Begin { at: to } => {
+            let to = euclid_pt_to_footile_pt(to);
+            Some(PathOp::Move(to))
         }
-    }).collect()
+        PathEvent::Line { to, .. } => {
+            let to = euclid_pt_to_footile_pt(to);
+            Some(PathOp::Line(to))
+        }
+        PathEvent::Quadratic { ctrl, to, .. } => {
+            let ctrl = euclid_pt_to_footile_pt(ctrl);
+            let to = euclid_pt_to_footile_pt(to);
+            Some(PathOp::Quad(ctrl, to))
+        }
+        PathEvent::Cubic {
+            ctrl1, ctrl2, to, ..
+        } => {
+            let ctrl1 = euclid_pt_to_footile_pt(ctrl1);
+            let ctrl2 = euclid_pt_to_footile_pt(ctrl2);
+            let to = euclid_pt_to_footile_pt(to);
+            Some(PathOp::Cubic(ctrl1, ctrl2, to))
+        }
+    })
+    .collect()
 }
 
 #[derive(Copy, Clone, Debug)]
@@ -149,102 +157,140 @@ enum PathType {
     #[allow(dead_code)]
     Background,
     Boundary,
-    BackgroundAndBoundary
+    BackgroundAndBoundary,
 }
 
 #[derive(Clone, Debug)]
 struct GlyphComponent {
-    path : Vec<PathEvent>,
-    path_type : PathType // Which of the parts of the glyph should this contribute to?
+    path: Vec<PathEvent>,
+    path_type: PathType, // Which of the parts of the glyph should this contribute to?
 }
-
 
 #[wasm_bindgen]
 pub struct GlyphBuilder {
-    paths : Vec<GlyphComponent>, // List of paths. The last one is assumed to determine the convex hull
-    bounding_box : Box2D<f32>,
+    paths: Vec<GlyphComponent>, // List of paths. The last one is assumed to determine the convex hull
+    bounding_box: Box2D<f32>,
 }
-
 
 #[wasm_bindgen]
 impl GlyphBuilder {
-    pub fn from_stix(character : &str, scale : f32, whole_shape : bool) -> Self {
-        let path : Vec<_> = STIX_FONT.render(
-            character,
-            (512.0 - 64.0) / FONT_SIZE, // What the heck is this?
-            font::TextAlign::Center
-        ).0.collect();
+    pub fn from_stix(character: &str, scale: f32, whole_shape: bool) -> Self {
+        let path: Vec<_> = STIX_FONT
+            .render(
+                character,
+                (512.0 - 64.0) / FONT_SIZE, // What the heck is this?
+                font::TextAlign::Center,
+            )
+            .0
+            .collect();
         let bounding_box = pathop_bounding_box(path.iter()).scale(scale, scale);
         let component = GlyphComponent {
-            path : scale_lyon_path(footile_path_to_lyon_path(path.iter().copied()), scale).collect(),
-            path_type : if whole_shape { PathType::BackgroundAndBoundary } else { PathType::Foreground }
+            path: scale_lyon_path(footile_path_to_lyon_path(path.iter().copied()), scale).collect(),
+            path_type: if whole_shape {
+                PathType::BackgroundAndBoundary
+            } else {
+                PathType::Foreground
+            },
         };
         Self {
-            paths : vec![component],
+            paths: vec![component],
             bounding_box,
         }
     }
 
     pub fn empty() -> Self {
         Self {
-            paths : vec![],
-            bounding_box : Box2D::new(point(0.0, 0.0), point(0.0, 0.0)),
+            paths: vec![],
+            bounding_box: Box2D::new(point(0.0, 0.0), point(0.0, 0.0)),
         }
     }
 
-    pub fn boxed(&mut self, padding : f32, include_background : bool ) {
+    pub fn boxed(&mut self, padding: f32, include_background: bool) {
         self.bounding_box = self.bounding_box.inflate(padding, padding);
-        let Point { x : xmin, y : ymin, ..} = self.bounding_box.min;
-        let Point { x : xmax, y : ymax, ..} = self.bounding_box.max;
-        let box_path = Path2D::default().absolute()
+        let Point {
+            x: xmin, y: ymin, ..
+        } = self.bounding_box.min;
+        let Point {
+            x: xmax, y: ymax, ..
+        } = self.bounding_box.max;
+        let box_path = Path2D::default()
+            .absolute()
             .move_to(xmin, ymin)
             .line_to(xmax, ymin)
             .line_to(xmax, ymax)
             .line_to(xmin, ymax)
-            .close().finish();
+            .close()
+            .finish();
         let component = GlyphComponent {
-            path : footile_path_to_lyon_path(box_path.iter().copied()).collect(),
-            path_type : if include_background { PathType::BackgroundAndBoundary } else { PathType::Boundary },
+            path: footile_path_to_lyon_path(box_path.iter().copied()).collect(),
+            path_type: if include_background {
+                PathType::BackgroundAndBoundary
+            } else {
+                PathType::Boundary
+            },
         };
         self.paths.push(component);
     }
 
-    pub fn circled(&mut self, padding : f32, num_circles : i32, circle_gap : f32, include_background : bool) {
+    pub fn circled(
+        &mut self,
+        padding: f32,
+        num_circles: i32,
+        circle_gap: f32,
+        include_background: bool,
+    ) {
         let bounding_box = self.bounding_box.inflate(padding, padding);
-        let radius = bounding_box.min.distance_to(bounding_box.max)/2.0;
+        let radius = bounding_box.min.distance_to(bounding_box.max) / 2.0;
         let center = bounding_box.min.lerp(bounding_box.max, 0.5);
         let max_radius = radius + (num_circles as f32) * circle_gap;
         self.bounding_box = Box2D::new(center, center).inflate(max_radius, max_radius);
         let mut circle_path = Path::builder();
         circle_path.move_to(center - vector(radius, 0.0));
-        circle_path.arc(center, vector(radius, radius), Angle::two_pi(), Angle::zero());
+        circle_path.arc(
+            center,
+            vector(radius, radius),
+            Angle::two_pi(),
+            Angle::zero(),
+        );
         circle_path.close();
-        let circle_path : Vec<_> = circle_path.build().iter().collect();
+        let circle_path: Vec<_> = circle_path.build().iter().collect();
         let component = GlyphComponent {
-            path : circle_path,
-            path_type : if include_background { PathType::BackgroundAndBoundary } else { PathType::Boundary },
+            path: circle_path,
+            path_type: if include_background {
+                PathType::BackgroundAndBoundary
+            } else {
+                PathType::Boundary
+            },
         };
         self.paths.push(component);
         for i in 1..num_circles {
             let radius = radius + (i as f32) * circle_gap;
             let mut circle_path = Path::builder();
             circle_path.move_to(center - vector(radius, 0.0));
-            circle_path.arc(center, vector(radius, radius), Angle::two_pi(), Angle::zero());
+            circle_path.arc(
+                center,
+                vector(radius, radius),
+                Angle::two_pi(),
+                Angle::zero(),
+            );
             circle_path.close();
-            let circle_path : Vec<_> = circle_path.build().iter().collect();
+            let circle_path: Vec<_> = circle_path.build().iter().collect();
             let component = GlyphComponent {
-                path : circle_path,
-                path_type : PathType::Boundary,
+                path: circle_path,
+                path_type: PathType::Boundary,
             };
             self.paths.push(component);
         }
     }
 
-    pub fn build(self, tolerance : f32, line_width : f32) -> Glyph {
-        let GlyphBuilder { paths, bounding_box } = self;
+    pub fn build(self, tolerance: f32, line_width: f32) -> Glyph {
+        let GlyphBuilder {
+            paths,
+            bounding_box,
+        } = self;
         let convex_hull = Rc::new(ConvexHull::from_path(
             lyon_path_to_footile_path(paths.last().unwrap().path.iter().copied()),
-            bounding_box
+            bounding_box,
         ));
         let paths = Rc::new(paths);
         Glyph {
@@ -252,8 +298,8 @@ impl GlyphBuilder {
             convex_hull,
             tolerance,
             line_width,
-            max_scale : SCALE_FACTOR,
-            uuid : GlyphUuid(Uuid::new_v4())
+            max_scale: SCALE_FACTOR,
+            uuid: GlyphUuid(Uuid::new_v4()),
         }
     }
 }
@@ -264,12 +310,12 @@ pub struct GlyphUuid(Uuid);
 #[wasm_bindgen]
 #[derive(Clone)]
 pub struct Glyph {
-    paths : Rc<Vec<GlyphComponent>>,
-    convex_hull : Rc<ConvexHull>,
-    tolerance : f32,
-    line_width : f32,
-    max_scale : f32,
-    pub(crate) uuid : GlyphUuid
+    paths: Rc<Vec<GlyphComponent>>,
+    convex_hull: Rc<ConvexHull>,
+    tolerance: f32,
+    line_width: f32,
+    max_scale: f32,
+    pub(crate) uuid: GlyphUuid,
 }
 
 impl Glyph {
@@ -277,44 +323,76 @@ impl Glyph {
     //     SCALE_FACTOR / self.
     // }
 
-    pub(crate) fn tessellate_background(&self, buffers : &mut VertexBuffers<Point, u16>) -> Result<(), JsValue> {
+    pub(crate) fn tessellate_background(
+        &self,
+        buffers: &mut VertexBuffers<Point, u16>,
+    ) -> Result<(), JsValue> {
         let mut vertex_builder = geometry_builder::simple_builder(buffers);
         let mut fill_tessellator = FillTessellator::new();
         let options = FillOptions::default().with_tolerance(self.tolerance / self.max_scale);
-        let transform = Transform::identity().then_translate(- self.convex_hull.center().to_vector());
-        for &GlyphComponent { ref path, path_type } in &*self.paths {
+        let transform =
+            Transform::identity().then_translate(-self.convex_hull.center().to_vector());
+        for &GlyphComponent {
+            ref path,
+            path_type,
+        } in &*self.paths
+        {
             if let PathType::Background | PathType::BackgroundAndBoundary = path_type {
                 let path = path.iter().copied().transformed(&transform);
-                fill_tessellator.tessellate(path, &options, &mut vertex_builder).map_err(convert_tessellation_error)?;
+                fill_tessellator
+                    .tessellate(path, &options, &mut vertex_builder)
+                    .map_err(convert_tessellation_error)?;
             }
         }
         Ok(())
     }
 
-    pub(crate) fn tessellate_boundary(&self, buffers : &mut VertexBuffers<Point /*PositionNormal*/, u16>,) -> Result<(), JsValue> {
+    pub(crate) fn tessellate_boundary(
+        &self,
+        buffers: &mut VertexBuffers<Point /*PositionNormal*/, u16>,
+    ) -> Result<(), JsValue> {
         // let mut vertex_builder = geometry_builder::BuffersBuilder::new(buffers, PositionNormalConstructor {});
         let mut vertex_builder = geometry_builder::simple_builder(buffers);
         let mut stroke_tessellator = StrokeTessellator::new();
-        let options = StrokeOptions::default().with_line_width(self.line_width).with_tolerance(self.tolerance / self.max_scale);
-        let transform = Transform::identity().then_translate(- self.convex_hull.center().to_vector());
-        for &GlyphComponent { ref path, path_type} in &*self.paths {
+        let options = StrokeOptions::default()
+            .with_line_width(self.line_width)
+            .with_tolerance(self.tolerance / self.max_scale);
+        let transform =
+            Transform::identity().then_translate(-self.convex_hull.center().to_vector());
+        for &GlyphComponent {
+            ref path,
+            path_type,
+        } in &*self.paths
+        {
             if let PathType::Boundary | PathType::BackgroundAndBoundary = path_type {
                 let path = path.iter().copied().transformed(&transform);
-                stroke_tessellator.tessellate(path, &options, &mut vertex_builder).map_err(convert_tessellation_error)?;
+                stroke_tessellator
+                    .tessellate(path, &options, &mut vertex_builder)
+                    .map_err(convert_tessellation_error)?;
             }
         }
         Ok(())
     }
 
-    pub(crate) fn tessellate_foreground(&self, buffers : &mut VertexBuffers<Point, u16>) -> Result<(), JsValue> {
+    pub(crate) fn tessellate_foreground(
+        &self,
+        buffers: &mut VertexBuffers<Point, u16>,
+    ) -> Result<(), JsValue> {
         let mut vertex_builder = geometry_builder::simple_builder(buffers);
         let mut fill_tessellator = FillTessellator::new();
         let options = FillOptions::default().with_tolerance(self.tolerance / self.max_scale);
-        let transform = Transform::identity().then_translate(- self.convex_hull.center().to_vector());
-        for &GlyphComponent { ref path, path_type } in &*self.paths {
+        let transform =
+            Transform::identity().then_translate(-self.convex_hull.center().to_vector());
+        for &GlyphComponent {
+            ref path,
+            path_type,
+        } in &*self.paths
+        {
             if let PathType::Foreground = path_type {
                 let path = path.iter().copied().transformed(&transform);
-                fill_tessellator.tessellate(path, &options, &mut vertex_builder).map_err(convert_tessellation_error)?;
+                fill_tessellator
+                    .tessellate(path, &options, &mut vertex_builder)
+                    .map_err(convert_tessellation_error)?;
             }
         }
         Ok(())
@@ -325,17 +403,16 @@ impl Glyph {
     }
 }
 
-
 #[wasm_bindgen]
 #[derive(Clone)]
 pub struct GlyphInstance {
-    pub(crate) glyph : Glyph,
-    pub(crate) position : Point,
-    pub(crate) offset : Vector,
-    pub(crate) scale : f32,
-    pub(crate) background_color : Vec4,
-    pub(crate) border_color : Vec4,
-    pub(crate) foreground_color : Vec4,
+    pub(crate) glyph: Glyph,
+    pub(crate) position: Point,
+    pub(crate) offset: Vector,
+    pub(crate) scale: f32,
+    pub(crate) background_color: Vec4,
+    pub(crate) border_color: Vec4,
+    pub(crate) foreground_color: Vec4,
 }
 
 #[wasm_bindgen]
@@ -349,16 +426,15 @@ impl GlyphInstance {
     }
 }
 
-
 impl GlyphInstance {
     pub fn new(
-        glyph : Glyph,
-        position : Point,
-        offset : Vector,
-        scale : f32,
-        background_color : Vec4,
-        border_color : Vec4,
-        foreground_color : Vec4
+        glyph: Glyph,
+        position: Point,
+        offset: Vector,
+        scale: f32,
+        background_color: Vec4,
+        border_color: Vec4,
+        foreground_color: Vec4,
     ) -> Self {
         Self {
             glyph,

--- a/chart/chart/display_backend/src/lib.rs
+++ b/chart/chart/display_backend/src/lib.rs
@@ -11,25 +11,22 @@ mod vector;
 
 mod arrow;
 
-mod webgl_wrapper;
 mod shader;
+mod webgl_wrapper;
 
-mod coordinate_system;
 mod canvas;
+mod coordinate_system;
 
-mod stroke_tessellation;
 mod glyph;
+mod stroke_tessellation;
+
+use wasm_bindgen::prelude::*;
+use web_sys::WebGl2RenderingContext;
 
 use crate::canvas::Canvas;
 
-
-use wasm_bindgen::prelude::*;
-
-
-use web_sys::{WebGl2RenderingContext};
-
 #[wasm_bindgen]
-pub fn get_rust_canvas(context : &WebGl2RenderingContext) -> Result<Canvas, JsValue> {
+pub fn get_rust_canvas(context: &WebGl2RenderingContext) -> Result<Canvas, JsValue> {
     console_error_panic_hook::set_once();
     Ok(Canvas::new(context)?)
 }

--- a/chart/chart/display_backend/src/shader/chart_shaders.rs
+++ b/chart/chart/display_backend/src/shader/chart_shaders.rs
@@ -1,19 +1,18 @@
-use std::collections::{BTreeMap, btree_map};
+use std::collections::{btree_map, BTreeMap};
 
-use wasm_bindgen::JsValue;
-
-use web_sys::{WebGlBuffer, WebGl2RenderingContext};
 use lyon::geom::math::{Point, Vector};
+use wasm_bindgen::JsValue;
+use web_sys::{WebGl2RenderingContext, WebGlBuffer};
 
 #[allow(unused_imports)]
 use crate::log;
-use crate::webgl_wrapper::WebGlWrapper;
-
-use crate::vector::{JsPoint, Vec4};
-use crate::coordinate_system::CoordinateSystem;
-use crate::glyph::{Glyph, GlyphUuid, GlyphInstance};
-
-use crate::shader::{GridShader, GlyphShader, HitCanvasShader, EdgeShader, EdgeOptions};
+use crate::{
+    coordinate_system::CoordinateSystem,
+    glyph::{Glyph, GlyphInstance, GlyphUuid},
+    shader::{EdgeOptions, EdgeShader, GlyphShader, GridShader, HitCanvasShader},
+    vector::{JsPoint, Vec4},
+    webgl_wrapper::WebGlWrapper,
+};
 
 // I'm pretty confused by the way matrices are laid out in opengl.
 // Apparently a mat3x2 has 3 "columns" and 2 "rows". std140 layout requires
@@ -22,52 +21,71 @@ use crate::shader::{GridShader, GlyphShader, HitCanvasShader, EdgeShader, EdgeOp
 #[derive(Copy, Clone, Debug)]
 #[repr(C)]
 struct UniformBufferData {
-    transform : [f32; 12],
-    origin : Point,
-    scale : Vector,
-    glyph_scale : f32,
+    transform: [f32; 12],
+    origin: Point,
+    scale: Vector,
+    glyph_scale: f32,
     // We have to be aligned to a multiple of 4 floats. This padding brings us up to 20.
-    padding : [f32 ; 3]
+    padding: [f32; 3],
 }
 
 impl From<CoordinateSystem> for UniformBufferData {
-    fn from(c : CoordinateSystem) -> Self {
+    fn from(c: CoordinateSystem) -> Self {
         let transform_array = c.transform.to_array();
         Self {
-            transform : [
-                transform_array[0], transform_array[1], 0.0, 0.0,
-                transform_array[2], transform_array[3], 0.0, 0.0,
-                transform_array[4], transform_array[5], 0.0, 0.0,
+            transform: [
+                transform_array[0],
+                transform_array[1],
+                0.0,
+                0.0,
+                transform_array[2],
+                transform_array[3],
+                0.0,
+                0.0,
+                transform_array[4],
+                transform_array[5],
+                0.0,
+                0.0,
             ],
-            origin : c.origin,
-            scale : c.scale,
-            glyph_scale : c.glyph_scale,
-            padding : [0.0, 0.0, 0.0]
+            origin: c.origin,
+            scale: c.scale,
+            glyph_scale: c.glyph_scale,
+            padding: [0.0, 0.0, 0.0],
         }
     }
 }
 
-
-static GRID_LIGHT_COLOR : Vec4 = Vec4::new(0.0, 0.0, 0.0, 30.0 / 255.0);
-static GRID_DARK_COLOR : Vec4 = Vec4::new(0.0, 0.0, 0.0, 90.0 / 255.0);
+static GRID_LIGHT_COLOR: Vec4 = Vec4::new(0.0, 0.0, 0.0, 30.0 / 255.0);
+static GRID_DARK_COLOR: Vec4 = Vec4::new(0.0, 0.0, 0.0, 90.0 / 255.0);
 
 pub struct ChartShaders {
-    webgl : WebGlWrapper,
-    glyph_map : BTreeMap<GlyphUuid, usize>,
-    uniform_buffer : Option<WebGlBuffer>,
-    minor_grid_shader : GridShader,
-    major_grid_shader : GridShader,
-    glyph_shader : GlyphShader,
-    edge_shader : EdgeShader,
-    hit_canvas_shader : HitCanvasShader,
+    webgl: WebGlWrapper,
+    glyph_map: BTreeMap<GlyphUuid, usize>,
+    uniform_buffer: Option<WebGlBuffer>,
+    minor_grid_shader: GridShader,
+    major_grid_shader: GridShader,
+    glyph_shader: GlyphShader,
+    edge_shader: EdgeShader,
+    hit_canvas_shader: HitCanvasShader,
 }
 
 impl ChartShaders {
-    pub fn new(webgl : WebGlWrapper) -> Result<Self, JsValue> {
+    pub fn new(webgl: WebGlWrapper) -> Result<Self, JsValue> {
         let uniform_buffer = webgl.create_buffer();
-        webgl.bind_buffer(WebGl2RenderingContext::UNIFORM_BUFFER, uniform_buffer.as_ref());
-        webgl.buffer_data_with_i32(WebGl2RenderingContext::UNIFORM_BUFFER, std::mem::size_of::<UniformBufferData>() as i32, WebGl2RenderingContext::DYNAMIC_DRAW);
-        webgl.bind_buffer_base(WebGl2RenderingContext::UNIFORM_BUFFER, 0, uniform_buffer.as_ref());
+        webgl.bind_buffer(
+            WebGl2RenderingContext::UNIFORM_BUFFER,
+            uniform_buffer.as_ref(),
+        );
+        webgl.buffer_data_with_i32(
+            WebGl2RenderingContext::UNIFORM_BUFFER,
+            std::mem::size_of::<UniformBufferData>() as i32,
+            WebGl2RenderingContext::DYNAMIC_DRAW,
+        );
+        webgl.bind_buffer_base(
+            WebGl2RenderingContext::UNIFORM_BUFFER,
+            0,
+            uniform_buffer.as_ref(),
+        );
         webgl.bind_buffer(WebGl2RenderingContext::UNIFORM_BUFFER, None);
 
         let mut minor_grid_shader = GridShader::new(webgl.clone())?;
@@ -85,7 +103,7 @@ impl ChartShaders {
         let edge_shader = EdgeShader::new(webgl.clone())?;
         Ok(Self {
             webgl,
-            glyph_map : BTreeMap::new(),
+            glyph_map: BTreeMap::new(),
             uniform_buffer,
             minor_grid_shader,
             major_grid_shader,
@@ -111,69 +129,98 @@ impl ChartShaders {
         self.edge_shader.clear_edge_instances();
     }
 
-    fn glyph_index(&mut self, glyph : &Glyph) -> Result<usize, JsValue>{
+    fn glyph_index(&mut self, glyph: &Glyph) -> Result<usize, JsValue> {
         let next_index = self.glyph_map.len();
         let entry = self.glyph_map.entry(glyph.uuid);
         Ok(match entry {
             btree_map::Entry::Occupied(oe) => *oe.get(),
             btree_map::Entry::Vacant(ve) => {
                 self.glyph_shader.add_glyph_data(glyph)?;
-                self.edge_shader.add_glyph_hull(glyph.boundary().iter().copied());
-                self.hit_canvas_shader.add_glyph_hull(glyph.boundary().iter().copied());
+                self.edge_shader
+                    .add_glyph_hull(glyph.boundary().iter().copied());
+                self.hit_canvas_shader
+                    .add_glyph_hull(glyph.boundary().iter().copied());
                 *ve.insert(next_index)
             }
         })
     }
 
-    pub fn add_glyph_instance(&mut self, glyph_instance : GlyphInstance) -> Result<(), JsValue> {
+    pub fn add_glyph_instance(&mut self, glyph_instance: GlyphInstance) -> Result<(), JsValue> {
         let glyph_index = self.glyph_index(&glyph_instance.glyph)?;
-        self.glyph_shader.add_glyph_instance(glyph_instance.clone(), glyph_index);
-        self.hit_canvas_shader.add_glyph_instance(glyph_instance, glyph_index)?;
+        self.glyph_shader
+            .add_glyph_instance(glyph_instance.clone(), glyph_index);
+        self.hit_canvas_shader
+            .add_glyph_instance(glyph_instance, glyph_index)?;
         Ok(())
     }
 
-    pub fn add_edge(&mut self, start : GlyphInstance, end : GlyphInstance, options : &EdgeOptions) -> Result<(), JsValue> {
+    pub fn add_edge(
+        &mut self,
+        start: GlyphInstance,
+        end: GlyphInstance,
+        options: &EdgeOptions,
+    ) -> Result<(), JsValue> {
         let start_glyph_index = self.glyph_index(&start.glyph)?;
         let end_glyph_index = self.glyph_index(&end.glyph)?;
-        self.edge_shader.add_edge(start, end, start_glyph_index, end_glyph_index, options)?;
+        self.edge_shader
+            .add_edge(start, end, start_glyph_index, end_glyph_index, options)?;
         Ok(())
     }
 
-    pub fn object_underneath_pixel(&self, coordinate_system : CoordinateSystem, p : JsPoint) -> Result<Option<u32>, JsValue> {
-        self.hit_canvas_shader.object_underneath_pixel(coordinate_system, p.into())
+    pub fn object_underneath_pixel(
+        &self,
+        coordinate_system: CoordinateSystem,
+        p: JsPoint,
+    ) -> Result<Option<u32>, JsValue> {
+        self.hit_canvas_shader
+            .object_underneath_pixel(coordinate_system, p.into())
     }
 
-
-    pub fn update_canvas_dimensions(&self, coord_system : CoordinateSystem){
-        let left = (coord_system.left_margin as f64 * coord_system.buffer_dimensions.density()) as i32;
-        let bottom = (coord_system.bottom_margin as f64 * coord_system.buffer_dimensions.density()) as i32;
-        let width = ((coord_system.buffer_dimensions.width() - coord_system.left_margin - coord_system.right_margin) as f64  * coord_system.buffer_dimensions.density()) as i32;
-        let height = ((coord_system.buffer_dimensions.height() - coord_system.top_margin - coord_system.bottom_margin) as f64  * coord_system.buffer_dimensions.density()) as i32;
+    pub fn update_canvas_dimensions(&self, coord_system: CoordinateSystem) {
+        let left =
+            (coord_system.left_margin as f64 * coord_system.buffer_dimensions.density()) as i32;
+        let bottom =
+            (coord_system.bottom_margin as f64 * coord_system.buffer_dimensions.density()) as i32;
+        let width = ((coord_system.buffer_dimensions.width()
+            - coord_system.left_margin
+            - coord_system.right_margin) as f64
+            * coord_system.buffer_dimensions.density()) as i32;
+        let height = ((coord_system.buffer_dimensions.height()
+            - coord_system.top_margin
+            - coord_system.bottom_margin) as f64
+            * coord_system.buffer_dimensions.density()) as i32;
         self.webgl.scissor(left, bottom, width, height);
-        self.webgl.viewport_dimensions(coord_system.buffer_dimensions);
+        self.webgl
+            .viewport_dimensions(coord_system.buffer_dimensions);
     }
 
-    fn update_uniform_buffer(&self, coordinate_system : CoordinateSystem){
-        self.webgl.bind_buffer(WebGl2RenderingContext::UNIFORM_BUFFER, self.uniform_buffer.as_ref());
-        let uniform_data : UniformBufferData = coordinate_system.into();
+    fn update_uniform_buffer(&self, coordinate_system: CoordinateSystem) {
+        self.webgl.bind_buffer(
+            WebGl2RenderingContext::UNIFORM_BUFFER,
+            self.uniform_buffer.as_ref(),
+        );
+        let uniform_data: UniformBufferData = coordinate_system.into();
         let ptr = &uniform_data as *const UniformBufferData as *const u8;
         let len = std::mem::size_of::<UniformBufferData>();
-        let data = unsafe {
-            std::slice::from_raw_parts(ptr, len)
-        };
-        self.webgl.buffer_sub_data_with_i32_and_u8_array(WebGl2RenderingContext::UNIFORM_BUFFER, 0, data);
-        self.webgl.bind_buffer(WebGl2RenderingContext::UNIFORM_BUFFER, None);
+        let data = unsafe { std::slice::from_raw_parts(ptr, len) };
+        self.webgl.buffer_sub_data_with_i32_and_u8_array(
+            WebGl2RenderingContext::UNIFORM_BUFFER,
+            0,
+            data,
+        );
+        self.webgl
+            .bind_buffer(WebGl2RenderingContext::UNIFORM_BUFFER, None);
     }
 
-    fn enable_clip(&self){
+    fn enable_clip(&self) {
         self.webgl.enable(WebGl2RenderingContext::SCISSOR_TEST);
     }
 
-    fn disable_clip(&self){
+    fn disable_clip(&self) {
         self.webgl.disable(WebGl2RenderingContext::SCISSOR_TEST);
     }
 
-    pub fn render(&mut self, coordinate_system : CoordinateSystem) -> Result<(), JsValue> {
+    pub fn render(&mut self, coordinate_system: CoordinateSystem) -> Result<(), JsValue> {
         self.update_canvas_dimensions(coordinate_system);
         self.update_uniform_buffer(coordinate_system);
         self.disable_clip();

--- a/chart/chart/display_backend/src/shader/data_texture.rs
+++ b/chart/chart/display_backend/src/shader/data_texture.rs
@@ -1,39 +1,43 @@
+use js_sys::Object;
+use wasm_bindgen::JsValue;
+use web_sys::{WebGl2RenderingContext, WebGlTexture};
+
 #[allow(unused_imports)]
 use crate::log;
-use crate::shader::range::Range;
-use crate::shader::attributes::{Format, Type};
-use web_sys::{WebGl2RenderingContext, WebGlTexture};
-use wasm_bindgen::{JsValue};
-use js_sys::Object;
-use crate::webgl_wrapper::WebGlWrapper;
-
+use crate::{
+    shader::{
+        attributes::{Format, Type},
+        range::Range,
+    },
+    webgl_wrapper::WebGlWrapper,
+};
 
 // TODO: context loss?
 pub struct DataTexture<T> {
-    webgl : WebGlWrapper,
-    width : usize,
-    format : Format,
-    pub data : Vec<T>,
-    used_entries : usize,
-    texture : Option<WebGlTexture>,
-    texture_rows : usize,
-    pub dirty_range : Range,
-    marker : std::marker::PhantomData<T>
+    webgl: WebGlWrapper,
+    width: usize,
+    format: Format,
+    pub data: Vec<T>,
+    used_entries: usize,
+    texture: Option<WebGlTexture>,
+    texture_rows: usize,
+    pub dirty_range: Range,
+    marker: std::marker::PhantomData<T>,
 }
 
-impl<T : std::fmt::Debug + std::default::Default> DataTexture<T> {
-    pub fn new(webgl : WebGlWrapper, format : Format) -> Self {
+impl<T: std::fmt::Debug + std::default::Default> DataTexture<T> {
+    pub fn new(webgl: WebGlWrapper, format: Format) -> Self {
         assert_eq!(std::mem::align_of::<T>() % format.0.alignment(), 0);
         Self {
             webgl,
-            width : 2048,
+            width: 2048,
             format,
-            data : Vec::new(),
-            used_entries : 0,
-            texture : None,
-            texture_rows : 0,
-            dirty_range : Range::empty(),
-            marker : std::marker::PhantomData
+            data: Vec::new(),
+            used_entries: 0,
+            texture: None,
+            texture_rows: 0,
+            dirty_range: Range::empty(),
+            marker: std::marker::PhantomData,
         }
     }
 
@@ -47,23 +51,22 @@ impl<T : std::fmt::Debug + std::default::Default> DataTexture<T> {
         total_bytes / self.row_bytes()
     }
 
-
     fn num_rows(&mut self) -> usize {
         self.num_rows_to_fit_extra_data(0)
     }
 
-    fn num_rows_to_fit_extra_data(&self, n : usize) -> usize {
+    fn num_rows_to_fit_extra_data(&self, n: usize) -> usize {
         let total_entries = self.used_entries + n;
         let total_bytes = total_entries * std::mem::size_of::<T>();
-        ( total_bytes + self.row_bytes() - 1) / self.row_bytes()
+        (total_bytes + self.row_bytes() - 1) / self.row_bytes()
     }
 
-    fn num_entries_to_fit_rows(&self, num_rows : usize) -> usize {
+    fn num_entries_to_fit_rows(&self, num_rows: usize) -> usize {
         (num_rows * self.row_bytes() + std::mem::size_of::<T>() - 1) / std::mem::size_of::<T>()
     }
 
     // TODO: use capacity of vector to determine new texture size.
-    fn ensure_size(&mut self){
+    fn ensure_size(&mut self) {
         let num_rows = self.num_rows();
         if num_rows <= self.texture_rows {
             return;
@@ -71,17 +74,35 @@ impl<T : std::fmt::Debug + std::default::Default> DataTexture<T> {
         self.texture_rows = num_rows;
         self.webgl.delete_texture(self.texture.as_ref());
         self.texture = self.webgl.inner.create_texture();
-        self.webgl.bind_texture(WebGl2RenderingContext::TEXTURE_2D, self.texture.as_ref());
+        self.webgl
+            .bind_texture(WebGl2RenderingContext::TEXTURE_2D, self.texture.as_ref());
         self.webgl.tex_storage_2d(
             WebGl2RenderingContext::TEXTURE_2D,
             1, // mip levels
             self.format.internal_format(),
-            self.width as i32, num_rows as i32
+            self.width as i32,
+            num_rows as i32,
         );
-        self.webgl.tex_parameteri(WebGl2RenderingContext::TEXTURE_2D, WebGl2RenderingContext::TEXTURE_MAG_FILTER, WebGl2RenderingContext::NEAREST as i32);
-        self.webgl.tex_parameteri(WebGl2RenderingContext::TEXTURE_2D, WebGl2RenderingContext::TEXTURE_MIN_FILTER, WebGl2RenderingContext::NEAREST as i32);
-        self.webgl.tex_parameteri(WebGl2RenderingContext::TEXTURE_2D, WebGl2RenderingContext::TEXTURE_WRAP_S, WebGl2RenderingContext::CLAMP_TO_EDGE as i32);
-        self.webgl.tex_parameteri(WebGl2RenderingContext::TEXTURE_2D, WebGl2RenderingContext::TEXTURE_WRAP_T, WebGl2RenderingContext::CLAMP_TO_EDGE as i32);
+        self.webgl.tex_parameteri(
+            WebGl2RenderingContext::TEXTURE_2D,
+            WebGl2RenderingContext::TEXTURE_MAG_FILTER,
+            WebGl2RenderingContext::NEAREST as i32,
+        );
+        self.webgl.tex_parameteri(
+            WebGl2RenderingContext::TEXTURE_2D,
+            WebGl2RenderingContext::TEXTURE_MIN_FILTER,
+            WebGl2RenderingContext::NEAREST as i32,
+        );
+        self.webgl.tex_parameteri(
+            WebGl2RenderingContext::TEXTURE_2D,
+            WebGl2RenderingContext::TEXTURE_WRAP_S,
+            WebGl2RenderingContext::CLAMP_TO_EDGE as i32,
+        );
+        self.webgl.tex_parameteri(
+            WebGl2RenderingContext::TEXTURE_2D,
+            WebGl2RenderingContext::TEXTURE_WRAP_T,
+            WebGl2RenderingContext::CLAMP_TO_EDGE as i32,
+        );
         self.dirty_range = Range::new(0, num_rows);
     }
 
@@ -89,7 +110,7 @@ impl<T : std::fmt::Debug + std::default::Default> DataTexture<T> {
         self.used_entries
     }
 
-    pub fn clear(&mut self){
+    pub fn clear(&mut self) {
         self.used_entries = 0;
     }
 
@@ -97,37 +118,48 @@ impl<T : std::fmt::Debug + std::default::Default> DataTexture<T> {
         &self.data[0..self.used_entries]
     }
 
-    pub fn append<It : ExactSizeIterator<Item = T>>(&mut self, data : It) {
+    pub fn append<It: ExactSizeIterator<Item = T>>(&mut self, data: It) {
         let data_len = data.len();
         let start_row = self.num_full_rows();
         // First make sure we have enough room. We have to have enough memory to fill a rectangular texture.
         // The size of T is not necessarily evenly divisible into rows, we just make sure that we have more than enough T's to fill out the rectangle.
         let total_rows_needed = self.num_rows_to_fit_extra_data(data_len);
         if total_rows_needed > self.num_rows() {
-            self.data.resize_with(self.num_entries_to_fit_rows(total_rows_needed), || T::default());
+            self.data
+                .resize_with(self.num_entries_to_fit_rows(total_rows_needed), || {
+                    T::default()
+                });
         }
         // splice replaces a range with the result of iterator.
         // splice returns an iterator over subbed out range, which we have to consume in order to ensure change takes place.
-        self.data.splice(self.used_entries .. self.used_entries + data_len, data).for_each(drop);  // consume iterator, ignore values.
+        self.data
+            .splice(self.used_entries..self.used_entries + data_len, data)
+            .for_each(drop); // consume iterator, ignore values.
         self.used_entries += data_len;
         let end_row = self.num_rows();
-        self.dirty_range.include_range(Range::new(start_row, end_row));
+        self.dirty_range
+            .include_range(Range::new(start_row, end_row));
     }
 
-    pub fn push(&mut self, entry : T){
+    pub fn push(&mut self, entry: T) {
         self.append(std::iter::once(entry));
     }
 
-    unsafe fn data_view(&self, min_row : usize, max_row : usize) -> Object {
+    unsafe fn data_view(&self, min_row: usize, max_row: usize) -> Object {
         // For float textures we are REQUIRED to provide Float32Array views.
         let data_bytes = std::mem::size_of_val(self.data.as_slice());
         let data_ptr = self.data.as_ptr() as *const u8;
         let data_u8_slice = std::slice::from_raw_parts(data_ptr, data_bytes);
-        let data_u8_slice = &data_u8_slice[min_row * self.row_bytes() .. max_row * self.row_bytes()];
+        let data_u8_slice = &data_u8_slice[min_row * self.row_bytes()..max_row * self.row_bytes()];
         match self.format.0 {
-            Type::F32 => js_sys::Float32Array::view_mut_raw(data_u8_slice.as_ptr() as *mut f32, data_u8_slice.len() / std::mem::size_of::<f32>()).into(),
-            Type::I16 | Type::U16 | Type::U8 | Type::U32
-                => js_sys::Uint8Array::view(data_u8_slice).into(),
+            Type::F32 => js_sys::Float32Array::view_mut_raw(
+                data_u8_slice.as_ptr() as *mut f32,
+                data_u8_slice.len() / std::mem::size_of::<f32>(),
+            )
+            .into(),
+            Type::I16 | Type::U16 | Type::U8 | Type::U32 => {
+                js_sys::Uint8Array::view(data_u8_slice).into()
+            }
         }
     }
 
@@ -140,25 +172,28 @@ impl<T : std::fmt::Debug + std::default::Default> DataTexture<T> {
         let dirty_min = self.dirty_range.min;
         let dirty_max = self.dirty_range.max.min(num_rows);
         let yoffset = dirty_min as i32;
-        let data_view = unsafe {
-            self.data_view(dirty_min, dirty_max)
-        };
-        self.webgl.tex_sub_image_2d_with_i32_and_i32_and_u32_and_type_and_opt_array_buffer_view(
-            WebGl2RenderingContext::TEXTURE_2D,
-            0, // mip level
-            0, yoffset, // xoffset, yoffset: i32,
-            self.width as i32, (dirty_max - dirty_min) as i32, // width, height
-            self.format.base_format(), // format: u32,
-            self.format.webgl_type(), // type_: u32,
-            Some(&data_view) // pixels: Option<&[u8]>
-        )?;
+        let data_view = unsafe { self.data_view(dirty_min, dirty_max) };
+        self.webgl
+            .tex_sub_image_2d_with_i32_and_i32_and_u32_and_type_and_opt_array_buffer_view(
+                WebGl2RenderingContext::TEXTURE_2D,
+                0, // mip level
+                0,
+                yoffset, // xoffset, yoffset: i32,
+                self.width as i32,
+                (dirty_max - dirty_min) as i32, // width, height
+                self.format.base_format(),      // format: u32,
+                self.format.webgl_type(),       // type_: u32,
+                Some(&data_view),               // pixels: Option<&[u8]>
+            )?;
         self.dirty_range = Range::empty();
         Ok(())
     }
 
-    pub fn bind(&mut self, texture_unit : u32) -> Result<(), JsValue> {
-        self.webgl.active_texture(WebGl2RenderingContext::TEXTURE0 + texture_unit);
-        self.webgl.bind_texture(WebGl2RenderingContext::TEXTURE_2D, self.texture.as_ref());
+    pub fn bind(&mut self, texture_unit: u32) -> Result<(), JsValue> {
+        self.webgl
+            .active_texture(WebGl2RenderingContext::TEXTURE0 + texture_unit);
+        self.webgl
+            .bind_texture(WebGl2RenderingContext::TEXTURE_2D, self.texture.as_ref());
         self.prepare()?;
         Ok(())
     }

--- a/chart/chart/display_backend/src/shader/edge_shader.rs
+++ b/chart/chart/display_backend/src/shader/edge_shader.rs
@@ -1,82 +1,85 @@
-use std::collections::{BTreeMap, btree_map};
-use std::convert::TryInto;
+use std::{
+    collections::{btree_map, BTreeMap},
+    convert::TryInto,
+};
 
+use lyon::{
+    geom::math::{Angle, Point, Vector},
+    tessellation::VertexBuffers,
+};
 use wasm_bindgen::prelude::*;
-use web_sys::{WebGl2RenderingContext, WebGlVertexArrayObject, WebGlTexture};
-
-use lyon::geom::math::{Point, Angle, Vector};
-use lyon::tessellation::{VertexBuffers};
+use web_sys::{WebGl2RenderingContext, WebGlTexture, WebGlVertexArrayObject};
 
 #[allow(unused_imports)]
 use crate::log;
-use crate::vector::{Vec4};
-use crate::shader::Program;
-use crate::webgl_wrapper::WebGlWrapper;
+use crate::{
+    arrow::{Arrow, ArrowId},
+    glyph::GlyphInstance,
+    shader::{
+        attributes::{Attribute, Attributes, Format, NumChannels, Type},
+        data_texture::DataTexture,
+        vertex_buffer::VertexBuffer,
+        Program,
+    },
+    vector::Vec4,
+    webgl_wrapper::WebGlWrapper,
+};
 
-use crate::glyph::{GlyphInstance};
-use crate::arrow::{Arrow, ArrowId};
+const DASH_PATTERN_TEXTURE_WIDTH: usize = 512;
 
-use crate::shader::attributes::{Format, Type, NumChannels, Attribute, Attributes};
-use crate::shader::data_texture::DataTexture;
-use crate::shader::vertex_buffer::VertexBuffer;
-
-
-const DASH_PATTERN_TEXTURE_WIDTH : usize = 512;
-
-const ATTRIBUTES : Attributes = Attributes::new(&[
-    Attribute::new("aColor", 4, Type::F32), // color
+const ATTRIBUTES: Attributes = Attributes::new(&[
+    Attribute::new("aColor", 4, Type::F32),               // color
     Attribute::new("aStartPositionOffset", 4, Type::F32), // (start_position, start_offset)
-    Attribute::new("aEndPositionOffset", 4, Type::F32), // (end_position, end_offset)
+    Attribute::new("aEndPositionOffset", 4, Type::F32),   // (end_position, end_offset)
     Attribute::new("aGlyphScales_angle_thickness", 4, Type::F32), // (start_glyph_scale, end_glyph_scale, angle, thickness)
-
     Attribute::new("aStart", 4, Type::I16), // (startGlyph, vec3 startArrow = (NumVertices, HeaderIndex, VerticesIndex) )
     Attribute::new("aEnd", 4, Type::I16), // (endGlyph, vec3 endArrow = (NumVertices, HeaderIndex, VerticesIndex) )
     Attribute::new("aDashPattern", 4, Type::I16), // (dash_length, dash_index, dash_offset, dash_padding )
 ]);
 
-const GLYPH_HULL_TEXTURE_UNIT : u32 = 0;
-const ARROW_METRICS_TEXTURE_UNIT : u32 = 1;
-const ARROW_PATHS_TEXTURE_UNIT : u32 = 2;
-const DASH_PATTERNS_TEXTURE_UNIT : u32 = 3;
+const GLYPH_HULL_TEXTURE_UNIT: u32 = 0;
+const ARROW_METRICS_TEXTURE_UNIT: u32 = 1;
+const ARROW_PATHS_TEXTURE_UNIT: u32 = 2;
+const DASH_PATTERNS_TEXTURE_UNIT: u32 = 3;
 
 #[wasm_bindgen]
 #[derive(Clone, Debug)]
 pub struct EdgeOptions {
-    start_tip : Option<Arrow>,
-    end_tip : Option<Arrow>,
-    angle : Angle,
-    thickness : f32,
-    dash_pattern : Vec<u8>,
-    color : Vec4,
+    start_tip: Option<Arrow>,
+    end_tip: Option<Arrow>,
+    angle: Angle,
+    thickness: f32,
+    dash_pattern: Vec<u8>,
+    color: Vec4,
 }
 
 #[wasm_bindgen]
 impl EdgeOptions {
     pub fn new() -> Self {
         Self {
-            start_tip : None,
-            end_tip : None,
-            angle : Angle::zero(),
-            thickness : 1.0,
-            dash_pattern : vec![],
-            color : Vec4::new(0.0, 0.0, 0.0, 1.0)
+            start_tip: None,
+            end_tip: None,
+            angle: Angle::zero(),
+            thickness: 1.0,
+            dash_pattern: vec![],
+            color: Vec4::new(0.0, 0.0, 0.0, 1.0),
         }
     }
 
-    pub fn set_color(&mut self, color : Vec4){
+    pub fn set_color(&mut self, color: Vec4) {
         self.color = color;
     }
 
-    pub fn set_tips(&mut self, arrow : &Arrow) {
+    pub fn set_tips(&mut self, arrow: &Arrow) {
         self.start_tip = Some(arrow.clone());
         self.end_tip = Some(arrow.clone());
     }
 
-    pub fn set_start_tip(&mut self, arrow : &Arrow) {
+    pub fn set_start_tip(&mut self, arrow: &Arrow) {
         self.start_tip = Some(arrow.clone());
     }
 
-    pub fn set_end_tip(&mut self, arrow : &Arrow) {
+    pub fn set_end_tip(&mut self, arrow: &Arrow) {
         self.end_tip = Some(arrow.clone());
     }
 
@@ -93,107 +96,111 @@ impl EdgeOptions {
         self.end_tip = None;
     }
 
-    pub fn set_bend_degrees(&mut self, degrees : f32) {
+    pub fn set_bend_degrees(&mut self, degrees: f32) {
         self.angle = Angle::degrees(degrees);
     }
 
-    pub fn set_thickness(&mut self, thickness : f32) {
+    pub fn set_thickness(&mut self, thickness: f32) {
         self.thickness = thickness;
     }
 
-    pub fn set_dash_pattern(&mut self, dash_pattern : Vec<u8>) {
+    pub fn set_dash_pattern(&mut self, dash_pattern: Vec<u8>) {
         self.dash_pattern = dash_pattern;
     }
 }
 
-
 #[derive(Clone, Copy, Debug)]
 #[repr(C, align(4))]
 struct EdgeInstance {
-    color : Vec4,
-    start_position : Point,
-    start_offset : Vector,
-    end_position : Point,
-    end_offset : Vector,
+    color: Vec4,
+    start_position: Point,
+    start_offset: Vector,
+    end_position: Point,
+    end_offset: Vector,
 
-    start_glyph_scale : f32,
-    end_glyph_scale : f32,
-    angle : f32,
-    thickness : f32,
+    start_glyph_scale: f32,
+    end_glyph_scale: f32,
+    angle: f32,
+    thickness: f32,
 
-    start_glyph : u16,
-    start_arrow : ArrowIndices,
-    end_glyph : u16,
-    end_arrow : ArrowIndices,
+    start_glyph: u16,
+    start_arrow: ArrowIndices,
+    end_glyph: u16,
+    end_arrow: ArrowIndices,
 
-    dash_length : u16,
-    dash_index : u16,
-    dash_offset : u16,
-    dash_padding : u16,
+    dash_length: u16,
+    dash_index: u16,
+    dash_offset: u16,
+    dash_padding: u16,
 }
 
 // Arrow metrics used to position the arrow.
 #[derive(Clone, Copy, Debug, Default)]
 #[repr(C)]
 struct ArrowMetrics {
-    tip_end : f32,
-    back_end : f32,
-    visual_tip_end : f32,
-    visual_back_end : f32,
-    line_end : f32,
+    tip_end: f32,
+    back_end: f32,
+    visual_tip_end: f32,
+    visual_back_end: f32,
+    line_end: f32,
 }
 
 // The part of the arrow data that we store directly into the attributes buffer.
 #[derive(Clone, Copy, Debug, Default)]
 #[repr(C)]
 struct ArrowIndices {
-    num_vertices : u16,
-    metrics_index : u16, // Where to find the rest of the arrow metrics in the ArrowHeader data texture
-    vertices_index : u16 // Where to find the arrow vertices.
+    num_vertices: u16,
+    metrics_index: u16, // Where to find the rest of the arrow metrics in the ArrowHeader data texture
+    vertices_index: u16, // Where to find the arrow vertices.
 }
 
 pub struct EdgeShader {
-    webgl : WebGlWrapper,
-    program : Program,
+    webgl: WebGlWrapper,
+    program: Program,
 
-    edge_instances : VertexBuffer<EdgeInstance>,
-    max_vertices : i32,
-    attribute_state : Option<WebGlVertexArrayObject>,
+    edge_instances: VertexBuffer<EdgeInstance>,
+    max_vertices: i32,
+    attribute_state: Option<WebGlVertexArrayObject>,
 
     // This stores the distance to the boundary at each angle.
     // Angle resolution is 2 degrees, so the float at index n is the distance to boundary at 2n degrees.
-    glyph_convex_hulls : DataTexture<f32>,
-
+    glyph_convex_hulls: DataTexture<f32>,
 
     // Arrow indices are stored in each EdgeInstance, contains number of arrows and index into arrow_metrics and arrow_paths
-    tip_map : BTreeMap<ArrowId, ArrowIndices>,
-    arrow_metrics_data : DataTexture<ArrowMetrics>,
-    arrow_path_data : DataTexture<Point>,
+    tip_map: BTreeMap<ArrowId, ArrowIndices>,
+    arrow_metrics_data: DataTexture<ArrowMetrics>,
+    arrow_path_data: DataTexture<Point>,
 
     // The dash texture we use like a 1D texture with linear blending.
     // So instead of leaving the management to DataTexture, we will manage it ourselves.
-    dash_data : Vec<u8>,
-    dash_texture : Option<WebGlTexture>,
-    dash_texture_num_rows : usize, // record how big texture is to decide when to reallocate.
-    dash_map : BTreeMap<Vec<u8>, (u16, u16)>,
+    dash_data: Vec<u8>,
+    dash_texture: Option<WebGlTexture>,
+    dash_texture_num_rows: usize, // record how big texture is to decide when to reallocate.
+    dash_map: BTreeMap<Vec<u8>, (u16, u16)>,
 
-    ready : bool,
+    ready: bool,
 }
 
-
 impl EdgeShader {
-    pub fn new(webgl : WebGlWrapper) -> Result<Self, JsValue> {
+    pub fn new(webgl: WebGlWrapper) -> Result<Self, JsValue> {
         let program = Program::new(
             webgl.clone(),
             include_str!("edge.vert"),
-            include_str!("edge.frag")
+            include_str!("edge.frag"),
         )?;
         let attribute_state = webgl.create_vertex_array();
         let edge_instances = VertexBuffer::new(webgl.clone());
-        ATTRIBUTES.set_up_vertex_array(&webgl, &program.program, attribute_state.as_ref(), edge_instances.buffer.as_ref())?;
+        ATTRIBUTES.set_up_vertex_array(
+            &webgl,
+            &program.program,
+            attribute_state.as_ref(),
+            edge_instances.buffer.as_ref(),
+        )?;
 
-        let glyph_convex_hulls = DataTexture::new(webgl.clone(), Format(Type::F32, NumChannels::Four));
-        let arrow_metrics_data = DataTexture::new(webgl.clone(), Format(Type::F32, NumChannels::Four));
+        let glyph_convex_hulls =
+            DataTexture::new(webgl.clone(), Format(Type::F32, NumChannels::Four));
+        let arrow_metrics_data =
+            DataTexture::new(webgl.clone(), Format(Type::F32, NumChannels::Four));
         let arrow_path_data = DataTexture::new(webgl.clone(), Format(Type::F32, NumChannels::Two));
 
         program.use_program();
@@ -213,20 +220,20 @@ impl EdgeShader {
             program,
 
             edge_instances,
-            max_vertices : 0,
+            max_vertices: 0,
             attribute_state,
 
             glyph_convex_hulls,
 
-            tip_map : BTreeMap::new(),
+            tip_map: BTreeMap::new(),
             arrow_metrics_data,
             arrow_path_data,
 
-            dash_data : Vec::new(),
+            dash_data: Vec::new(),
             dash_texture,
-            dash_texture_num_rows : 0,
+            dash_texture_num_rows: 0,
             dash_map,
-            ready : false,
+            ready: false,
         })
     }
 
@@ -238,23 +245,27 @@ impl EdgeShader {
     // To ensure that the starting edge when we start the pattern over is correctly blended, we add one extra "on" byte at the end.
     // The total of all of the entries must be <= DASH_PATTERN_TEXTURE_WIDTH.
     // (Instead of requiring this we could also dynamically widen the texture...)
-    fn dash_data(&mut self, dash_pattern : Vec<u8>) -> Result<(u16, u16), JsValue> {
+    fn dash_data(&mut self, dash_pattern: Vec<u8>) -> Result<(u16, u16), JsValue> {
         let entry = self.dash_map.entry(dash_pattern);
         Ok(match entry {
             btree_map::Entry::Occupied(oe) => *oe.get(),
             btree_map::Entry::Vacant(ve) => {
                 let dash_pattern = ve.key();
-                let mut pattern_len : u16 = dash_pattern.iter().map(|&b| b as u16).sum();
+                let mut pattern_len: u16 = dash_pattern.iter().map(|&b| b as u16).sum();
                 if dash_pattern.len() % 2 == 1 {
                     pattern_len *= 2;
                 }
                 if pattern_len > DASH_PATTERN_TEXTURE_WIDTH as u16 {
-                    return Err(format!("Dash pattern too long. Max of {} total.", DASH_PATTERN_TEXTURE_WIDTH - 1).into())
+                    return Err(format!(
+                        "Dash pattern too long. Max of {} total.",
+                        DASH_PATTERN_TEXTURE_WIDTH - 1
+                    )
+                    .into());
                 }
                 let orig_dash_data_len = self.dash_data.len();
                 let dash_pattern_row = orig_dash_data_len / DASH_PATTERN_TEXTURE_WIDTH;
                 for (i, &e) in dash_pattern.iter().enumerate() {
-                    let value = if i%2 == 1 { 0 } else { 255 };
+                    let value = if i % 2 == 1 { 0 } else { 255 };
                     for _ in 0..e {
                         self.dash_data.extend(&[value]);
                     }
@@ -262,7 +273,7 @@ impl EdgeShader {
                 // If pattern has odd length, then double it up with its negation
                 if dash_pattern.len() % 2 == 1 {
                     for (i, &e) in dash_pattern.iter().enumerate() {
-                        let value = if i%2 == 1 { 255 } else { 0 };
+                        let value = if i % 2 == 1 { 255 } else { 0 };
                         for _ in 0..e {
                             self.dash_data.extend(&[value]);
                         }
@@ -275,7 +286,8 @@ impl EdgeShader {
                 if pattern_len < DASH_PATTERN_TEXTURE_WIDTH as u16 {
                     self.dash_data.extend(&[255]);
                 }
-                self.dash_data.resize_with(orig_dash_data_len +  DASH_PATTERN_TEXTURE_WIDTH, ||0);
+                self.dash_data
+                    .resize_with(orig_dash_data_len + DASH_PATTERN_TEXTURE_WIDTH, || 0);
                 *ve.insert((dash_pattern_row as u16, pattern_len))
             }
         })
@@ -283,7 +295,7 @@ impl EdgeShader {
 
     // Increase number of texture rows to make space if necessary.
     // TODO: Maybe double number of rows for each realloc?
-    fn ensure_dash_texture_size(&mut self){
+    fn ensure_dash_texture_size(&mut self) {
         let num_rows = self.dash_data.len() / DASH_PATTERN_TEXTURE_WIDTH;
         if num_rows <= self.dash_texture_num_rows {
             return;
@@ -291,45 +303,75 @@ impl EdgeShader {
         self.dash_texture_num_rows = num_rows;
         self.webgl.delete_texture(self.dash_texture.as_ref());
         self.dash_texture = self.webgl.create_texture();
-        self.webgl.bind_texture(WebGl2RenderingContext::TEXTURE_2D, self.dash_texture.as_ref());
+        self.webgl.bind_texture(
+            WebGl2RenderingContext::TEXTURE_2D,
+            self.dash_texture.as_ref(),
+        );
         self.webgl.tex_storage_2d(
             WebGl2RenderingContext::TEXTURE_2D,
             1, // mip levels
             WebGl2RenderingContext::R8,
-            DASH_PATTERN_TEXTURE_WIDTH as i32, self.dash_texture_num_rows as i32
+            DASH_PATTERN_TEXTURE_WIDTH as i32,
+            self.dash_texture_num_rows as i32,
         );
-        self.webgl.tex_parameteri(WebGl2RenderingContext::TEXTURE_2D, WebGl2RenderingContext::TEXTURE_MAG_FILTER, WebGl2RenderingContext::LINEAR as i32);
-        self.webgl.tex_parameteri(WebGl2RenderingContext::TEXTURE_2D, WebGl2RenderingContext::TEXTURE_MIN_FILTER, WebGl2RenderingContext::LINEAR as i32);
-        self.webgl.tex_parameteri(WebGl2RenderingContext::TEXTURE_2D, WebGl2RenderingContext::TEXTURE_WRAP_S, WebGl2RenderingContext::REPEAT as i32);
-        self.webgl.tex_parameteri(WebGl2RenderingContext::TEXTURE_2D, WebGl2RenderingContext::TEXTURE_WRAP_T, WebGl2RenderingContext::CLAMP_TO_EDGE as i32);
+        self.webgl.tex_parameteri(
+            WebGl2RenderingContext::TEXTURE_2D,
+            WebGl2RenderingContext::TEXTURE_MAG_FILTER,
+            WebGl2RenderingContext::LINEAR as i32,
+        );
+        self.webgl.tex_parameteri(
+            WebGl2RenderingContext::TEXTURE_2D,
+            WebGl2RenderingContext::TEXTURE_MIN_FILTER,
+            WebGl2RenderingContext::LINEAR as i32,
+        );
+        self.webgl.tex_parameteri(
+            WebGl2RenderingContext::TEXTURE_2D,
+            WebGl2RenderingContext::TEXTURE_WRAP_S,
+            WebGl2RenderingContext::REPEAT as i32,
+        );
+        self.webgl.tex_parameteri(
+            WebGl2RenderingContext::TEXTURE_2D,
+            WebGl2RenderingContext::TEXTURE_WRAP_T,
+            WebGl2RenderingContext::CLAMP_TO_EDGE as i32,
+        );
     }
 
-    fn upload_dash_texture_data(&mut self) -> Result<(), JsValue>{
+    fn upload_dash_texture_data(&mut self) -> Result<(), JsValue> {
         self.ensure_dash_texture_size();
         let num_rows = self.dash_data.len() / DASH_PATTERN_TEXTURE_WIDTH;
-        self.webgl.bind_texture(WebGl2RenderingContext::TEXTURE_2D, self.dash_texture.as_ref());
-        self.webgl.tex_sub_image_2d_with_i32_and_i32_and_u32_and_type_and_opt_u8_array(
+        self.webgl.bind_texture(
             WebGl2RenderingContext::TEXTURE_2D,
-            0, // mip level
-            0, 0, // xoffset, yoffset: i32,
-            DASH_PATTERN_TEXTURE_WIDTH as i32, num_rows as i32, // width, height
-            WebGl2RenderingContext::RED, // format: u32,
-            WebGl2RenderingContext::UNSIGNED_BYTE, // type_: u32,
-            Some(&self.dash_data) // pixels: Option<&Object>
-        )?;
+            self.dash_texture.as_ref(),
+        );
+        self.webgl
+            .tex_sub_image_2d_with_i32_and_i32_and_u32_and_type_and_opt_u8_array(
+                WebGl2RenderingContext::TEXTURE_2D,
+                0, // mip level
+                0,
+                0, // xoffset, yoffset: i32,
+                DASH_PATTERN_TEXTURE_WIDTH as i32,
+                num_rows as i32,                       // width, height
+                WebGl2RenderingContext::RED,           // format: u32,
+                WebGl2RenderingContext::UNSIGNED_BYTE, // type_: u32,
+                Some(&self.dash_data),                 // pixels: Option<&Object>
+            )?;
         Ok(())
     }
 
-    fn bind_dash_data(&mut self, texture_unit : u32) -> Result<(), JsValue> {
-        self.webgl.active_texture(WebGl2RenderingContext::TEXTURE0 + texture_unit);
-        self.webgl.bind_texture(WebGl2RenderingContext::TEXTURE_2D, self.dash_texture.as_ref());
+    fn bind_dash_data(&mut self, texture_unit: u32) -> Result<(), JsValue> {
+        self.webgl
+            .active_texture(WebGl2RenderingContext::TEXTURE0 + texture_unit);
+        self.webgl.bind_texture(
+            WebGl2RenderingContext::TEXTURE_2D,
+            self.dash_texture.as_ref(),
+        );
         if !self.dash_data.is_empty() {
             self.upload_dash_texture_data()?;
         }
         Ok(())
     }
 
-    pub fn clear_all(&mut self){
+    pub fn clear_all(&mut self) {
         self.tip_map.clear();
         self.edge_instances.clear();
         self.arrow_metrics_data.clear();
@@ -337,7 +379,7 @@ impl EdgeShader {
         self.ready = false;
     }
 
-    pub fn clear_edge_instances(&mut self){
+    pub fn clear_edge_instances(&mut self) {
         self.max_vertices = 0;
         self.edge_instances.clear();
         self.ready = false;
@@ -345,7 +387,7 @@ impl EdgeShader {
 
     // Get arrow tip data to put into the attribute buffer.
     // If the given arrow has never been used before, we tessellate it and add the path and metrics to the relevant data textures.
-    fn arrow_tip_data(&mut self, arrow : &Arrow) -> Result<ArrowIndices, JsValue> {
+    fn arrow_tip_data(&mut self, arrow: &Arrow) -> Result<ArrowIndices, JsValue> {
         let entry = self.tip_map.entry(arrow.uuid);
         match entry {
             btree_map::Entry::Occupied(oe) => Ok(*oe.get()),
@@ -355,21 +397,27 @@ impl EdgeShader {
 
                 let vertices_index = self.arrow_path_data.len();
                 let num_vertices = buffers.indices.len();
-                let metrics_index : Result<u16, _> = (std::mem::size_of_val(self.arrow_metrics_data.data())/4).try_into();
+                let metrics_index: Result<u16, _> =
+                    (std::mem::size_of_val(self.arrow_metrics_data.data()) / 4).try_into();
                 let metrics_index = metrics_index.map_err(|_| "Too many total arrow heads.")?;
-                self.arrow_path_data.append(buffers.indices.iter().map(|&i| buffers.vertices[i as usize]));
+                self.arrow_path_data.append(
+                    buffers
+                        .indices
+                        .iter()
+                        .map(|&i| buffers.vertices[i as usize]),
+                );
                 self.arrow_metrics_data.push(ArrowMetrics {
-                    tip_end : arrow.tip_end,
-                    back_end : arrow.back_end,
-                    visual_tip_end : arrow.visual_tip_end,
-                    visual_back_end : arrow.visual_back_end,
-                    line_end : arrow.line_end,
+                    tip_end: arrow.tip_end,
+                    back_end: arrow.back_end,
+                    visual_tip_end: arrow.visual_tip_end,
+                    visual_back_end: arrow.visual_back_end,
+                    line_end: arrow.line_end,
                 });
 
                 let arrow_indices = ArrowIndices {
-                    num_vertices : num_vertices as u16,
+                    num_vertices: num_vertices as u16,
                     metrics_index,
-                    vertices_index : vertices_index as u16,
+                    vertices_index: vertices_index as u16,
                 };
                 Ok(*ve.insert(arrow_indices))
             }
@@ -377,56 +425,70 @@ impl EdgeShader {
     }
 
     // Edge shader takes the convex hull as a list of distances from center (to decide how far to travel along path)
-    pub fn add_glyph_hull<It : ExactSizeIterator<Item = Vector>>(&mut self, convex_hull : It){
-        self.glyph_convex_hulls.append(convex_hull.map(|v| v.length()));
+    pub fn add_glyph_hull<It: ExactSizeIterator<Item = Vector>>(&mut self, convex_hull: It) {
+        self.glyph_convex_hulls
+            .append(convex_hull.map(|v| v.length()));
     }
 
-
-    pub fn add_edge(&mut self,
-        start : GlyphInstance,
-        end : GlyphInstance,
-        start_glyph_id : usize,
-        end_glyph_id : usize,
-        options : &EdgeOptions,
+    pub fn add_edge(
+        &mut self,
+        start: GlyphInstance,
+        end: GlyphInstance,
+        start_glyph_id: usize,
+        end_glyph_id: usize,
+        options: &EdgeOptions,
         // start_tip : Option<&Arrow>, end_tip : Option<&Arrow>,
         // angle : Angle,
         // thickness : f32,
         // dash_pattern : &[u8],
     ) -> Result<(), JsValue> {
-        let start_arrow = options.start_tip.as_ref().map(|tip| self.arrow_tip_data(tip)).unwrap_or_else(|| Ok(Default::default()))?;
-        let end_arrow = options.end_tip.as_ref().map(|tip| self.arrow_tip_data(tip)).unwrap_or_else(|| Ok(Default::default()))?;
+        let start_arrow = options
+            .start_tip
+            .as_ref()
+            .map(|tip| self.arrow_tip_data(tip))
+            .unwrap_or_else(|| Ok(Default::default()))?;
+        let end_arrow = options
+            .end_tip
+            .as_ref()
+            .map(|tip| self.arrow_tip_data(tip))
+            .unwrap_or_else(|| Ok(Default::default()))?;
         let start_glyph_idx = start_glyph_id as u16;
         let end_glyph_idx = end_glyph_id as u16;
         let (dash_index, dash_length) = self.dash_data(options.dash_pattern.to_vec())?;
 
-        let edge_num_vertices = if options.angle == Angle::zero() { 6 } else { 12 };
-        self.max_vertices = self.max_vertices.max((start_arrow.num_vertices + end_arrow.num_vertices + edge_num_vertices) as i32);
+        let edge_num_vertices = if options.angle == Angle::zero() {
+            6
+        } else {
+            12
+        };
+        self.max_vertices = self
+            .max_vertices
+            .max((start_arrow.num_vertices + end_arrow.num_vertices + edge_num_vertices) as i32);
 
         self.ready = false;
         self.edge_instances.push(EdgeInstance {
-            color : options.color,
-            start_position : start.position,
-            start_offset : start.offset,
-            end_position : end.position,
-            end_offset : end.offset,
-            start_glyph : start_glyph_idx,
-            end_glyph : end_glyph_idx,
-            start_glyph_scale : start.scale,
-            end_glyph_scale : end.scale,
-            angle : options.angle.radians,
-            thickness : options.thickness,
+            color: options.color,
+            start_position: start.position,
+            start_offset: start.offset,
+            end_position: end.position,
+            end_offset: end.offset,
+            start_glyph: start_glyph_idx,
+            end_glyph: end_glyph_idx,
+            start_glyph_scale: start.scale,
+            end_glyph_scale: end.scale,
+            angle: options.angle.radians,
+            thickness: options.thickness,
 
             start_arrow,
             end_arrow,
 
             dash_length,
             dash_index,
-            dash_offset : 0,
-            dash_padding : 0,
+            dash_offset: 0,
+            dash_padding: 0,
         });
         Ok(())
     }
-
 
     pub fn draw(&mut self) -> Result<(), JsValue> {
         if self.edge_instances.is_empty() {
@@ -445,7 +507,7 @@ impl EdgeShader {
             WebGl2RenderingContext::TRIANGLES,
             0,
             self.max_vertices,
-            self.edge_instances.len() as i32
+            self.edge_instances.len() as i32,
         );
         Ok(())
     }

--- a/chart/chart/display_backend/src/shader/grid_shader.rs
+++ b/chart/chart/display_backend/src/shader/grid_shader.rs
@@ -1,29 +1,25 @@
-#[allow(unused_imports)]
-use crate::log;
-
-use crate::vector::{Vec4};
-use lyon::geom::math::{Point, vector};
-use crate::webgl_wrapper::WebGlWrapper;
-use crate::shader::Program;
-
+use lyon::geom::math::{vector, Point};
 use wasm_bindgen::JsValue;
 use web_sys::WebGl2RenderingContext;
-use crate::coordinate_system::CoordinateSystem;
 
+#[allow(unused_imports)]
+use crate::log;
+use crate::{
+    coordinate_system::CoordinateSystem, shader::Program, vector::Vec4, webgl_wrapper::WebGlWrapper,
+};
 
 pub struct GridShader {
-    pub program : Program,
-    x_grid_step : i32,
-    y_grid_step : i32,
-    color : Vec4,
-    thickness : f32,
-    offsets : Point,
-    ready : bool,
+    pub program: Program,
+    x_grid_step: i32,
+    y_grid_step: i32,
+    color: Vec4,
+    thickness: f32,
+    offsets: Point,
+    ready: bool,
 }
 
-
 impl GridShader {
-    pub fn new(webgl : WebGlWrapper) -> Result<Self, JsValue> {
+    pub fn new(webgl: WebGlWrapper) -> Result<Self, JsValue> {
         let program = Program::new(
             webgl,
             // vertexShader :
@@ -36,18 +32,19 @@ impl GridShader {
                 void main() {
                     outColor = uColor;
                 }
-            "#
+            "#,
         )?;
         Ok(Self {
             program,
-            x_grid_step : 1,
-            y_grid_step : 1,
-            color : Vec4::new(0.0, 0.0, 0.0, 1.0),
-            thickness : 1.0,
-            offsets : Point::new(0.0, 0.0),
-            ready : false,
+            x_grid_step: 1,
+            y_grid_step: 1,
+            color: Vec4::new(0.0, 0.0, 0.0, 1.0),
+            thickness: 1.0,
+            offsets: Point::new(0.0, 0.0),
+            ready: false,
         })
     }
+
     // uniform mat3x2 uTransformationMatrix;
     // uniform vec2 uOrigin;
     // uniform vec2 uScale;
@@ -56,62 +53,86 @@ impl GridShader {
     // uniform ivec2 uGridStep; // (xGridStep, yGridStep)
     // uniform vec2 uGridOffset; // (xGridStep, yGridStep)
 
-    pub fn grid_step(&mut self, x_grid_step : i32, y_grid_step : i32){
+    pub fn grid_step(&mut self, x_grid_step: i32, y_grid_step: i32) {
         self.x_grid_step = x_grid_step;
         self.y_grid_step = y_grid_step;
         self.ready = false;
     }
 
     #[allow(dead_code)]
-    pub fn grid_offsets(&mut self, x_grid_offset : f32, y_grid_offset : f32){
+    pub fn grid_offsets(&mut self, x_grid_offset: f32, y_grid_offset: f32) {
         self.offsets = Point::new(x_grid_offset, y_grid_offset);
         self.ready = false;
     }
 
-    pub fn color(&mut self, color : Vec4) {
+    pub fn color(&mut self, color: Vec4) {
         self.color = color;
         self.ready = false;
     }
 
-    pub fn thickness(&mut self, thickness : f32){
+    pub fn thickness(&mut self, thickness: f32) {
         self.thickness = thickness;
         self.ready = false;
     }
 
-    fn prepare(&mut self){
+    fn prepare(&mut self) {
         if self.ready {
             return;
         }
         self.program.set_uniform_float("uThickness", self.thickness);
         self.program.set_uniform_vec4("uColor", self.color);
         self.program.set_uniform_point("uGridOffset", self.offsets);
-        let loc = self.program.webgl.get_uniform_location(&self.program.program, "uGridStep");
-        self.program.webgl.uniform2iv_with_i32_array(loc.as_ref(), &[self.x_grid_step, self.y_grid_step]);
+        let loc = self
+            .program
+            .webgl
+            .get_uniform_location(&self.program.program, "uGridStep");
+        self.program
+            .webgl
+            .uniform2iv_with_i32_array(loc.as_ref(), &[self.x_grid_step, self.y_grid_step]);
         self.ready = true;
     }
 
-
-    pub fn draw(&mut self, coordinate_system : CoordinateSystem) -> Result<(), JsValue> {
+    pub fn draw(&mut self, coordinate_system: CoordinateSystem) -> Result<(), JsValue> {
         self.program.use_program();
         self.prepare();
-        self.program.set_uniform_transform("uTransformationMatrix", coordinate_system.transform);
-        self.program.set_uniform_point("uOrigin", coordinate_system.origin);
-        self.program.set_uniform_vector("uScale", coordinate_system.scale);
+        self.program
+            .set_uniform_transform("uTransformationMatrix", coordinate_system.transform);
+        self.program
+            .set_uniform_point("uOrigin", coordinate_system.origin);
+        self.program
+            .set_uniform_vector("uScale", coordinate_system.scale);
 
-        let [mut chart_x_min, mut chart_y_min] : [i32; 2] = (coordinate_system.current_min_xy().floor() - vector(1.0, 1.0)).cast().to_array();
-        let [chart_x_max, chart_y_max] : [i32; 2] = (coordinate_system.current_max_xy().ceil() + vector(1.0, 1.0)).cast().to_array();
+        let [mut chart_x_min, mut chart_y_min]: [i32; 2] =
+            (coordinate_system.current_min_xy().floor() - vector(1.0, 1.0))
+                .cast()
+                .to_array();
+        let [chart_x_max, chart_y_max]: [i32; 2] = (coordinate_system.current_max_xy().ceil()
+            + vector(1.0, 1.0))
+        .cast()
+        .to_array();
 
-        chart_x_min = (chart_x_min/self.x_grid_step) * self.x_grid_step;
-        chart_y_min = (chart_y_min/self.y_grid_step) * self.x_grid_step;
+        chart_x_min = (chart_x_min / self.x_grid_step) * self.x_grid_step;
+        chart_y_min = (chart_y_min / self.y_grid_step) * self.x_grid_step;
 
         let (screen_x_min, screen_x_max) = coordinate_system.screen_x_range();
         let (screen_y_min, screen_y_max) = coordinate_system.screen_y_range();
 
-        let num_vertical_grid_lines = (chart_x_max - chart_x_min + self.x_grid_step - 1) / self.x_grid_step + 1;
-        let num_horizontal_grid_lines = (chart_y_max - chart_y_min + self.y_grid_step - 1) / self.y_grid_step + 1;
-        let loc = self.program.webgl.get_uniform_location(&self.program.program, "uChartRange");
-        self.program.webgl.uniform4iv_with_i32_array(loc.as_ref(), &[chart_x_min, chart_x_max, chart_y_min, chart_y_max]);
-        self.program.set_uniform_vec4("uScreenRange", Vec4::new(screen_x_min, screen_x_max, screen_y_min, screen_y_max));
+        let num_vertical_grid_lines =
+            (chart_x_max - chart_x_min + self.x_grid_step - 1) / self.x_grid_step + 1;
+        let num_horizontal_grid_lines =
+            (chart_y_max - chart_y_min + self.y_grid_step - 1) / self.y_grid_step + 1;
+        let loc = self
+            .program
+            .webgl
+            .get_uniform_location(&self.program.program, "uChartRange");
+        self.program.webgl.uniform4iv_with_i32_array(
+            loc.as_ref(),
+            &[chart_x_min, chart_x_max, chart_y_min, chart_y_max],
+        );
+        self.program.set_uniform_vec4(
+            "uScreenRange",
+            Vec4::new(screen_x_min, screen_x_max, screen_y_min, screen_y_max),
+        );
 
         // Without this check, it seems to freeze the computer when you zoom out very far.
         if num_vertical_grid_lines + num_horizontal_grid_lines > 10_000 {
@@ -122,7 +143,7 @@ impl GridShader {
             WebGl2RenderingContext::TRIANGLES,
             0,
             6,
-            num_vertical_grid_lines + num_horizontal_grid_lines
+            num_vertical_grid_lines + num_horizontal_grid_lines,
         );
         Ok(())
     }

--- a/chart/chart/display_backend/src/shader/hit_canvas_shader.rs
+++ b/chart/chart/display_backend/src/shader/hit_canvas_shader.rs
@@ -1,65 +1,65 @@
-use web_sys::{WebGl2RenderingContext, WebGlVertexArrayObject, WebGlTexture, WebGlFramebuffer, WebGlRenderbuffer};
-use wasm_bindgen::JsValue;
-
 use lyon::geom::math::{Point, Vector};
-
+use wasm_bindgen::JsValue;
+use web_sys::{
+    WebGl2RenderingContext, WebGlFramebuffer, WebGlRenderbuffer, WebGlTexture,
+    WebGlVertexArrayObject,
+};
 
 #[allow(unused_imports)]
 use crate::log;
+use crate::{
+    convex_hull::ANGLE_RESOLUTION,
+    coordinate_system::{BufferDimensions, CoordinateSystem},
+    glyph::GlyphInstance,
+    shader::{
+        attributes::{Attribute, Attributes, Format, NumChannels, Type},
+        data_texture::DataTexture,
+        vertex_buffer::VertexBuffer,
+        Program,
+    },
+    webgl_wrapper::WebGlWrapper,
+};
 
-use crate::webgl_wrapper::WebGlWrapper;
-use crate::shader::Program;
-use crate::shader::attributes::{Format, NumChannels, Type, Attribute, Attributes};
-
-use crate::shader::data_texture::DataTexture;
-use crate::shader::vertex_buffer::VertexBuffer;
-
-use crate::glyph::{GlyphInstance};
-
-use crate::convex_hull::ANGLE_RESOLUTION;
-use crate::coordinate_system::{CoordinateSystem, BufferDimensions};
-
-
-const ATTRIBUTES : Attributes = Attributes::new(&[
+const ATTRIBUTES: Attributes = Attributes::new(&[
     Attribute::new("aPositionOffset", 4, Type::F32),
     Attribute::new("aScale", 1, Type::F32),
     Attribute::new("aGlyphIndex", 2, Type::U16), // (index, padding)
 ]);
 
-const GLYPH_HULL_TEXTURE_UNIT : u32 = 0;
+const GLYPH_HULL_TEXTURE_UNIT: u32 = 0;
 
 #[derive(Debug)]
 struct ShaderGlyphHeader {
-    index : u16,
-    padding : u16,
+    index: u16,
+    padding: u16,
 }
 
 #[derive(Debug)]
 struct ShaderGlyphInstance {
-    position : Point,
-    offset : Vector,
-    scale : f32,
-    glyph : ShaderGlyphHeader,
+    position: Point,
+    offset: Vector,
+    scale: f32,
+    glyph: ShaderGlyphHeader,
 }
 
 pub struct HitCanvasShader {
-    webgl : WebGlWrapper,
-    program : Program,
-    hit_canvas_buffer_dimensions : BufferDimensions,
-    hit_canvas_framebuffer : Option<WebGlFramebuffer>,
-    hit_canvas_texture : Option<WebGlTexture>,
-    hit_canvas_depth_buffer : Option<WebGlRenderbuffer>,
+    webgl: WebGlWrapper,
+    program: Program,
+    hit_canvas_buffer_dimensions: BufferDimensions,
+    hit_canvas_framebuffer: Option<WebGlFramebuffer>,
+    hit_canvas_texture: Option<WebGlTexture>,
+    hit_canvas_depth_buffer: Option<WebGlRenderbuffer>,
 
-    attribute_state : Option<WebGlVertexArrayObject>,
+    attribute_state: Option<WebGlVertexArrayObject>,
 
-    glyph_convex_hulls : DataTexture<Vector>,
+    glyph_convex_hulls: DataTexture<Vector>,
 
-    glyph_instances : VertexBuffer<ShaderGlyphInstance>,
-    ready : bool,
+    glyph_instances: VertexBuffer<ShaderGlyphInstance>,
+    ready: bool,
 }
 
 impl HitCanvasShader {
-    pub fn new(webgl : WebGlWrapper) -> Result<Self, JsValue> {
+    pub fn new(webgl: WebGlWrapper) -> Result<Self, JsValue> {
         let program = Program::new(
             webgl.clone(),
             include_str!("hit_canvas.vert"),
@@ -72,15 +72,21 @@ impl HitCanvasShader {
                     gl_FragDepth = length(vPosition) / 2000.0;
                     outColor = fColor;
                 }
-            "#
+            "#,
         )?;
 
         let attribute_state = webgl.create_vertex_array();
         let glyph_instances = VertexBuffer::new(webgl.clone());
 
-        ATTRIBUTES.set_up_vertex_array(&webgl, &program.program, attribute_state.as_ref(), glyph_instances.buffer.as_ref())?;
+        ATTRIBUTES.set_up_vertex_array(
+            &webgl,
+            &program.program,
+            attribute_state.as_ref(),
+            glyph_instances.buffer.as_ref(),
+        )?;
 
-        let glyph_convex_hulls = DataTexture::new(webgl.clone(), Format(Type::F32, NumChannels::Four));
+        let glyph_convex_hulls =
+            DataTexture::new(webgl.clone(), Format(Type::F32, NumChannels::Four));
 
         program.use_program();
         program.set_uniform_texture_unit("uGlyphConvexHulls", GLYPH_HULL_TEXTURE_UNIT);
@@ -90,98 +96,142 @@ impl HitCanvasShader {
         Ok(Self {
             webgl,
             program,
-            hit_canvas_buffer_dimensions : BufferDimensions::new(1, 1, 0.0),
-            hit_canvas_texture : None,
-            hit_canvas_framebuffer : None,
-            hit_canvas_depth_buffer : None,
+            hit_canvas_buffer_dimensions: BufferDimensions::new(1, 1, 0.0),
+            hit_canvas_texture: None,
+            hit_canvas_framebuffer: None,
+            hit_canvas_depth_buffer: None,
 
             glyph_convex_hulls,
             glyph_instances,
 
             attribute_state,
-            ready : false
+            ready: false,
         })
     }
 
-    fn initialize_hit_canvas(&mut self, dimensions : BufferDimensions){
+    fn initialize_hit_canvas(&mut self, dimensions: BufferDimensions) {
         if self.hit_canvas_buffer_dimensions == dimensions {
             return;
         }
-        self.webgl.delete_framebuffer(self.hit_canvas_framebuffer.as_ref());
+        self.webgl
+            .delete_framebuffer(self.hit_canvas_framebuffer.as_ref());
         self.webgl.delete_texture(self.hit_canvas_texture.as_ref());
-        self.webgl.delete_renderbuffer(self.hit_canvas_depth_buffer.as_ref());
+        self.webgl
+            .delete_renderbuffer(self.hit_canvas_depth_buffer.as_ref());
         self.hit_canvas_framebuffer = self.webgl.create_framebuffer();
         self.hit_canvas_texture = self.webgl.create_texture();
         self.hit_canvas_depth_buffer = self.webgl.create_renderbuffer();
 
-        self.webgl.bind_texture(WebGl2RenderingContext::TEXTURE_2D, self.hit_canvas_texture.as_ref());
-        self.webgl.bind_renderbuffer(WebGl2RenderingContext::RENDERBUFFER, self.hit_canvas_depth_buffer.as_ref());
+        self.webgl.bind_texture(
+            WebGl2RenderingContext::TEXTURE_2D,
+            self.hit_canvas_texture.as_ref(),
+        );
+        self.webgl.bind_renderbuffer(
+            WebGl2RenderingContext::RENDERBUFFER,
+            self.hit_canvas_depth_buffer.as_ref(),
+        );
         self.webgl.tex_storage_2d(
             WebGl2RenderingContext::TEXTURE_2D,
             1, // mip levels
             WebGl2RenderingContext::RGBA8,
-            dimensions.pixel_width(), dimensions.pixel_height() // width, height
+            dimensions.pixel_width(),
+            dimensions.pixel_height(), // width, height
         );
-        self.webgl.tex_parameteri(WebGl2RenderingContext::TEXTURE_2D, WebGl2RenderingContext::TEXTURE_MAG_FILTER, WebGl2RenderingContext::NEAREST as i32);
-        self.webgl.tex_parameteri(WebGl2RenderingContext::TEXTURE_2D, WebGl2RenderingContext::TEXTURE_MIN_FILTER, WebGl2RenderingContext::NEAREST as i32);
-        self.webgl.tex_parameteri(WebGl2RenderingContext::TEXTURE_2D, WebGl2RenderingContext::TEXTURE_WRAP_S, WebGl2RenderingContext::CLAMP_TO_EDGE as i32);
-        self.webgl.tex_parameteri(WebGl2RenderingContext::TEXTURE_2D, WebGl2RenderingContext::TEXTURE_WRAP_T, WebGl2RenderingContext::CLAMP_TO_EDGE as i32);
+        self.webgl.tex_parameteri(
+            WebGl2RenderingContext::TEXTURE_2D,
+            WebGl2RenderingContext::TEXTURE_MAG_FILTER,
+            WebGl2RenderingContext::NEAREST as i32,
+        );
+        self.webgl.tex_parameteri(
+            WebGl2RenderingContext::TEXTURE_2D,
+            WebGl2RenderingContext::TEXTURE_MIN_FILTER,
+            WebGl2RenderingContext::NEAREST as i32,
+        );
+        self.webgl.tex_parameteri(
+            WebGl2RenderingContext::TEXTURE_2D,
+            WebGl2RenderingContext::TEXTURE_WRAP_S,
+            WebGl2RenderingContext::CLAMP_TO_EDGE as i32,
+        );
+        self.webgl.tex_parameteri(
+            WebGl2RenderingContext::TEXTURE_2D,
+            WebGl2RenderingContext::TEXTURE_WRAP_T,
+            WebGl2RenderingContext::CLAMP_TO_EDGE as i32,
+        );
 
-        self.webgl.bind_framebuffer(WebGl2RenderingContext::FRAMEBUFFER, self.hit_canvas_framebuffer.as_ref());
+        self.webgl.bind_framebuffer(
+            WebGl2RenderingContext::FRAMEBUFFER,
+            self.hit_canvas_framebuffer.as_ref(),
+        );
         self.webgl.framebuffer_texture_2d(
             WebGl2RenderingContext::FRAMEBUFFER,
             WebGl2RenderingContext::COLOR_ATTACHMENT0,
             WebGl2RenderingContext::TEXTURE_2D,
             self.hit_canvas_texture.as_ref(),
-            0 // level
+            0, // level
         );
-        self.webgl.framebuffer_renderbuffer(WebGl2RenderingContext::FRAMEBUFFER, WebGl2RenderingContext::DEPTH_ATTACHMENT, WebGl2RenderingContext::RENDERBUFFER,
-            self.hit_canvas_depth_buffer.as_ref()
+        self.webgl.framebuffer_renderbuffer(
+            WebGl2RenderingContext::FRAMEBUFFER,
+            WebGl2RenderingContext::DEPTH_ATTACHMENT,
+            WebGl2RenderingContext::RENDERBUFFER,
+            self.hit_canvas_depth_buffer.as_ref(),
         );
-        self.webgl.renderbuffer_storage(WebGl2RenderingContext::RENDERBUFFER, WebGl2RenderingContext::DEPTH_COMPONENT16, dimensions.pixel_width(), dimensions.pixel_height());
-
+        self.webgl.renderbuffer_storage(
+            WebGl2RenderingContext::RENDERBUFFER,
+            WebGl2RenderingContext::DEPTH_COMPONENT16,
+            dimensions.pixel_width(),
+            dimensions.pixel_height(),
+        );
     }
 
-    pub fn add_glyph_hull<It : ExactSizeIterator<Item = Vector>>(&mut self, convex_hull : It){
+    pub fn add_glyph_hull<It: ExactSizeIterator<Item = Vector>>(&mut self, convex_hull: It) {
         self.glyph_convex_hulls.append(convex_hull);
     }
 
-    pub fn add_glyph_instance(&mut self, glyph_instance : GlyphInstance, glyph_index : usize) -> Result<(), JsValue> {
+    pub fn add_glyph_instance(
+        &mut self,
+        glyph_instance: GlyphInstance,
+        glyph_index: usize,
+    ) -> Result<(), JsValue> {
         self.glyph_instances.push(ShaderGlyphInstance {
-            position : glyph_instance.position,
-            offset : glyph_instance.offset,
-            scale : glyph_instance.scale,
-            glyph : ShaderGlyphHeader {
-                index : glyph_index as u16,
-                padding : 0
+            position: glyph_instance.position,
+            offset: glyph_instance.offset,
+            scale: glyph_instance.scale,
+            glyph: ShaderGlyphHeader {
+                index: glyph_index as u16,
+                padding: 0,
             },
         });
         self.ready = false;
         Ok(())
     }
 
-    pub fn clear_all(&mut self){
+    pub fn clear_all(&mut self) {
         self.glyph_instances.clear();
         self.glyph_convex_hulls.clear();
         self.ready = false;
     }
 
-    pub fn clear_glyph_instances(&mut self){
+    pub fn clear_glyph_instances(&mut self) {
         self.glyph_instances.clear();
         self.ready = false;
     }
 
-    pub fn draw(&mut self, coordinate_system : CoordinateSystem) -> Result<(), JsValue> {
+    pub fn draw(&mut self, coordinate_system: CoordinateSystem) -> Result<(), JsValue> {
         if self.glyph_instances.is_empty() {
             return Ok(());
         }
         self.program.use_program();
         self.webgl.bind_vertex_array(self.attribute_state.as_ref());
 
-        self.webgl.bind_framebuffer(WebGl2RenderingContext::FRAMEBUFFER, self.hit_canvas_framebuffer.as_ref());
+        self.webgl.bind_framebuffer(
+            WebGl2RenderingContext::FRAMEBUFFER,
+            self.hit_canvas_framebuffer.as_ref(),
+        );
         self.initialize_hit_canvas(coordinate_system.buffer_dimensions);
         self.webgl.clear_color(0.0, 0.0, 0.0, 0.0);
-        self.webgl.clear(WebGl2RenderingContext::COLOR_BUFFER_BIT | WebGl2RenderingContext::DEPTH_BUFFER_BIT);
+        self.webgl.clear(
+            WebGl2RenderingContext::COLOR_BUFFER_BIT | WebGl2RenderingContext::DEPTH_BUFFER_BIT,
+        );
         self.webgl.disable(WebGl2RenderingContext::BLEND);
         self.webgl.enable(WebGl2RenderingContext::DEPTH_TEST);
 
@@ -196,31 +246,42 @@ impl HitCanvasShader {
             WebGl2RenderingContext::TRIANGLE_FAN,
             0,
             num_vertices,
-            num_instances
+            num_instances,
         );
 
-        self.webgl.bind_framebuffer(WebGl2RenderingContext::FRAMEBUFFER, None);
+        self.webgl
+            .bind_framebuffer(WebGl2RenderingContext::FRAMEBUFFER, None);
         self.webgl.bind_vertex_array(None);
-        self.webgl.render_to_canvas(coordinate_system.buffer_dimensions);
+        self.webgl
+            .render_to_canvas(coordinate_system.buffer_dimensions);
         self.webgl.disable(WebGl2RenderingContext::DEPTH_TEST);
         self.webgl.enable(WebGl2RenderingContext::BLEND);
         Ok(())
     }
 
-    pub fn object_underneath_pixel(&self, coordinate_system : CoordinateSystem, point : Point) -> Result<Option<u32>, JsValue> {
+    pub fn object_underneath_pixel(
+        &self,
+        coordinate_system: CoordinateSystem,
+        point: Point,
+    ) -> Result<Option<u32>, JsValue> {
         let mut data = [0; 4];
-        self.webgl.bind_framebuffer(WebGl2RenderingContext::FRAMEBUFFER, self.hit_canvas_framebuffer.as_ref());
+        self.webgl.bind_framebuffer(
+            WebGl2RenderingContext::FRAMEBUFFER,
+            self.hit_canvas_framebuffer.as_ref(),
+        );
         let density = coordinate_system.buffer_dimensions.density();
         let pixel_height = coordinate_system.buffer_dimensions.pixel_height();
         self.webgl.read_pixels_with_opt_u8_array(
-            (point.x as f64 * density) as i32,                 // x
-            pixel_height - (point.y as f64 * density) as i32,  // y
-            1, 1,                                   // width, height
-            WebGl2RenderingContext::RGBA,           // format
-            WebGl2RenderingContext::UNSIGNED_BYTE,  // type
-            Some(&mut data) // array to hold result
+            (point.x as f64 * density) as i32,                // x
+            pixel_height - (point.y as f64 * density) as i32, // y
+            1,
+            1,                                     // width, height
+            WebGl2RenderingContext::RGBA,          // format
+            WebGl2RenderingContext::UNSIGNED_BYTE, // type
+            Some(&mut data),                       // array to hold result
         )?;
-        self.webgl.bind_framebuffer(WebGl2RenderingContext::FRAMEBUFFER, None);
+        self.webgl
+            .bind_framebuffer(WebGl2RenderingContext::FRAMEBUFFER, None);
         let id = u32::from_le_bytes(data);
         Ok(id.checked_sub(1))
     }

--- a/chart/chart/display_backend/src/shader/mod.rs
+++ b/chart/chart/display_backend/src/shader/mod.rs
@@ -2,23 +2,19 @@ mod range;
 
 mod attributes;
 mod data_texture;
-mod vertex_buffer;
 mod program;
+mod vertex_buffer;
 
-
-mod grid_shader;
-mod glyph_shader;
-mod hit_canvas_shader;
-mod edge_shader;
 mod chart_shaders;
+mod edge_shader;
+mod glyph_shader;
+mod grid_shader;
+mod hit_canvas_shader;
 
-
-pub(in crate::shader) use program::Program;
-pub(in crate::shader) use glyph_shader::GlyphShader;
-pub(in crate::shader) use hit_canvas_shader::HitCanvasShader;
-pub(in crate::shader) use edge_shader::EdgeShader;
-
-
-pub use grid_shader::GridShader;
-pub use edge_shader::EdgeOptions;
 pub use chart_shaders::ChartShaders;
+pub use edge_shader::EdgeOptions;
+pub(in crate::shader) use edge_shader::EdgeShader;
+pub(in crate::shader) use glyph_shader::GlyphShader;
+pub use grid_shader::GridShader;
+pub(in crate::shader) use hit_canvas_shader::HitCanvasShader;
+pub(in crate::shader) use program::Program;

--- a/chart/chart/display_backend/src/shader/program.rs
+++ b/chart/chart/display_backend/src/shader/program.rs
@@ -1,71 +1,70 @@
-use crate::vector::{Vec4};
-use lyon::geom::math::{Point, Vector, Transform};
-
+use lyon::geom::math::{Point, Transform, Vector};
 use wasm_bindgen::JsValue;
-use crate::webgl_wrapper::WebGlWrapper;
-use web_sys::{
-    WebGl2RenderingContext, WebGlProgram, WebGlShader,
-};
+use web_sys::{WebGl2RenderingContext, WebGlProgram, WebGlShader};
+
+use crate::{vector::Vec4, webgl_wrapper::WebGlWrapper};
 
 pub struct Program {
-    pub webgl : WebGlWrapper,
-    pub program : WebGlProgram
+    pub webgl: WebGlWrapper,
+    pub program: WebGlProgram,
 }
 
 impl Program {
-    pub fn new(webgl : WebGlWrapper, vertex_shader : &str, fragment_shader : &str) -> Result<Self, JsValue> {
-        let vert_shader = compile_shader(
-            &webgl,
-            WebGl2RenderingContext::VERTEX_SHADER,
-            vertex_shader
-        )?;
+    pub fn new(
+        webgl: WebGlWrapper,
+        vertex_shader: &str,
+        fragment_shader: &str,
+    ) -> Result<Self, JsValue> {
+        let vert_shader =
+            compile_shader(&webgl, WebGl2RenderingContext::VERTEX_SHADER, vertex_shader)?;
         let frag_shader = compile_shader(
             &webgl,
             WebGl2RenderingContext::FRAGMENT_SHADER,
-            fragment_shader
+            fragment_shader,
         )?;
         let program = link_program(&webgl, &vert_shader, &frag_shader)?;
-        Ok(Program {
-            webgl,
-            program
-        })
+        Ok(Program { webgl, program })
     }
 
-    pub fn use_program(&self){
+    pub fn use_program(&self) {
         self.webgl.use_program(Some(&self.program));
     }
 
-    pub fn set_uniform_float(&self, name : &str, x : f32) {
+    pub fn set_uniform_float(&self, name: &str, x: f32) {
         let loc = self.webgl.get_uniform_location(&self.program, name);
         self.webgl.uniform1f(loc.as_ref(), x);
     }
 
-    pub fn set_uniform_texture_unit(&self, name : &str, x : u32) {
+    pub fn set_uniform_texture_unit(&self, name: &str, x: u32) {
         let loc = self.webgl.get_uniform_location(&self.program, name);
-        self.webgl.uniform1iv_with_i32_array(loc.as_ref(), &[x as i32]);
+        self.webgl
+            .uniform1iv_with_i32_array(loc.as_ref(), &[x as i32]);
     }
 
-    pub fn set_uniform_point(&self, name : &str, v2 : Point) {
+    pub fn set_uniform_point(&self, name: &str, v2: Point) {
         let loc = self.webgl.get_uniform_location(&self.program, name);
-        self.webgl.uniform2fv_with_f32_array(loc.as_ref(), &v2.to_array());
+        self.webgl
+            .uniform2fv_with_f32_array(loc.as_ref(), &v2.to_array());
     }
 
-    pub fn set_uniform_vector(&self, name : &str, v2 : Vector) {
+    pub fn set_uniform_vector(&self, name: &str, v2: Vector) {
         let loc = self.webgl.get_uniform_location(&self.program, name);
-        self.webgl.uniform2fv_with_f32_array(loc.as_ref(), &v2.to_array());
+        self.webgl
+            .uniform2fv_with_f32_array(loc.as_ref(), &v2.to_array());
     }
 
-    pub fn set_uniform_vec4(&self, name : &str, v4 : Vec4) {
+    pub fn set_uniform_vec4(&self, name: &str, v4: Vec4) {
         let loc = self.webgl.get_uniform_location(&self.program, name);
-        self.webgl.uniform4fv_with_f32_array(loc.as_ref(), &[v4.x, v4.y, v4.z, v4.w]);
+        self.webgl
+            .uniform4fv_with_f32_array(loc.as_ref(), &[v4.x, v4.y, v4.z, v4.w]);
     }
 
-    pub fn set_uniform_transform(&self, name : &str, transform : Transform) {
+    pub fn set_uniform_transform(&self, name: &str, transform: Transform) {
         let loc = self.webgl.get_uniform_location(&self.program, name);
-        self.webgl.uniform_matrix3x2fv_with_f32_array(loc.as_ref(), false, &transform.to_array());
+        self.webgl
+            .uniform_matrix3x2fv_with_f32_array(loc.as_ref(), false, &transform.to_array());
     }
 }
-
 
 fn compile_shader(
     webgl: &WebGlWrapper,

--- a/chart/chart/display_backend/src/shader/range.rs
+++ b/chart/chart/display_backend/src/shader/range.rs
@@ -1,25 +1,22 @@
 #[derive(Copy, Clone, Debug)]
 pub struct Range {
-    pub min : usize,
-    pub max : usize
+    pub min: usize,
+    pub max: usize,
 }
 
 impl Range {
     pub fn empty() -> Self {
         Self {
-            min : usize::MAX,
-            max : 0
+            min: usize::MAX,
+            max: 0,
         }
     }
 
-    pub fn new(min : usize, max : usize) -> Self {
+    pub fn new(min: usize, max: usize) -> Self {
         if max <= min {
             Self::empty()
         } else {
-            Self {
-                min,
-                max
-            }
+            Self { min, max }
         }
     }
 
@@ -27,12 +24,12 @@ impl Range {
         self.max <= self.min
     }
 
-    pub fn include_int(&mut self, x : usize) {
+    pub fn include_int(&mut self, x: usize) {
         self.min = self.min.min(x);
         self.max = self.max.max(x + 1);
     }
 
-    pub fn include_range(&mut self, other : Range){
+    pub fn include_range(&mut self, other: Range) {
         self.min = self.min.min(other.min);
         self.max = self.max.max(other.max);
     }
@@ -41,43 +38,43 @@ impl Range {
 use std::ops;
 
 impl From<usize> for Range {
-    fn from(a : usize) -> Self {
-        Self::new(a, a+1)
+    fn from(a: usize) -> Self {
+        Self::new(a, a + 1)
     }
 }
 
 impl From<ops::Range<usize>> for Range {
-    fn from(a : ops::Range<usize>) -> Self {
+    fn from(a: ops::Range<usize>) -> Self {
         Self::new(a.start, a.end + 1)
     }
 }
 
 impl From<ops::RangeFrom<usize>> for Range {
-    fn from(a : ops::RangeFrom<usize>) -> Self {
+    fn from(a: ops::RangeFrom<usize>) -> Self {
         Self::new(a.start, usize::MAX)
     }
 }
 
 impl From<ops::RangeFull> for Range {
-    fn from(_a : ops::RangeFull) -> Self {
+    fn from(_a: ops::RangeFull) -> Self {
         Self::new(0, usize::MAX)
     }
 }
 
 impl From<ops::RangeInclusive<usize>> for Range {
-    fn from(a : ops::RangeInclusive<usize>) -> Self {
+    fn from(a: ops::RangeInclusive<usize>) -> Self {
         Self::new(*a.start(), *a.end() + 1)
     }
 }
 
 impl From<ops::RangeTo<usize>> for Range {
-    fn from(a : ops::RangeTo<usize>) -> Self {
+    fn from(a: ops::RangeTo<usize>) -> Self {
         Self::new(0, a.end)
     }
 }
 
 impl From<ops::RangeToInclusive<usize>> for Range {
-    fn from(a : ops::RangeToInclusive<usize>) -> Self {
+    fn from(a: ops::RangeToInclusive<usize>) -> Self {
         Self::new(0, a.end + 1)
     }
 }

--- a/chart/chart/display_backend/src/shader/vertex_buffer.rs
+++ b/chart/chart/display_backend/src/shader/vertex_buffer.rs
@@ -1,33 +1,33 @@
-use crate::shader::range::Range;
-use crate::webgl_wrapper::WebGlWrapper;
+use std::{
+    ops::{Index, IndexMut},
+    slice::SliceIndex,
+};
 
+use web_sys::{WebGl2RenderingContext, WebGlBuffer};
 
-use std::ops::{Index, IndexMut};
-use std::slice::SliceIndex;
-use web_sys::{WebGlBuffer, WebGl2RenderingContext};
-
+use crate::{shader::range::Range, webgl_wrapper::WebGlWrapper};
 
 pub struct VertexBuffer<T> {
-    webgl : WebGlWrapper,
-    pub buffer : Option<WebGlBuffer>,
-    buffer_capacity : usize,
-    pub data : Vec<T>,
-    dirty_range : Range,
+    webgl: WebGlWrapper,
+    pub buffer: Option<WebGlBuffer>,
+    buffer_capacity: usize,
+    pub data: Vec<T>,
+    dirty_range: Range,
 }
 
 impl<T> VertexBuffer<T> {
-    pub fn new(webgl : WebGlWrapper) -> Self {
+    pub fn new(webgl: WebGlWrapper) -> Self {
         Self::with_capacity(webgl, 0)
     }
 
-    pub fn with_capacity(webgl : WebGlWrapper, capacity: usize) -> Self {
+    pub fn with_capacity(webgl: WebGlWrapper, capacity: usize) -> Self {
         let buffer = webgl.create_buffer();
         Self {
             webgl,
             buffer,
-            buffer_capacity : 0,
-            data : Vec::with_capacity(capacity),
-            dirty_range : Range::empty(),
+            buffer_capacity: 0,
+            data: Vec::with_capacity(capacity),
+            dirty_range: Range::empty(),
         }
     }
 
@@ -35,7 +35,7 @@ impl<T> VertexBuffer<T> {
         self.data.len()
     }
 
-    pub fn clear(&mut self){
+    pub fn clear(&mut self) {
         self.data.clear();
     }
 
@@ -54,48 +54,54 @@ impl<T> VertexBuffer<T> {
         }
         // reserve size for buffer.
         let buffer_size = (self.data.capacity() * std::mem::size_of::<T>()) as i32;
-        self.webgl.buffer_data_with_i32(WebGl2RenderingContext::ARRAY_BUFFER, buffer_size, WebGl2RenderingContext::STATIC_DRAW);
+        self.webgl.buffer_data_with_i32(
+            WebGl2RenderingContext::ARRAY_BUFFER,
+            buffer_size,
+            WebGl2RenderingContext::STATIC_DRAW,
+        );
         self.dirty_range = Range::new(0, self.data.len());
     }
 
-    fn update_buffer_data(&mut self){
+    fn update_buffer_data(&mut self) {
         if self.dirty_range.is_empty() {
             return;
         }
         let dirty_min = self.dirty_range.min;
         let dirty_max = self.dirty_range.max.min(self.data.len());
         let offset = std::mem::size_of_val(&self.data[0..dirty_min]) as i32;
-        let slice = &self.data[dirty_min .. dirty_max];
+        let slice = &self.data[dirty_min..dirty_max];
         let slice_size = std::mem::size_of_val(slice);
         let u8_ptr = self.data.as_ptr() as *mut u8;
-        let u8_slice = unsafe {
-            std::slice::from_raw_parts(u8_ptr, slice_size)
-        };
-        self.webgl.buffer_sub_data_with_i32_and_u8_array(WebGl2RenderingContext::ARRAY_BUFFER, offset, u8_slice);
+        let u8_slice = unsafe { std::slice::from_raw_parts(u8_ptr, slice_size) };
+        self.webgl.buffer_sub_data_with_i32_and_u8_array(
+            WebGl2RenderingContext::ARRAY_BUFFER,
+            offset,
+            u8_slice,
+        );
         self.dirty_range = Range::empty();
     }
-
 
     pub fn prepare(&mut self) {
         if self.data.len() == 0 {
             return;
         }
-        self.webgl.bind_buffer(WebGl2RenderingContext::ARRAY_BUFFER, self.buffer.as_ref());
+        self.webgl
+            .bind_buffer(WebGl2RenderingContext::ARRAY_BUFFER, self.buffer.as_ref());
         self.ensure_buffer_size();
         self.update_buffer_data();
     }
-
 }
 
 impl<T, I: SliceIndex<[T]>> Index<I> for VertexBuffer<T> {
     type Output = I::Output;
+
     #[inline]
     fn index(&self, index: I) -> &Self::Output {
         &self.data[index]
     }
 }
 
-impl<T, I: SliceIndex<[T]> + Copy + Into<Range> > IndexMut<I> for VertexBuffer<T> {
+impl<T, I: SliceIndex<[T]> + Copy + Into<Range>> IndexMut<I> for VertexBuffer<T> {
     #[inline]
     fn index_mut(&mut self, index: I) -> &mut Self::Output {
         self.dirty_range.include_range(index.into());

--- a/chart/chart/display_backend/src/stroke_tessellation.rs
+++ b/chart/chart/display_backend/src/stroke_tessellation.rs
@@ -1,6 +1,8 @@
 use lyon::tessellation as tess;
-use tess::{StrokeVertexConstructor, StrokeAttributes};
-use tess::math::{Point, Vector};
+use tess::{
+    math::{Point, Vector},
+    StrokeAttributes, StrokeVertexConstructor,
+};
 
 #[derive(Copy, Clone, Debug)]
 pub struct PositionNormal {
@@ -13,10 +15,11 @@ pub struct PositionNormalConstructor;
 
 impl StrokeVertexConstructor<PositionNormal> for PositionNormalConstructor {
     fn new_vertex(&mut self, position: Point, attributes: StrokeAttributes) -> PositionNormal {
-        let normal = if attributes.side().is_right() { attributes.normal() } else { Vector::new(0.0, 0.0) };
-        PositionNormal {
-            position,
-            normal
-        }
+        let normal = if attributes.side().is_right() {
+            attributes.normal()
+        } else {
+            Vector::new(0.0, 0.0)
+        };
+        PositionNormal { position, normal }
     }
 }

--- a/chart/chart/display_backend/src/vector.rs
+++ b/chart/chart/display_backend/src/vector.rs
@@ -5,67 +5,64 @@ use wasm_bindgen::prelude::*;
 
 // use derive_more::{From, Add, Sub, Mul, Div, AddAssign, SubAssign, MulAssign, DivAssign, Sum};
 
-
 #[wasm_bindgen(inspectable)]
 #[derive(Copy, Clone, Debug)]
 #[repr(C)]
 pub struct JsPoint {
-    pub x : f32,
-    pub y : f32
+    pub x: f32,
+    pub y: f32,
 }
 
 impl From<(f32, f32)> for JsPoint {
-    fn from((px, py) : (f32, f32)) -> Self {
+    fn from((px, py): (f32, f32)) -> Self {
         Self::new(px, py)
     }
 }
 
-
 impl From<JsPoint> for Point {
-    fn from(p : JsPoint) -> Self {
+    fn from(p: JsPoint) -> Self {
         Self::new(p.x, p.y)
     }
 }
 
 impl From<JsPoint> for Vector {
-    fn from(p : JsPoint) -> Self {
+    fn from(p: JsPoint) -> Self {
         Self::new(p.x, p.y)
     }
 }
 
-
 impl From<Point> for JsPoint {
-    fn from(p : Point) -> Self {
+    fn from(p: Point) -> Self {
         Self::new(p.x, p.y)
     }
 }
 
 impl From<Vector> for JsPoint {
-    fn from(p : Vector) -> Self {
+    fn from(p: Vector) -> Self {
         Self::new(p.x, p.y)
     }
 }
 
 impl From<&Point> for JsPoint {
-    fn from(p : &Point) -> Self {
+    fn from(p: &Point) -> Self {
         Self::new(p.x, p.y)
     }
 }
 
 impl From<&Vector> for JsPoint {
-    fn from(p : &Vector) -> Self {
+    fn from(p: &Vector) -> Self {
         Self::new(p.x, p.y)
     }
 }
 
 impl From<&JsPoint> for Point {
-    fn from(p : &JsPoint) -> Self {
+    fn from(p: &JsPoint) -> Self {
         Self::new(p.x, p.y)
     }
 }
 
 impl From<&JsPoint> for Vector {
-    fn from(p : &JsPoint) -> Self {
+    fn from(p: &JsPoint) -> Self {
         Self::new(p.x, p.y)
     }
 }
@@ -73,35 +70,31 @@ impl From<&JsPoint> for Vector {
 #[wasm_bindgen]
 impl JsPoint {
     #[wasm_bindgen(constructor)]
-    pub fn new(x : f32, y : f32) -> Self {
+    pub fn new(x: f32, y: f32) -> Self {
         Self { x, y }
     }
 }
-
-
 
 #[wasm_bindgen(inspectable)]
 #[derive(Copy, Clone, Debug)]
 #[repr(C)]
 pub struct Vec4 {
-    pub x : f32,
-    pub y : f32,
-    pub z : f32,
-    pub w : f32
+    pub x: f32,
+    pub y: f32,
+    pub z: f32,
+    pub w: f32,
 }
 
 #[wasm_bindgen]
 impl Vec4 {
     #[wasm_bindgen(constructor)]
-    pub fn new_js(x : f32, y : f32, z : f32, w : f32) -> Self {
+    pub fn new_js(x: f32, y: f32, z: f32, w: f32) -> Self {
         Self::new(x, y, z, w)
     }
 }
 
 impl Vec4 {
-    pub const fn new(x : f32, y : f32, z : f32, w : f32) -> Self {
-        Self {
-            x, y, z, w
-        }
+    pub const fn new(x: f32, y: f32, z: f32, w: f32) -> Self {
+        Self { x, y, z, w }
     }
 }

--- a/chart/chart/display_backend/src/webgl_wrapper.rs
+++ b/chart/chart/display_backend/src/webgl_wrapper.rs
@@ -1,33 +1,36 @@
-use web_sys::{HtmlCanvasElement, WebGl2RenderingContext};
-use wasm_bindgen::{JsValue, JsCast};
 use std::ops::Deref;
 
+use wasm_bindgen::{JsCast, JsValue};
+use web_sys::{HtmlCanvasElement, WebGl2RenderingContext};
 
+use crate::coordinate_system::BufferDimensions;
 #[allow(unused_imports)]
 use crate::log;
-use crate::coordinate_system::BufferDimensions;
-
-
 
 #[derive(Clone)]
 pub struct WebGlWrapper {
-    pub inner : WebGl2RenderingContext
+    pub inner: WebGl2RenderingContext,
 }
 
 impl Deref for WebGlWrapper {
     type Target = WebGl2RenderingContext;
+
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
 
 impl WebGlWrapper {
-    pub fn new(inner : WebGl2RenderingContext) -> Self {
+    pub fn new(inner: WebGl2RenderingContext) -> Self {
         Self { inner }
     }
 
     pub fn canvas(&self) -> Result<HtmlCanvasElement, JsValue> {
-        Ok(self.inner.canvas().ok_or("context.canvas is undefined")?.dyn_into()?)
+        Ok(self
+            .inner
+            .canvas()
+            .ok_or("context.canvas is undefined")?
+            .dyn_into()?)
     }
 
     // pub fn dimensions(&self) -> Result<BufferDimensions, JsValue> {
@@ -42,16 +45,18 @@ impl WebGlWrapper {
         web_sys::window().unwrap().device_pixel_ratio()
     }
 
-    pub fn point_to_pixels(points : f32) -> f32 {
+    pub fn point_to_pixels(points: f32) -> f32 {
         ((points as f64) * WebGlWrapper::pixel_density()) as f32
     }
 
-    pub fn viewport_dimensions(&self, dimensions : BufferDimensions) {
-        self.inner.viewport(0, 0, dimensions.pixel_width(), dimensions.pixel_height());
+    pub fn viewport_dimensions(&self, dimensions: BufferDimensions) {
+        self.inner
+            .viewport(0, 0, dimensions.pixel_width(), dimensions.pixel_height());
     }
 
-    pub fn render_to_canvas(&self, dimensions : BufferDimensions) {
-        self.inner.bind_framebuffer(WebGl2RenderingContext::FRAMEBUFFER, None);
+    pub fn render_to_canvas(&self, dimensions: BufferDimensions) {
+        self.inner
+            .bind_framebuffer(WebGl2RenderingContext::FRAMEBUFFER, None);
         self.viewport_dimensions(dimensions);
     }
 
@@ -59,8 +64,11 @@ impl WebGlWrapper {
     //     self.disable(WebGl2RenderingContext::BLEND);
     // }
 
-    pub fn premultiplied_blend_mode(&self){
+    pub fn premultiplied_blend_mode(&self) {
         self.enable(WebGl2RenderingContext::BLEND);
-        self.blend_func(WebGl2RenderingContext::ONE, WebGl2RenderingContext::ONE_MINUS_SRC_ALPHA);
+        self.blend_func(
+            WebGl2RenderingContext::ONE,
+            WebGl2RenderingContext::ONE_MINUS_SRC_ALPHA,
+        );
     }
 }

--- a/ext/benches/load_resolution.rs
+++ b/ext/benches/load_resolution.rs
@@ -1,6 +1,5 @@
 use algebra::Algebra;
-use ext::chain_complex::ChainComplex;
-use ext::utils::construct;
+use ext::{chain_complex::ChainComplex, utils::construct};
 use sseq::coordinates::Bidegree;
 
 fn main() {

--- a/ext/benches/resolve.rs
+++ b/ext/benches/resolve.rs
@@ -1,8 +1,7 @@
-use ext::chain_complex::ChainComplex;
-use ext::utils::construct;
+use std::{io::Write, time::Instant};
+
+use ext::{chain_complex::ChainComplex, utils::construct};
 use sseq::coordinates::Bidegree;
-use std::io::Write;
-use std::time::Instant;
 
 fn benchmark(module_name: &str, max_degree: i32, algebra: &str, n_times: u128) {
     print!("benchmark  {algebra:6}  {module_name}  {max_degree}:    ");

--- a/ext/benches/resolve_concurrent.rs
+++ b/ext/benches/resolve_concurrent.rs
@@ -1,10 +1,9 @@
 #[cfg(feature = "concurrent")]
 fn benchmark(algebra: &str) {
-    use ext::chain_complex::ChainComplex;
-    use ext::utils::construct;
+    use std::{io::Write, time::Instant};
+
+    use ext::{chain_complex::ChainComplex, utils::construct};
     use sseq::coordinates::Bidegree;
-    use std::io::Write;
-    use std::time::Instant;
 
     let resolution = construct(("S_2", algebra), None).unwrap();
 

--- a/ext/benches/secondary.rs
+++ b/ext/benches/secondary.rs
@@ -1,12 +1,10 @@
 //! This example uses secondary.rs to compute d_2 on x_{65, 4}. The code is similar to that in the
 //! secondary command, but with hardcoded values. I also use this for performance benchmarking.
 
-use ext::chain_complex::ChainComplex;
-use ext::secondary::*;
-use ext::utils::construct;
+use std::{sync::Arc, time::Instant};
+
+use ext::{chain_complex::ChainComplex, secondary::*, utils::construct};
 use sseq::coordinates::Bidegree;
-use std::sync::Arc;
-use std::time::Instant;
 
 fn main() {
     // Attempt to load a resolution of S_2 from resolution_milnor.save, and generates one from

--- a/ext/crates/algebra/src/algebra/adem_algebra.rs
+++ b/ext/crates/algebra/src/algebra/adem_algebra.rs
@@ -2,21 +2,23 @@
 
 use std::fmt;
 
-use itertools::Itertools;
-use rustc_hash::FxHashMap as HashMap;
-
-use fp::prime::{
-    iter::{BinomialIterator, BitflagIterator},
-    Prime, ValidPrime,
+use fp::{
+    prime::{
+        iter::{BinomialIterator, BitflagIterator},
+        Prime, ValidPrime,
+    },
+    vector::{FpVector, SliceMut},
 };
-use fp::vector::{FpVector, SliceMut};
+use itertools::Itertools;
 use once::OnceVec;
-
-use crate::algebra::combinatorics::{self, MAX_XI_TAU};
-use crate::algebra::{Algebra, Bialgebra, GeneratedAlgebra, UnstableAlgebra};
+use rustc_hash::FxHashMap as HashMap;
 
 #[cfg(doc)]
 use crate::algebra::SteenrodAlgebra;
+use crate::algebra::{
+    combinatorics::{self, MAX_XI_TAU},
+    Algebra, Bialgebra, GeneratedAlgebra, UnstableAlgebra,
+};
 
 /// An algebra that can be viewed as an Adem algebra.
 ///
@@ -288,8 +290,9 @@ impl Algebra for AdemAlgebra {
     }
 
     fn basis_element_from_string(&self, mut elt: &str) -> Option<(i32, usize)> {
-        use crate::steenrod_parser::{digits, p_or_sq};
         use nom::sequence::preceded;
+
+        use crate::steenrod_parser::{digits, p_or_sq};
 
         let q = self.q();
 
@@ -1432,9 +1435,11 @@ impl Bialgebra for AdemAlgebra {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use rstest::rstest;
     use std::fmt::Write as _; // Needed for write! macro for String
+
+    use rstest::rstest;
+
+    use super::*;
 
     #[rstest(p, max_degree, case(2, 32), case(3, 120))]
     #[trace]

--- a/ext/crates/algebra/src/algebra/algebra_trait.rs
+++ b/ext/crates/algebra/src/algebra/algebra_trait.rs
@@ -1,10 +1,11 @@
-use fp::prime::ValidPrime;
-use fp::vector::{Slice, SliceMut};
-
 use std::fmt::Write as _; // Needed for write! macro for String
 
 #[cfg(doc)]
 use fp::vector::FpVector;
+use fp::{
+    prime::ValidPrime,
+    vector::{Slice, SliceMut},
+};
 
 /// A graded algebra over $\mathbb{F}_p$.
 ///
@@ -532,7 +533,7 @@ pub trait GeneratedAlgebra: Algebra {
 
 #[macro_export]
 macro_rules! dispatch_algebra {
-    ($struct:ty, $dispatch_macro: ident) => {
+    ($struct:ty, $dispatch_macro:ident) => {
         impl Algebra for $struct {
             $dispatch_macro! {
                 fn prefix(&self) -> &str;

--- a/ext/crates/algebra/src/algebra/combinatorics.rs
+++ b/ext/crates/algebra/src/algebra/combinatorics.rs
@@ -1,8 +1,10 @@
-use fp::vector::FpVector;
+use fp::{
+    const_for,
+    prime::{minus_one_to_the_n, Binomial, Prime, ValidPrime},
+    vector::FpVector,
+    MAX_MULTINOMIAL_LEN, NUM_PRIMES, PRIMES, PRIME_TO_INDEX_MAP,
+};
 use once::OnceVec;
-
-use fp::prime::{minus_one_to_the_n, Binomial, Prime, ValidPrime};
-use fp::{const_for, MAX_MULTINOMIAL_LEN, NUM_PRIMES, PRIMES, PRIME_TO_INDEX_MAP};
 
 pub const MAX_XI_TAU: usize = MAX_MULTINOMIAL_LEN;
 
@@ -293,6 +295,7 @@ impl<'a> PartitionIterator<'a> {
 
 impl<'a> Iterator for PartitionIterator<'a> {
     type Item = (i32, &'a Vec<u32>);
+
     fn next(&mut self) -> Option<Self::Item> {
         let found;
         if self.initial {

--- a/ext/crates/algebra/src/algebra/field.rs
+++ b/ext/crates/algebra/src/algebra/field.rs
@@ -1,8 +1,11 @@
 //! Finite fields over a prime.
 
+use fp::{
+    prime::ValidPrime,
+    vector::{Slice, SliceMut},
+};
+
 use crate::algebra::{Algebra, Bialgebra};
-use fp::prime::ValidPrime;
-use fp::vector::{Slice, SliceMut};
 
 /// $\mathbb{F}_p$, viewed as an [`Algebra`] over itself.
 ///
@@ -72,6 +75,7 @@ impl Bialgebra for Field {
     fn coproduct(&self, _op_deg: i32, _op_idx: usize) -> Vec<(i32, usize, i32, usize)> {
         vec![(1, 0, 1, 0)]
     }
+
     fn decompose(&self, _op_deg: i32, _op_idx: usize) -> Vec<(i32, usize)> {
         vec![(1, 0)]
     }

--- a/ext/crates/algebra/src/algebra/milnor_algebra.rs
+++ b/ext/crates/algebra/src/algebra/milnor_algebra.rs
@@ -1,15 +1,15 @@
-use fp::prime::Prime;
-use itertools::Itertools;
-use rustc_hash::FxHashMap as HashMap;
 use std::cell::Cell;
 
-use crate::algebra::combinatorics;
-use crate::algebra::{Algebra, Bialgebra, GeneratedAlgebra, UnstableAlgebra};
-use fp::prime::{factor_pk, iter::BitflagIterator, Binomial, ValidPrime};
-use fp::vector::{FpVector, Slice, SliceMut};
+use fp::{
+    prime::{factor_pk, iter::BitflagIterator, Binomial, Prime, ValidPrime},
+    vector::{FpVector, Slice, SliceMut},
+};
+use itertools::Itertools;
 use once::OnceVec;
+use rustc_hash::FxHashMap as HashMap;
+use serde::{Deserialize, Serialize};
 
-use {serde::Deserialize, serde::Serialize};
+use crate::algebra::{combinatorics, Algebra, Bialgebra, GeneratedAlgebra, UnstableAlgebra};
 
 // This is here so that the Python bindings can use modules defined for AdemAlgebraT with their own algebra enum.
 // In order for things to work AdemAlgebraT cannot implement Algebra.
@@ -581,7 +581,6 @@ impl Algebra for MilnorAlgebra {
     }
 
     fn basis_element_from_string(&self, elt: &str) -> Option<(i32, usize)> {
-        use crate::steenrod_parser::{brackets, digits, p_or_sq};
         use nom::{
             branch::alt,
             bytes::complete::tag,
@@ -590,6 +589,8 @@ impl Algebra for MilnorAlgebra {
             multi::{many0, separated_list1},
             sequence::{preceded, tuple},
         };
+
+        use crate::steenrod_parser::{brackets, digits, p_or_sq};
 
         let p = self.prime();
 
@@ -1793,6 +1794,7 @@ impl Bialgebra for MilnorAlgebra {
         }
         result
     }
+
     fn decompose(&self, op_deg: i32, op_idx: usize) -> Vec<(i32, usize)> {
         vec![(op_deg, op_idx)]
     }
@@ -1800,11 +1802,12 @@ impl Bialgebra for MilnorAlgebra {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use std::fmt::Write as _; // Needed for write! macro for String
 
     use expect_test::expect;
     use rstest::rstest;
-    use std::fmt::Write as _; // Needed for write! macro for String
+
+    use super::*;
 
     #[rstest]
     #[trace]

--- a/ext/crates/algebra/src/algebra/pair_algebra.rs
+++ b/ext/crates/algebra/src/algebra/pair_algebra.rs
@@ -6,11 +6,13 @@
 //! To keep the pair algebra business contained, we put the implementation of the Milnor algebra as
 //! a pair algebra in this file instead of `milnor_algebra.rs`.
 
-use crate::combinatorics;
-use crate::Algebra;
-use fp::prime::TWO;
-use fp::vector::{FpVector, Slice, SliceMut};
+use fp::{
+    prime::TWO,
+    vector::{FpVector, Slice, SliceMut},
+};
 use rustc_hash::FxHasher;
+
+use crate::{combinatorics, Algebra};
 
 type HashMap<K, V> = hashbrown::HashMap<K, V, std::hash::BuildHasherDefault<FxHasher>>;
 
@@ -88,9 +90,12 @@ pub trait PairAlgebra: Algebra {
     ) -> std::io::Result<Self::Element>;
 }
 
-use crate::milnor_algebra::{MilnorBasisElement as MilnorElt, PPartAllocation, PPartMultiplier};
-use crate::MilnorAlgebra;
 use std::cell::RefCell;
+
+use crate::{
+    milnor_algebra::{MilnorBasisElement as MilnorElt, PPartAllocation, PPartMultiplier},
+    MilnorAlgebra,
+};
 
 macro_rules! sub {
     ($elt:ident, $k:expr, $n:expr) => {
@@ -429,9 +434,10 @@ fn a_y_inner(algebra: &MilnorAlgebra, a: &MilnorElt, k: usize, l: usize) -> FpVe
 
 #[cfg(test)]
 mod test {
+    use expect_test::{expect, Expect};
+
     use super::*;
     use crate::milnor_algebra::PPartEntry;
-    use expect_test::{expect, Expect};
 
     fn from_p_part(p_part: &[PPartEntry]) -> MilnorElt {
         let degree = p_part

--- a/ext/crates/algebra/src/algebra/polynomial_algebra.rs
+++ b/ext/crates/algebra/src/algebra/polynomial_algebra.rs
@@ -1,13 +1,14 @@
-use itertools::Itertools;
-use rustc_hash::FxHashMap as HashMap;
 use std::fmt;
 
-use fp::prime::{Prime, ValidPrime};
-use fp::vector::{FpVector, SliceMut};
+use fp::{
+    prime::{Prime, ValidPrime},
+    vector::{FpVector, SliceMut},
+};
+use itertools::Itertools;
 use once::OnceVec;
+use rustc_hash::FxHashMap as HashMap;
 
-use crate::algebra::combinatorics::TruncatedPolynomialMonomialBasis;
-use crate::algebra::Algebra;
+use crate::algebra::{combinatorics::TruncatedPolynomialMonomialBasis, Algebra};
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct PolynomialAlgebraMonomial {

--- a/ext/crates/algebra/src/algebra/steenrod_algebra.rs
+++ b/ext/crates/algebra/src/algebra/steenrod_algebra.rs
@@ -1,15 +1,20 @@
-use crate::algebra::{
-    AdemAlgebra, AdemAlgebraT, Algebra, Bialgebra, GeneratedAlgebra, MilnorAlgebra, MilnorAlgebraT,
-};
-use crate::dispatch_algebra;
-use fp::prime::ValidPrime;
-use fp::vector::{Slice, SliceMut};
-
-use anyhow::anyhow;
-
 use std::io::{Read, Write};
 
-use {serde::Deserialize, serde_json::Value};
+use anyhow::anyhow;
+use fp::{
+    prime::ValidPrime,
+    vector::{Slice, SliceMut},
+};
+use serde::Deserialize;
+use serde_json::Value;
+
+use crate::{
+    algebra::{
+        AdemAlgebra, AdemAlgebraT, Algebra, Bialgebra, GeneratedAlgebra, MilnorAlgebra,
+        MilnorAlgebraT,
+    },
+    dispatch_algebra,
+};
 
 // This is here so that the Python bindings can use modules defined aor SteenrodAlgebraT with their own algebra enum.
 // In order for things to work SteenrodAlgebraT cannot implement Algebra.
@@ -105,6 +110,7 @@ impl<A: SteenrodAlgebraT> MilnorAlgebraT for A {
 
 impl<'a> TryInto<&'a AdemAlgebra> for &'a SteenrodAlgebra {
     type Error = anyhow::Error;
+
     fn try_into(self) -> Result<&'a AdemAlgebra, Self::Error> {
         match self {
             SteenrodAlgebra::AdemAlgebra(a) => Ok(a),
@@ -117,6 +123,7 @@ impl<'a> TryInto<&'a AdemAlgebra> for &'a SteenrodAlgebra {
 
 impl<'a> TryInto<&'a MilnorAlgebra> for &'a SteenrodAlgebra {
     type Error = anyhow::Error;
+
     fn try_into(self) -> Result<&'a MilnorAlgebra, Self::Error> {
         match self {
             SteenrodAlgebra::MilnorAlgebra(a) => Ok(a),
@@ -273,13 +280,6 @@ impl crate::pair_algebra::PairAlgebra for AdemAlgebra {
 impl crate::pair_algebra::PairAlgebra for SteenrodAlgebra {
     type Element = crate::pair_algebra::MilnorPairElement;
 
-    fn element_is_zero(elt: &Self::Element) -> bool {
-        MilnorAlgebra::element_is_zero(elt)
-    }
-    fn finalize_element(elt: &mut Self::Element) {
-        MilnorAlgebra::finalize_element(elt);
-    }
-
     dispatch_steenrod! {
         fn p_tilde(&self) -> usize;
         fn new_pair_element(&self, degree: i32) -> Self::Element;
@@ -288,6 +288,14 @@ impl crate::pair_algebra::PairAlgebra for SteenrodAlgebra {
         fn a_multiply(&self, result: SliceMut, coeff: u32, r_degree: i32, r: Slice, s_degree: i32, s: &Self::Element);
         fn element_to_bytes(&self, elt: &Self::Element, buffer: &mut impl Write) -> std::io::Result<()>;
         fn element_from_bytes(&self, degree: i32, buffer: &mut impl Read) -> std::io::Result<Self::Element>;
+    }
+
+    fn element_is_zero(elt: &Self::Element) -> bool {
+        MilnorAlgebra::element_is_zero(elt)
+    }
+
+    fn finalize_element(elt: &mut Self::Element) {
+        MilnorAlgebra::finalize_element(elt);
     }
 }
 

--- a/ext/crates/algebra/src/module/block_structure.rs
+++ b/ext/crates/algebra/src/module/block_structure.rs
@@ -1,6 +1,7 @@
+use std::ops::Range;
+
 use bivec::BiVec;
 use fp::vector::{Slice, SliceMut};
-use std::ops::Range;
 
 #[derive(Debug)]
 pub struct GeneratorBasisEltPair {

--- a/ext/crates/algebra/src/module/finite_dimensional_module.rs
+++ b/ext/crates/algebra/src/module/finite_dimensional_module.rs
@@ -1,17 +1,14 @@
-use crate::algebra::Algebra;
-use crate::module::{Module, ZeroModule};
+use std::{fmt::Write as _, sync::Arc};
+
+use anyhow::{anyhow, Context};
 use bivec::BiVec;
 use fp::vector::{FpVector, SliceMut};
+use serde::Deserialize;
+use serde_json::{json, value::Value};
 
-use std::fmt::Write as _;
-use std::sync::Arc;
-
-use {
-    crate::algebra::GeneratedAlgebra,
-    crate::module::ModuleFailedRelationError,
-    anyhow::{anyhow, Context},
-    serde::Deserialize,
-    serde_json::{json, value::Value},
+use crate::{
+    algebra::{Algebra, GeneratedAlgebra},
+    module::{Module, ModuleFailedRelationError, ZeroModule},
 };
 
 pub struct FiniteDimensionalModule<A: Algebra> {
@@ -70,11 +67,11 @@ impl<A: Algebra> FiniteDimensionalModule<A> {
                 }
             }
             if !disagreements.is_empty() {
-                return Err(format!("Graded dimensions disagree in positions {:?}. Left has graded dimensions:\n    {:?}\nRight has graded dimension:\n    {:?}\n",
-                disagreements,
-                self.graded_dimension,
-                other.graded_dimension
-            ));
+                return Err(format!(
+                    "Graded dimensions disagree in positions {:?}. Left has graded \
+                        dimensions:\n    {:?}\nRight has graded dimension:\n    {:?}\n",
+                    disagreements, self.graded_dimension, other.graded_dimension
+                ));
             }
         }
         let max_degree = std::cmp::min(self.actions.len(), other.actions.len());
@@ -681,9 +678,10 @@ impl<A: GeneratedAlgebra> FiniteDimensionalModule<A> {
 
 #[cfg(test)]
 mod tests {
+    use bivec::BiVec;
+
     use super::*;
     use crate::algebra::AdemAlgebra;
-    use bivec::BiVec;
 
     #[test]
     fn test_module_check_validity() {

--- a/ext/crates/algebra/src/module/free_module.rs
+++ b/ext/crates/algebra/src/module/free_module.rs
@@ -1,9 +1,12 @@
 use std::sync::Arc;
 
-use crate::algebra::MuAlgebra;
-use crate::module::{Module, ZeroModule};
 use fp::vector::{Slice, SliceMut};
 use once::{OnceBiVec, OnceVec};
+
+use crate::{
+    algebra::MuAlgebra,
+    module::{Module, ZeroModule},
+};
 
 #[derive(Clone, Debug)]
 pub struct OperationGeneratorPair {

--- a/ext/crates/algebra/src/module/hom_module.rs
+++ b/ext/crates/algebra/src/module/hom_module.rs
@@ -1,12 +1,13 @@
 use std::sync::Arc;
 
 use bivec::BiVec;
-
-use crate::algebra::Field;
-use crate::module::block_structure::BlockStructure;
-use crate::module::{FreeModule, Module};
 use fp::vector::SliceMut;
 use once::OnceBiVec;
+
+use crate::{
+    algebra::Field,
+    module::{block_structure::BlockStructure, FreeModule, Module},
+};
 
 /// Given a module N and a free module M, this is the module Hom(M, N) as a module over the ground
 /// field. This requires N to be bounded, and is graded *opposite* to the usual grading so that
@@ -121,8 +122,7 @@ impl<M: Module> Module for HomModule<M> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::module::FDModule;
-    use crate::MilnorAlgebra;
+    use crate::{module::FDModule, MilnorAlgebra};
 
     #[test]
     fn test_hom_dim() {

--- a/ext/crates/algebra/src/module/homomorphism/free_module_homomorphism.rs
+++ b/ext/crates/algebra/src/module/homomorphism/free_module_homomorphism.rs
@@ -1,12 +1,19 @@
 use std::sync::Arc;
 
-use crate::algebra::MuAlgebra;
-use crate::module::free_module::OperationGeneratorPair;
-use crate::module::homomorphism::{ModuleHomomorphism, ZeroHomomorphism};
-use crate::module::{Module, MuFreeModule};
-use fp::matrix::{MatrixSliceMut, QuasiInverse, Subspace};
-use fp::vector::{FpVector, Slice, SliceMut};
+use fp::{
+    matrix::{MatrixSliceMut, QuasiInverse, Subspace},
+    vector::{FpVector, Slice, SliceMut},
+};
 use once::OnceBiVec;
+
+use crate::{
+    algebra::MuAlgebra,
+    module::{
+        free_module::OperationGeneratorPair,
+        homomorphism::{ModuleHomomorphism, ZeroHomomorphism},
+        Module, MuFreeModule,
+    },
+};
 
 pub type FreeModuleHomomorphism<M> = MuFreeModuleHomomorphism<false, M>;
 pub type UnstableFreeModuleHomomorphism<M> = MuFreeModuleHomomorphism<true, M>;

--- a/ext/crates/algebra/src/module/homomorphism/full_module_homomorphism.rs
+++ b/ext/crates/algebra/src/module/homomorphism/full_module_homomorphism.rs
@@ -1,12 +1,19 @@
 use std::sync::Arc;
 
-use crate::algebra::Algebra;
-use crate::module::homomorphism::{IdentityHomomorphism, ModuleHomomorphism, ZeroHomomorphism};
-use crate::module::Module;
 use bivec::BiVec;
-use fp::matrix::{Matrix, QuasiInverse, Subspace};
-use fp::vector::SliceMut;
+use fp::{
+    matrix::{Matrix, QuasiInverse, Subspace},
+    vector::SliceMut,
+};
 use once::OnceBiVec;
+
+use crate::{
+    algebra::Algebra,
+    module::{
+        homomorphism::{IdentityHomomorphism, ModuleHomomorphism, ZeroHomomorphism},
+        Module,
+    },
+};
 
 /// A ModuleHomomorphism that simply records the matrix of the homomorphism in every degree.
 /// This is currently rather bare bones.

--- a/ext/crates/algebra/src/module/homomorphism/generic_zero_homomorphism.rs
+++ b/ext/crates/algebra/src/module/homomorphism/generic_zero_homomorphism.rs
@@ -1,7 +1,11 @@
-use crate::module::homomorphism::{ModuleHomomorphism, ZeroHomomorphism};
-use crate::module::Module;
-use fp::vector::SliceMut;
 use std::sync::Arc;
+
+use fp::vector::SliceMut;
+
+use crate::module::{
+    homomorphism::{ModuleHomomorphism, ZeroHomomorphism},
+    Module,
+};
 
 pub struct GenericZeroHomomorphism<S: Module, T: Module<Algebra = S::Algebra>> {
     source: Arc<S>,

--- a/ext/crates/algebra/src/module/homomorphism/hom_pullback.rs
+++ b/ext/crates/algebra/src/module/homomorphism/hom_pullback.rs
@@ -1,12 +1,16 @@
 use std::sync::Arc;
 
-use crate::module::block_structure::GeneratorBasisEltPair;
-use crate::module::homomorphism::{FreeModuleHomomorphism, ModuleHomomorphism};
-use crate::module::HomModule;
-use crate::module::{FreeModule, Module};
-use fp::matrix::{QuasiInverse, Subspace};
-use fp::vector::SliceMut;
+use fp::{
+    matrix::{QuasiInverse, Subspace},
+    vector::SliceMut,
+};
 use once::OnceBiVec;
+
+use crate::module::{
+    block_structure::GeneratorBasisEltPair,
+    homomorphism::{FreeModuleHomomorphism, ModuleHomomorphism},
+    FreeModule, HomModule, Module,
+};
 
 /// Given a map $\mathtt{map}: A \to B$ and hom modules $\mathtt{source} = \Hom(B, X)$, $\mathtt{target} = \Hom(A, X)$, produce the induced pullback map $\Hom(B, X) \to \Hom(A, X)$.
 pub struct HomPullback<M: Module> {
@@ -137,12 +141,11 @@ impl<M: Module> ModuleHomomorphism for HomPullback<M> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::module::FDModule;
-    use crate::MilnorAlgebra;
     use bivec::BiVec;
-    use fp::matrix::Matrix;
-    use fp::vector::FpVector;
+    use fp::{matrix::Matrix, vector::FpVector};
+
+    use super::*;
+    use crate::{module::FDModule, MilnorAlgebra};
 
     #[test]
     fn test_pullback_id() {

--- a/ext/crates/algebra/src/module/homomorphism/mod.rs
+++ b/ext/crates/algebra/src/module/homomorphism/mod.rs
@@ -1,9 +1,12 @@
 use std::sync::Arc;
 
+use fp::{
+    matrix::{AugmentedMatrix, Matrix, MatrixSliceMut, QuasiInverse, Subspace},
+    prime::ValidPrime,
+    vector::{Slice, SliceMut},
+};
+
 use crate::module::Module;
-use fp::matrix::{AugmentedMatrix, Matrix, MatrixSliceMut, QuasiInverse, Subspace};
-use fp::prime::ValidPrime;
-use fp::vector::{Slice, SliceMut};
 
 mod free_module_homomorphism;
 mod full_module_homomorphism;
@@ -17,10 +20,9 @@ pub use free_module_homomorphism::{
 pub use full_module_homomorphism::FullModuleHomomorphism;
 pub use generic_zero_homomorphism::GenericZeroHomomorphism;
 pub use hom_pullback::HomPullback;
-pub use quotient_homomorphism::{QuotientHomomorphism, QuotientHomomorphismSource};
-
 #[allow(unused_imports)]
 use maybe_rayon::prelude::*;
+pub use quotient_homomorphism::{QuotientHomomorphism, QuotientHomomorphismSource};
 
 /// Each `ModuleHomomorphism` may come with auxiliary data, namely the kernel, image and
 /// quasi_inverse at each degree (the quasi-inverse is a map that is a right inverse when

--- a/ext/crates/algebra/src/module/homomorphism/quotient_homomorphism.rs
+++ b/ext/crates/algebra/src/module/homomorphism/quotient_homomorphism.rs
@@ -1,8 +1,8 @@
-use crate::module::{Module, QuotientModule};
-use fp::vector::{FpVector, SliceMut};
 use std::sync::Arc;
 
-use crate::module::homomorphism::ModuleHomomorphism;
+use fp::vector::{FpVector, SliceMut};
+
+use crate::module::{homomorphism::ModuleHomomorphism, Module, QuotientModule};
 
 pub struct QuotientHomomorphism<F: ModuleHomomorphism> {
     f: Arc<F>,
@@ -27,9 +27,11 @@ impl<F: ModuleHomomorphism> ModuleHomomorphism for QuotientHomomorphism<F> {
     fn source(&self) -> Arc<Self::Source> {
         Arc::clone(&self.s)
     }
+
     fn target(&self) -> Arc<Self::Target> {
         Arc::clone(&self.t)
     }
+
     fn degree_shift(&self) -> i32 {
         self.f.degree_shift()
     }

--- a/ext/crates/algebra/src/module/mod.rs
+++ b/ext/crates/algebra/src/module/mod.rs
@@ -20,12 +20,11 @@ pub use finitely_presented_module::FinitelyPresentedModule as FPModule;
 pub use free_module::{
     FreeModule, GeneratorData, MuFreeModule, OperationGeneratorPair, UnstableFreeModule,
 };
+pub use hom_module::HomModule;
 pub use module_trait::{Module, ModuleFailedRelationError};
+pub use quotient_module::QuotientModule;
 pub use rpn::RealProjectiveSpace;
 pub use steenrod_module::SteenrodModule;
+pub use suspension_module::SuspensionModule;
+pub use tensor_module::TensorModule;
 pub use zero_module::ZeroModule;
-
-pub use {
-    hom_module::HomModule, quotient_module::QuotientModule, suspension_module::SuspensionModule,
-    tensor_module::TensorModule,
-};

--- a/ext/crates/algebra/src/module/module_trait.rs
+++ b/ext/crates/algebra/src/module/module_trait.rs
@@ -1,9 +1,11 @@
-use auto_impl::auto_impl;
-use itertools::Itertools;
 use std::sync::Arc;
 
-use fp::prime::ValidPrime;
-use fp::vector::{Slice, SliceMut};
+use auto_impl::auto_impl;
+use fp::{
+    prime::ValidPrime,
+    vector::{Slice, SliceMut},
+};
+use itertools::Itertools;
 
 use crate::algebra::Algebra;
 

--- a/ext/crates/algebra/src/module/quotient_module.rs
+++ b/ext/crates/algebra/src/module/quotient_module.rs
@@ -1,8 +1,12 @@
-use crate::module::{Module, ZeroModule};
-use bivec::BiVec;
-use fp::matrix::Subspace;
-use fp::vector::{FpVector, Slice, SliceMut};
 use std::sync::Arc;
+
+use bivec::BiVec;
+use fp::{
+    matrix::Subspace,
+    vector::{FpVector, Slice, SliceMut},
+};
+
+use crate::module::{Module, ZeroModule};
 
 /// A quotient of a module truncated below a fix degree.
 pub struct QuotientModule<M: Module> {
@@ -133,6 +137,7 @@ impl<M: Module> QuotientModule<M> {
 
 impl<M: Module> Module for QuotientModule<M> {
     type Algebra = M::Algebra;
+
     fn algebra(&self) -> Arc<Self::Algebra> {
         self.module.algebra()
     }

--- a/ext/crates/algebra/src/module/rpn.rs
+++ b/ext/crates/algebra/src/module/rpn.rs
@@ -1,15 +1,20 @@
-use crate::algebra::{
-    adem_algebra::AdemBasisElement,
-    milnor_algebra::{MilnorBasisElement, PPartEntry},
-    AdemAlgebra, Algebra, MilnorAlgebra, SteenrodAlgebra,
-};
-use crate::module::{Module, ZeroModule};
-use fp::prime::{Binomial, TWO};
-use fp::vector::SliceMut;
-
 use std::sync::Arc;
 
-use {serde::Deserialize, serde_json::Value};
+use fp::{
+    prime::{Binomial, TWO},
+    vector::SliceMut,
+};
+use serde::Deserialize;
+use serde_json::Value;
+
+use crate::{
+    algebra::{
+        adem_algebra::AdemBasisElement,
+        milnor_algebra::{MilnorBasisElement, PPartEntry},
+        AdemAlgebra, Algebra, MilnorAlgebra, SteenrodAlgebra,
+    },
+    module::{Module, ZeroModule},
+};
 
 /// This is $\mathbb{RP}_{\mathrm{min}}^{\mathrm{max}}$. The cohomology is the subquotient of
 /// $\mathbb{F}_2[x^\pm]$ given by elements of degree between min and max (inclusive)

--- a/ext/crates/algebra/src/module/steenrod_module.rs
+++ b/ext/crates/algebra/src/module/steenrod_module.rs
@@ -3,11 +3,12 @@ use crate::algebra::SteenrodAlgebra;
 pub type SteenrodModule = Box<dyn Module<Algebra = SteenrodAlgebra>>;
 
 mod json {
-    use super::*;
-
-    use crate::module::{FDModule, FPModule, RealProjectiveSpace, SuspensionModule};
-    use anyhow::anyhow;
     use std::sync::Arc;
+
+    use anyhow::anyhow;
+
+    use super::*;
+    use crate::module::{FDModule, FPModule, RealProjectiveSpace, SuspensionModule};
 
     pub fn from_json(
         algebra: Arc<SteenrodAlgebra>,

--- a/ext/crates/algebra/src/module/suspension_module.rs
+++ b/ext/crates/algebra/src/module/suspension_module.rs
@@ -1,5 +1,6 @@
-use crate::module::{Module, ZeroModule};
 use std::sync::Arc;
+
+use crate::module::{Module, ZeroModule};
 
 pub struct SuspensionModule<M: Module> {
     inner: Arc<M>,

--- a/ext/crates/algebra/src/module/tensor_module.rs
+++ b/ext/crates/algebra/src/module/tensor_module.rs
@@ -1,13 +1,16 @@
+use std::sync::Arc;
+
 use bivec::BiVec;
+use fp::{
+    prime::minus_one_to_the_n,
+    vector::{FpVector, Slice, SliceMut},
+};
 use once::OnceBiVec;
 
-use crate::algebra::{Algebra, Bialgebra};
-use crate::module::block_structure::BlockStructure;
-use crate::module::{Module, ZeroModule};
-use fp::prime::minus_one_to_the_n;
-use fp::vector::{FpVector, Slice, SliceMut};
-
-use std::sync::Arc;
+use crate::{
+    algebra::{Algebra, Bialgebra},
+    module::{block_structure::BlockStructure, Module, ZeroModule},
+};
 
 // This really only makes sense when the algebra is a bialgebra, but associated type bounds are
 // unstable. Since the methods are only defined when A is a bialgebra, this is not too much of a

--- a/ext/crates/algebra/src/module/zero_module.rs
+++ b/ext/crates/algebra/src/module/zero_module.rs
@@ -1,8 +1,9 @@
 use std::sync::Arc;
 
-use crate::module::Module;
-use crate::module::{FDModule, SteenrodModule};
-use crate::SteenrodAlgebra;
+use crate::{
+    module::{FDModule, Module, SteenrodModule},
+    SteenrodAlgebra,
+};
 
 pub trait ZeroModule: Module {
     fn zero_module(algebra: Arc<Self::Algebra>, min_degree: i32) -> Self;

--- a/ext/crates/algebra/src/steenrod_evaluator.rs
+++ b/ext/crates/algebra/src/steenrod_evaluator.rs
@@ -1,12 +1,16 @@
-use crate::algebra::adem_algebra::AdemBasisElement;
-use crate::algebra::{AdemAlgebra, Algebra, MilnorAlgebra};
-use crate::milnor_algebra::{MilnorBasisElement, PPartEntry};
-use crate::steenrod_parser::*;
-use fp::prime::{Prime, ValidPrime};
-use fp::vector::FpVector;
+use std::collections::BTreeMap;
 
 use anyhow::anyhow;
-use std::collections::BTreeMap;
+use fp::{
+    prime::{Prime, ValidPrime},
+    vector::FpVector,
+};
+
+use crate::{
+    algebra::{adem_algebra::AdemBasisElement, AdemAlgebra, Algebra, MilnorAlgebra},
+    milnor_algebra::{MilnorBasisElement, PPartEntry},
+    steenrod_parser::*,
+};
 
 pub struct SteenrodEvaluator {
     pub adem: AdemAlgebra,
@@ -388,10 +392,11 @@ impl SteenrodEvaluator {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use expect_test::{expect, Expect};
     use fp::prime::ValidPrime;
     use rstest::rstest;
+
+    use super::*;
 
     #[test]
     fn test_evaluate_2() {

--- a/ext/crates/algebra/src/steenrod_parser.rs
+++ b/ext/crates/algebra/src/steenrod_parser.rs
@@ -1,12 +1,13 @@
 //! This module includes code for parsing an expression in the Steenrod algebra into an abstract
 //! syntax tree.
 
+use std::str::FromStr;
+
 use anyhow::{anyhow, Context};
 use nom::{
     branch::alt,
     bytes::complete::tag,
-    character::complete::{alpha1, alphanumeric0, char},
-    character::complete::{digit1 as digit, space0},
+    character::complete::{alpha1, alphanumeric0, char, digit1 as digit, space0},
     combinator::{map, map_res, opt, peek},
     error::{context, ParseError, VerboseError, VerboseErrorKind},
     multi::{many0, separated_list1},
@@ -15,7 +16,6 @@ use nom::{
 };
 
 use crate::{adem_algebra::AdemBasisElement, algebra::milnor_algebra::PPart};
-use std::str::FromStr;
 
 type IResult<I, O> = IResultBase<I, O, VerboseError<I>>;
 
@@ -274,8 +274,9 @@ pub fn parse_module(i: &str) -> anyhow::Result<ModuleNode> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use expect_test::{expect, Expect};
+
+    use super::*;
 
     #[test]
     fn test_parse_algebra() {

--- a/ext/crates/bivec/src/lib.rs
+++ b/ext/crates/bivec/src/lib.rs
@@ -1,9 +1,10 @@
-use core::ops::Index;
-use core::ops::IndexMut;
+use core::ops::{Index, IndexMut};
+use std::{
+    fmt,
+    slice::{Iter, IterMut},
+};
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use std::fmt;
-use std::slice::{Iter, IterMut};
 
 /// A BiVec is like a Vec, except we allow indices to be negative. It has a min_degree
 /// property which tells us where the starting index is.
@@ -127,6 +128,7 @@ impl<T> BiVec<T> {
     pub fn last(&self) -> Option<&T> {
         self.data.last()
     }
+
     pub fn iter(&self) -> Iter<T> {
         self.data.iter()
     }
@@ -210,8 +212,8 @@ impl<T> BiVec<T> {
 }
 
 impl<T> IntoIterator for BiVec<T> {
-    type Item = T;
     type IntoIter = std::vec::IntoIter<T>;
+    type Item = T;
 
     fn into_iter(self) -> Self::IntoIter {
         self.data.into_iter()
@@ -219,8 +221,8 @@ impl<T> IntoIterator for BiVec<T> {
 }
 
 impl<'a, T> IntoIterator for &'a BiVec<T> {
-    type Item = &'a T;
     type IntoIter = std::slice::Iter<'a, T>;
+    type Item = &'a T;
 
     fn into_iter(self) -> Self::IntoIter {
         self.iter()
@@ -228,8 +230,8 @@ impl<'a, T> IntoIterator for &'a BiVec<T> {
 }
 
 impl<'a, T> IntoIterator for &'a mut BiVec<T> {
-    type Item = &'a mut T;
     type IntoIter = std::slice::IterMut<'a, T>;
+    type Item = &'a mut T;
 
     fn into_iter(self) -> Self::IntoIter {
         self.iter_mut()
@@ -265,6 +267,7 @@ impl<'de, T: Deserialize<'de>> Deserialize<'de> for BiVec<T> {
 
 impl<T> Index<i32> for BiVec<T> {
     type Output = T;
+
     fn index(&self, i: i32) -> &T {
         assert!(
             i >= self.min_degree(),

--- a/ext/crates/chart/src/lib.rs
+++ b/ext/crates/chart/src/lib.rs
@@ -1,7 +1,4 @@
-use std::collections::HashMap;
-use std::fmt::Display;
-use std::io::Write;
-use std::result::Result;
+use std::{collections::HashMap, fmt::Display, io::Write, result::Result};
 
 #[rustfmt::skip]
 const PATTERNS: [(f32, &[(f32, f32)]); 12] = [
@@ -114,6 +111,8 @@ pub struct SvgBackend<T: Write> {
 }
 
 impl<T: Write> SvgBackend<T> {
+    const GRID_WIDTH: i32 = 20;
+    const MARGIN: i32 = 30;
     const STYLES: &'static str = r#"
     circle {
         fill: black;
@@ -146,9 +145,6 @@ impl<T: Write> SvgBackend<T> {
      dominant-baseline: middle;
     }
     "#;
-
-    const GRID_WIDTH: i32 = 20;
-    const MARGIN: i32 = 30;
 
     /// Print the legend for node patterns
     pub fn legend(mut out: T) -> std::io::Result<()> {
@@ -204,6 +200,7 @@ impl<T: Write> SvgBackend<T> {
 
 impl<T: Write> Backend for SvgBackend<T> {
     type Error = std::io::Error;
+
     const EXT: &'static str = "svg";
 
     fn header(&mut self, max_x: i32, max_y: i32) -> Result<(), Self::Error> {
@@ -353,6 +350,7 @@ impl<T: Write> TikzBackend<T> {
 
 impl<T: Write> Backend for TikzBackend<T> {
     type Error = std::io::Error;
+
     const EXT: &'static str = "tex";
 
     fn header(&mut self, max_x: i32, max_y: i32) -> Result<(), Self::Error> {
@@ -440,8 +438,9 @@ impl<T: Write> Drop for TikzBackend<T> {
 
 #[cfg(test)]
 mod test {
-    use super::*;
     use expect_test::expect_file;
+
+    use super::*;
 
     #[test]
     fn test_legend() {

--- a/ext/crates/fp/src/constants.rs
+++ b/ext/crates/fp/src/constants.rs
@@ -4,7 +4,7 @@ build_const!("constants");
 
 #[macro_export]
 macro_rules! const_for {
-    ($i:ident in $a:literal .. $b:ident $contents:block) => {
+    ($i:ident in $a:literal.. $b:ident $contents:block) => {
         let mut $i = $a;
         while $i < $b {
             $contents;

--- a/ext/crates/fp/src/limb.rs
+++ b/ext/crates/fp/src/limb.rs
@@ -1,7 +1,6 @@
 use std::ops::Range;
 
 pub(crate) use crate::constants::Limb;
-
 use crate::{constants::BITS_PER_LIMB, prime::Prime};
 
 /// A struct containing the information required to access a specific entry in an array of `Limb`s.

--- a/ext/crates/fp/src/matrix/m4ri.rs
+++ b/ext/crates/fp/src/matrix/m4ri.rs
@@ -1,10 +1,12 @@
-use crate::constants::BITS_PER_LIMB;
-use crate::limb::{number, Limb};
-use crate::matrix::Matrix;
-use crate::prime::P2;
-use crate::simd;
-
 use itertools::Itertools;
+
+use crate::{
+    constants::BITS_PER_LIMB,
+    limb::{number, Limb},
+    matrix::Matrix,
+    prime::P2,
+    simd,
+};
 
 #[derive(Debug, Default)]
 /// M4RI works as follows --- first row reduce k rows using the naive algorithm. We then construct

--- a/ext/crates/fp/src/matrix/matrix_inner.rs
+++ b/ext/crates/fp/src/matrix/matrix_inner.rs
@@ -1,15 +1,18 @@
-use super::{QuasiInverse, Subspace};
-use crate::matrix::m4ri::M4riTable;
-use crate::prime::{self, ValidPrime};
-use crate::vector::{FpVector, Slice, SliceMut};
-
-use std::fmt;
-use std::io::{Read, Write};
-use std::ops::{Index, IndexMut};
+use std::{
+    fmt,
+    io::{Read, Write},
+    ops::{Index, IndexMut},
+};
 
 use itertools::Itertools;
-
 use maybe_rayon::prelude::*;
+
+use super::{QuasiInverse, Subspace};
+use crate::{
+    matrix::m4ri::M4riTable,
+    prime::{self, ValidPrime},
+    vector::{FpVector, Slice, SliceMut},
+};
 
 /// A matrix! In particular, a matrix with values in F_p. The way we store matrices means it is
 /// easier to perform row operations than column operations, and the way we use matrices means we
@@ -173,10 +176,10 @@ impl Matrix {
     /// # use fp::prime::ValidPrime;
     /// let p = ValidPrime::new(7);
     /// # use fp::matrix::Matrix;
-    /// let input  = [vec![1, 3, 6],
-    ///               vec![0, 3, 4]];
+    /// let input = [vec![1, 3, 6], vec![0, 3, 4]];
     ///
     /// let m = Matrix::from_vec(p, &input);
+    /// ```
     pub fn from_vec(p: ValidPrime, input: &[Vec<u32>]) -> Matrix {
         let rows = input.len();
         if rows == 0 {
@@ -289,8 +292,8 @@ impl Matrix {
 }
 
 impl<'a> IntoIterator for &'a Matrix {
-    type Item = &'a FpVector;
     type IntoIter = std::slice::Iter<'a, FpVector>;
+    type Item = &'a FpVector;
 
     fn into_iter(self) -> Self::IntoIter {
         self.iter()
@@ -298,8 +301,8 @@ impl<'a> IntoIterator for &'a Matrix {
 }
 
 impl<'a> IntoIterator for &'a mut Matrix {
-    type Item = &'a mut FpVector;
     type IntoIter = std::slice::IterMut<'a, FpVector>;
+    type Item = &'a mut FpVector;
 
     fn into_iter(self) -> Self::IntoIter {
         self.iter_mut()
@@ -311,11 +314,7 @@ impl fmt::Display for Matrix {
     /// ```
     /// # use fp::matrix::Matrix;
     /// # use fp::prime::ValidPrime;
-    /// let m = Matrix::from_vec(ValidPrime::new(2),
-    ///    &[
-    ///         vec![0, 1, 0],
-    ///         vec![1, 1, 0],
-    ///     ]);
+    /// let m = Matrix::from_vec(ValidPrime::new(2), &[vec![0, 1, 0], vec![1, 1, 0]]);
     /// assert_eq!(&format!("{m}"), "[\n    [0, 1, 0],\n    [1, 1, 0]\n]");
     /// assert_eq!(&format!("{m:#}"), "010\n110");
     /// ```
@@ -348,6 +347,7 @@ where
     Vec<FpVector>: Index<I>,
 {
     type Output = <Vec<FpVector> as Index<I>>::Output;
+
     /// Returns the ith row of the matrix
     fn index(&self, i: I) -> &Self::Output {
         &self.vectors[i]
@@ -499,11 +499,9 @@ impl Matrix {
     /// let p = ValidPrime::new(7);
     /// # use fp::matrix::Matrix;
     ///
-    /// let input  = [vec![1, 3, 6],
-    ///               vec![0, 3, 4]];
+    /// let input = [vec![1, 3, 6], vec![0, 3, 4]];
     ///
-    /// let result = [vec![1, 0, 2],
-    ///               vec![0, 1, 6]];
+    /// let result = [vec![1, 0, 2], vec![0, 1, 6]];
     ///
     /// let mut m = Matrix::from_vec(p, &input);
     /// m.row_reduce();
@@ -621,16 +619,17 @@ impl Matrix {
     /// let p = ValidPrime::new(3);
     /// # use fp::matrix::Matrix;
     /// # use fp::vector::FpVector;
-    /// let input  = [vec![1, 2, 1, 1, 0],
-    ///               vec![1, 0, 2, 1, 1],
-    ///               vec![2, 2, 0, 2, 1]];
+    /// let input = [
+    ///     vec![1, 2, 1, 1, 0],
+    ///     vec![1, 0, 2, 1, 1],
+    ///     vec![2, 2, 0, 2, 1],
+    /// ];
     ///
     /// let (padded_cols, mut m) = Matrix::augmented_from_vec(p, &input);
     /// m.row_reduce();
     /// let qi = m.compute_quasi_inverse(input[0].len(), padded_cols);
     ///
-    /// let preimage = [vec![0, 1, 0],
-    ///                 vec![0, 2, 2]];
+    /// let preimage = [vec![0, 1, 0], vec![0, 2, 2]];
     /// assert_eq!(qi.preimage(), &Matrix::from_vec(p, &preimage));
     /// ```
     pub fn compute_quasi_inverse(
@@ -664,17 +663,18 @@ impl Matrix {
     /// let p = ValidPrime::new(3);
     /// # use fp::matrix::Matrix;
     /// # use fp::vector::FpVector;
-    /// let input  = [vec![1, 2, 1, 1, 0],
-    ///               vec![1, 0, 2, 1, 1],
-    ///               vec![2, 2, 0, 2, 1]];
+    /// let input = [
+    ///     vec![1, 2, 1, 1, 0],
+    ///     vec![1, 0, 2, 1, 1],
+    ///     vec![2, 2, 0, 2, 1],
+    /// ];
     ///
     /// let (padded_cols, mut m) = Matrix::augmented_from_vec(p, &input);
     /// m.row_reduce();
     ///
     /// let computed_image = m.compute_image(input[0].len(), padded_cols);
     ///
-    /// let image = [vec![1, 0, 2, 1, 1],
-    ///              vec![0, 1, 1, 0, 1]];
+    /// let image = [vec![1, 0, 2, 1, 1], vec![0, 1, 1, 0, 1]];
     /// assert_eq!(computed_image.matrix, Matrix::from_vec(p, &image));
     /// assert_eq!(computed_image.pivots(), &vec![0, 1, -1, -1, -1]);
     /// ```
@@ -715,9 +715,11 @@ impl Matrix {
     /// let p = ValidPrime::new(3);
     /// # use fp::matrix::Matrix;
     /// # use fp::vector::FpVector;
-    /// let input  = [vec![1, 2, 1, 1, 0],
-    ///               vec![1, 0, 2, 1, 1],
-    ///               vec![2, 2, 0, 2, 1]];
+    /// let input = [
+    ///     vec![1, 2, 1, 1, 0],
+    ///     vec![1, 0, 2, 1, 1],
+    ///     vec![2, 2, 0, 2, 1],
+    /// ];
     ///
     /// let (padded_cols, mut m) = Matrix::augmented_from_vec(p, &input);
     /// m.row_reduce();
@@ -867,8 +869,7 @@ impl Matrix {
     /// let p = ValidPrime::new(7);
     /// # use fp::matrix::Matrix;
     /// # use fp::vector::FpVector;
-    /// let input  = [vec![1, 3, 6],
-    ///               vec![0, 3, 4]];
+    /// let input = [vec![1, 3, 6], vec![0, 3, 4]];
     ///
     /// let m = Matrix::from_vec(p, &input);
     /// let v = FpVector::from_slice(p, &vec![3, 1]);
@@ -1088,6 +1089,7 @@ impl AugmentedMatrix<3> {
             end: [self.end[1] - offset, self.end[2] - offset],
         }
     }
+
     /// This function computes quasi-inverses for matrices A, B given a reduced row echelon form of
     /// [A|0|B|0|I] such that A is surjective. Moreover, if Q is the quasi-inverse of A, it is
     /// guaranteed that the image of QB and B|_{ker A} are disjoint.

--- a/ext/crates/fp/src/matrix/quasi_inverse.rs
+++ b/ext/crates/fp/src/matrix/quasi_inverse.rs
@@ -1,10 +1,13 @@
-use super::Matrix;
-use crate::prime::ValidPrime;
-use crate::vector::{FpVector, Slice, SliceMut};
-use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use std::io::{Read, Write};
 
+use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use itertools::Itertools;
+
+use super::Matrix;
+use crate::{
+    prime::ValidPrime,
+    vector::{FpVector, Slice, SliceMut},
+};
 
 /// Given a matrix M, a quasi-inverse Q is a map from the co-domain to the domain such that xQM = x
 /// for all x in the image (recall our matrices act on the right).

--- a/ext/crates/fp/src/matrix/subquotient.rs
+++ b/ext/crates/fp/src/matrix/subquotient.rs
@@ -1,7 +1,9 @@
 use super::Subspace;
-use crate::matrix::Matrix;
-use crate::prime::ValidPrime;
-use crate::vector::{FpVector, Slice, SliceMut};
+use crate::{
+    matrix::Matrix,
+    prime::ValidPrime,
+    vector::{FpVector, Slice, SliceMut},
+};
 
 #[derive(Clone)]
 pub struct Subquotient {
@@ -177,8 +179,9 @@ impl Subquotient {
 
 #[cfg(test)]
 mod test {
-    use super::*;
     use expect_test::expect;
+
+    use super::*;
 
     #[test]
     fn test_add_gen() {

--- a/ext/crates/fp/src/matrix/subspace.rs
+++ b/ext/crates/fp/src/matrix/subspace.rs
@@ -1,9 +1,12 @@
-use super::Matrix;
-use crate::prime::ValidPrime;
-use crate::vector::{FpVector, Slice, SliceMut};
+use std::io::{Read, Write};
 
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
-use std::io::{Read, Write};
+
+use super::Matrix;
+use crate::{
+    prime::ValidPrime,
+    vector::{FpVector, Slice, SliceMut},
+};
 
 /// A subspace of a vector space.
 ///

--- a/ext/crates/fp/src/prime/binomial.rs
+++ b/ext/crates/fp/src/prime/binomial.rs
@@ -1,9 +1,8 @@
+use super::{Prime, ValidPrime};
 use crate::{
     constants::{BINOMIAL4_TABLE, BINOMIAL4_TABLE_SIZE, BINOMIAL_TABLE},
     PRIME_TO_INDEX_MAP,
 };
-
-use super::{Prime, ValidPrime};
 
 /// This uses a lookup table for n choose k when n and k are both less than p.
 /// Lucas's theorem reduces general binomial coefficients to this case.
@@ -35,7 +34,6 @@ pub trait Binomial: Sized {
     /// This is easy to verify using the fact that
     ///
     ///    (x + y)^{2^k} = x^{2^k} + 2 x^{2^{k - 1}} y^{2^{k - 1}} + y^{2^k}
-    ///
     fn binomial4(n: Self, k: Self) -> Self;
 
     /// Compute binomial coefficients mod 4 using the recursion relation in the documentation of
@@ -102,6 +100,7 @@ macro_rules! impl_binomial {
                     0
                 }
             }
+
             #[inline]
             fn multinomial_odd(p_: ValidPrime, l: &mut [Self]) -> Self {
                 let p = p_.as_u32() as Self;
@@ -179,6 +178,7 @@ macro_rules! impl_binomial {
                 }
                 false
             }
+
             fn binomial4(n: Self, j: Self) -> Self {
                 if (n as usize) < BINOMIAL4_TABLE_SIZE {
                     return BINOMIAL4_TABLE[n as usize][j as usize] as Self;

--- a/ext/crates/fp/src/prime/iter.rs
+++ b/ext/crates/fp/src/prime/iter.rs
@@ -26,6 +26,7 @@ impl BitflagIterator {
 
 impl Iterator for BitflagIterator {
     type Item = bool;
+
     fn next(&mut self) -> Option<Self::Item> {
         if self.remaining > 64 && self.flag == 0 || self.remaining == 0 {
             None
@@ -54,6 +55,7 @@ impl BinomialIterator {
 
 impl Iterator for BinomialIterator {
     type Item = u32;
+
     fn next(&mut self) -> Option<Self::Item> {
         let v = self.value;
         let c = v & v.wrapping_neg();

--- a/ext/crates/fp/src/prime/mod.rs
+++ b/ext/crates/fp/src/prime/mod.rs
@@ -107,6 +107,7 @@ macro_rules! def_prime_static {
             fn as_i32(self) -> i32 {
                 $p
             }
+
             #[inline]
             fn to_dyn(self) -> ValidPrime {
                 ValidPrime::new($p)

--- a/ext/crates/fp/src/vector/impl_fpvectorp.rs
+++ b/ext/crates/fp/src/vector/impl_fpvectorp.rs
@@ -1,14 +1,13 @@
 use itertools::Itertools;
 
+use super::{
+    inner::{FpVectorP, SliceMutP, SliceP},
+    iter::{FpVectorIterator, FpVectorNonZeroIteratorP},
+};
 use crate::{
     limb::{self, Limb},
     prime::{Prime, ValidPrime},
     simd,
-};
-
-use super::{
-    inner::{FpVectorP, SliceMutP, SliceP},
-    iter::{FpVectorIterator, FpVectorNonZeroIteratorP},
 };
 
 impl<P: Prime> FpVectorP<P> {

--- a/ext/crates/fp/src/vector/impl_slicemutp.rs
+++ b/ext/crates/fp/src/vector/impl_slicemutp.rs
@@ -2,13 +2,12 @@ use std::cmp::Ordering;
 
 use itertools::Itertools;
 
+use super::inner::{FpVectorP, SliceMutP, SliceP};
 use crate::{
     constants,
     limb::{self, Limb},
     prime::{Prime, ValidPrime, P2},
 };
-
-use super::inner::{FpVectorP, SliceMutP, SliceP};
 
 impl<'a, P: Prime> SliceMutP<'a, P> {
     pub fn prime(&self) -> ValidPrime {

--- a/ext/crates/fp/src/vector/impl_slicep.rs
+++ b/ext/crates/fp/src/vector/impl_slicep.rs
@@ -1,12 +1,11 @@
+use super::{
+    inner::{FpVectorP, SliceP},
+    iter::{FpVectorIterator, FpVectorNonZeroIteratorP},
+};
 use crate::{
     constants,
     limb::{self, Limb},
     prime::{Prime, ValidPrime},
-};
-
-use super::{
-    inner::{FpVectorP, SliceP},
-    iter::{FpVectorIterator, FpVectorNonZeroIteratorP},
 };
 
 // Public methods
@@ -67,6 +66,7 @@ impl<'a, P: Prime> SliceP<'a, P> {
         }
         true
     }
+
     #[must_use]
     pub fn slice(self, start: usize, end: usize) -> SliceP<'a, P> {
         assert!(start <= end && end <= self.len());

--- a/ext/crates/fp/src/vector/iter.rs
+++ b/ext/crates/fp/src/vector/iter.rs
@@ -1,9 +1,8 @@
+use super::inner::SliceP;
 use crate::{
     limb::{self, Limb},
     prime::Prime,
 };
-
-use super::inner::SliceP;
 
 pub struct FpVectorIterator<'a> {
     limbs: &'a [Limb],
@@ -84,6 +83,7 @@ impl<'a> FpVectorIterator<'a> {
 
 impl<'a> Iterator for FpVectorIterator<'a> {
     type Item = u32;
+
     fn next(&mut self) -> Option<Self::Item> {
         if self.counter == 0 {
             return None;
@@ -157,6 +157,7 @@ impl<'a, P: Prime> FpVectorNonZeroIteratorP<'a, P> {
 
 impl<'a, P: Prime> Iterator for FpVectorNonZeroIteratorP<'a, P> {
     type Item = (usize, u32);
+
     fn next(&mut self) -> Option<Self::Item> {
         let bit_length: usize = limb::bit_length(self.p);
         let bitmask: Limb = limb::bitmask(self.p);

--- a/ext/crates/fp/src/vector/mod.rs
+++ b/ext/crates/fp/src/vector/mod.rs
@@ -24,8 +24,10 @@ mod test {
     use rstest::rstest;
 
     use super::{inner::FpVectorP, *};
-    use crate::limb::{self, bit_length};
-    use crate::prime::{Prime, ValidPrime, P2};
+    use crate::{
+        limb::{self, bit_length},
+        prime::{Prime, ValidPrime, P2},
+    };
 
     pub struct VectorDiffEntry {
         pub index: usize,
@@ -1062,7 +1064,8 @@ mod test {
                 .iter()
                 .format_with("\n", |(tuple, popcnts, res, test_res), f| {
                     f(&format_args!(
-                        "   Inputs: {tuple:x?}\n      expected {res:?}, got {test_res:?}. popcnts: {popcnts:?}"
+                        "   Inputs: {tuple:x?}\n      expected {res:?}, got {test_res:?}. \
+                         popcnts: {popcnts:?}"
                     ))
                 });
             panic!("\nFailed test cases:\n {formatter}");

--- a/ext/crates/fp/src/vector/vector_2.rs
+++ b/ext/crates/fp/src/vector/vector_2.rs
@@ -1,18 +1,20 @@
 //! This module replaces `vector` when `odd-primes` is disabled. Instead of producing enum
 //! wrappers, it simply rexports `FooP<2>` as `Foo`.
 
-use std::io::{Read, Write};
-use std::mem::size_of;
+use std::{
+    io::{Read, Write},
+    mem::size_of,
+};
 
 use itertools::Itertools;
-
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-use crate::limb::{entries_per_limb, Limb};
-use crate::prime::{Prime, ValidPrime, P2};
-use crate::vector::inner::{FpVectorP, SliceMutP, SliceP};
-
 use super::iter::{FpVectorIterator, FpVectorNonZeroIteratorP};
+use crate::{
+    limb::{entries_per_limb, Limb},
+    prime::{Prime, ValidPrime, P2},
+    vector::inner::{FpVectorP, SliceMutP, SliceP},
+};
 
 pub type FpVector = FpVectorP<P2>;
 pub type Slice<'a> = SliceP<'a, P2>;

--- a/ext/crates/fp/src/vector/vector_generic.rs
+++ b/ext/crates/fp/src/vector/vector_generic.rs
@@ -7,19 +7,21 @@
 //!
 //! This module is only used when the `odd-primes` feature is enabled.
 
-use std::convert::TryInto;
-use std::io::{Read, Write};
-use std::mem::size_of;
+use std::{
+    convert::TryInto,
+    io::{Read, Write},
+    mem::size_of,
+};
 
 use itertools::Itertools;
-
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-use crate::limb::{entries_per_limb, Limb};
-use crate::prime::{primes::*, Prime, ValidPrime};
-use crate::vector::inner::{FpVectorP, SliceMutP, SliceP};
-
 use super::iter::{FpVectorIterator, FpVectorNonZeroIteratorP};
+use crate::{
+    limb::{entries_per_limb, Limb},
+    prime::{primes::*, Prime, ValidPrime},
+    vector::inner::{FpVectorP, SliceMutP, SliceP},
+};
 
 macro_rules! dispatch_vector_inner {
     // other is a type, but marking it as a :ty instead of :tt means we cannot use it to access its
@@ -201,6 +203,42 @@ pub enum FpVectorNonZeroIterator<'a> {
 }
 
 impl FpVector {
+    dispatch_vector! {
+        pub fn prime(&self) -> ValidPrime;
+        pub fn len(&self) -> usize;
+        pub fn is_empty(&self) -> bool;
+        pub fn scale(&mut self, c: u32);
+        pub fn set_to_zero(&mut self);
+        pub fn entry(&self, index: usize) -> u32;
+        pub fn set_entry(&mut self, index: usize, value: u32);
+        pub fn assign(&mut self, other: &Self);
+        pub fn assign_partial(&mut self, other: &Self);
+        pub fn add(&mut self, other: &Self, c: u32);
+        pub fn add_nosimd(&mut self, other: &Self, c: u32);
+        pub fn add_offset(&mut self, other: &Self, c: u32, offset: usize);
+        pub fn add_offset_nosimd(&mut self, other: &Self, c: u32, offset: usize);
+        pub fn slice(&self, start: usize, end: usize) -> (dispatch Slice);
+        pub fn as_slice(&self) -> (dispatch Slice);
+        pub fn slice_mut(&mut self, start: usize, end: usize) -> (dispatch SliceMut);
+        pub fn as_slice_mut(&mut self) -> (dispatch SliceMut);
+        pub fn is_zero(&self) -> bool;
+        pub fn iter(&self) -> FpVectorIterator;
+        pub fn iter_nonzero(&self) -> (dispatch FpVectorNonZeroIterator);
+        pub fn extend_len(&mut self, dim: usize);
+        pub fn set_scratch_vector_size(&mut self, dim: usize);
+        pub fn add_basis_element(&mut self, index: usize, value: u32);
+        pub fn copy_from_slice(&mut self, slice: &[u32]);
+        pub(crate) fn trim_start(&mut self, n: usize);
+        pub fn add_truncate(&mut self, other: &Self, c: u32) -> (Option<()>);
+        pub fn sign_rule(&self, other: &Self) -> bool;
+        pub fn add_carry(&mut self, other: &Self, c: u32, rest: &mut [FpVector]) -> bool;
+        pub fn first_nonzero(&self) -> (Option<(usize, u32)>);
+        pub fn density(&self) -> f32;
+
+        pub(crate) fn limbs(&self) -> (&[Limb]);
+        pub(crate) fn limbs_mut(&mut self) -> (&mut [Limb]);
+    }
+
     pub fn new<P: Prime>(p: P, len: usize) -> FpVector {
         match p.as_u32() {
             2 => FpVector::_2(FpVectorP::new(P2, len)),
@@ -235,6 +273,7 @@ impl FpVector {
         let entries_per_limb = entries_per_limb(p);
         (len + entries_per_limb - 1) / entries_per_limb
     }
+
     pub(crate) fn padded_len(p: ValidPrime, len: usize) -> usize {
         Self::num_limbs(p, len) * entries_per_limb(p)
     }
@@ -284,42 +323,6 @@ impl FpVector {
             }
         }
         Ok(())
-    }
-
-    dispatch_vector! {
-        pub fn prime(&self) -> ValidPrime;
-        pub fn len(&self) -> usize;
-        pub fn is_empty(&self) -> bool;
-        pub fn scale(&mut self, c: u32);
-        pub fn set_to_zero(&mut self);
-        pub fn entry(&self, index: usize) -> u32;
-        pub fn set_entry(&mut self, index: usize, value: u32);
-        pub fn assign(&mut self, other: &Self);
-        pub fn assign_partial(&mut self, other: &Self);
-        pub fn add(&mut self, other: &Self, c: u32);
-        pub fn add_nosimd(&mut self, other: &Self, c: u32);
-        pub fn add_offset(&mut self, other: &Self, c: u32, offset: usize);
-        pub fn add_offset_nosimd(&mut self, other: &Self, c: u32, offset: usize);
-        pub fn slice(&self, start: usize, end: usize) -> (dispatch Slice);
-        pub fn as_slice(&self) -> (dispatch Slice);
-        pub fn slice_mut(&mut self, start: usize, end: usize) -> (dispatch SliceMut);
-        pub fn as_slice_mut(&mut self) -> (dispatch SliceMut);
-        pub fn is_zero(&self) -> bool;
-        pub fn iter(&self) -> FpVectorIterator;
-        pub fn iter_nonzero(&self) -> (dispatch FpVectorNonZeroIterator);
-        pub fn extend_len(&mut self, dim: usize);
-        pub fn set_scratch_vector_size(&mut self, dim: usize);
-        pub fn add_basis_element(&mut self, index: usize, value: u32);
-        pub fn copy_from_slice(&mut self, slice: &[u32]);
-        pub(crate) fn trim_start(&mut self, n: usize);
-        pub fn add_truncate(&mut self, other: &Self, c: u32) -> (Option<()>);
-        pub fn sign_rule(&self, other: &Self) -> bool;
-        pub fn add_carry(&mut self, other: &Self, c: u32, rest: &mut [FpVector]) -> bool;
-        pub fn first_nonzero(&self) -> (Option<(usize, u32)>);
-        pub fn density(&self) -> f32;
-
-        pub(crate) fn limbs(&self) -> (&[Limb]);
-        pub(crate) fn limbs_mut(&mut self) -> (&mut [Limb]);
     }
 }
 

--- a/ext/crates/fp/tests/row_reduce.rs
+++ b/ext/crates/fp/tests/row_reduce.rs
@@ -1,11 +1,10 @@
 use std::sync::OnceLock;
 
-use proptest::prelude::*;
-
 use fp::{
     matrix::Matrix,
     prime::{Prime, ValidPrime},
 };
+use proptest::prelude::*;
 
 /// An arbitrary `ValidPrime` in the range `2..(1 << 24)`, plus the largest prime that we support.
 fn arb_prime() -> impl Strategy<Value = ValidPrime> {

--- a/ext/crates/maybe-rayon/src/concurrent.rs
+++ b/ext/crates/maybe-rayon/src/concurrent.rs
@@ -1,7 +1,6 @@
 pub mod prelude {
-    use rayon::prelude::*;
-
     pub use rayon::iter::{IndexedParallelIterator, ParallelIterator};
+    use rayon::prelude::*;
 
     pub trait MaybeParallelIterator: ParallelIterator {}
 

--- a/ext/crates/once/src/lib.rs
+++ b/ext/crates/once/src/lib.rs
@@ -1,14 +1,17 @@
 extern crate alloc;
 
-use core::ops::{Index, IndexMut};
-use std::cmp::{Eq, PartialEq};
-use std::collections::BTreeSet;
-use std::fmt;
-use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::{Mutex, MutexGuard};
-
 use alloc::alloc::Layout;
-use std::ptr::NonNull;
+use core::ops::{Index, IndexMut};
+use std::{
+    cmp::{Eq, PartialEq},
+    collections::BTreeSet,
+    fmt,
+    ptr::NonNull,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Mutex, MutexGuard,
+    },
+};
 
 use maybe_rayon::prelude::*;
 
@@ -49,6 +52,7 @@ impl<T> Page<T> {
         )
         .unwrap()
     }
+
     fn allocated(&self) -> bool {
         self.0.is_some()
     }
@@ -244,7 +248,7 @@ impl<T> OnceVec<T> {
     /// let v = vec![1, 3, 5, 2];
     /// let w = OnceVec::from_vec(v.clone());
     /// assert_eq!(w.len(), 4);
-    /// for i in 0 .. 4 {
+    /// for i in 0..4 {
     ///     assert_eq!(v[i], w[i]);
     /// }
     /// ```
@@ -616,6 +620,7 @@ impl<T: Send + Sync> OnceVec<T> {
 
 impl<T> Index<usize> for OnceVec<T> {
     type Output = T;
+
     fn index(&self, index: usize) -> &T {
         self.get(index).unwrap_or_else(|| {
             panic!(
@@ -637,6 +642,7 @@ impl<T> IndexMut<usize> for OnceVec<T> {
 
 impl<T> Index<u32> for OnceVec<T> {
     type Output = T;
+
     fn index(&self, index: u32) -> &T {
         self.index(index as usize)
     }
@@ -841,6 +847,7 @@ impl<T: Send + Sync> OnceBiVec<T> {
 
 impl<T> Index<i32> for OnceBiVec<T> {
     type Output = T;
+
     fn index(&self, i: i32) -> &T {
         assert!(
             i >= self.min_degree(),

--- a/ext/crates/query/src/lib.rs
+++ b/ext/crates/query/src/lib.rs
@@ -10,11 +10,12 @@
 //! The "normal" usage mode is to not supply any command line arguments and just use the second
 //! functionality. However, the first is useful for testing and batch processing.
 
-use std::fmt::Display;
-use std::io::{stderr, stdin, Write};
-
-use std::cell::RefCell;
-use std::env::Args;
+use std::{
+    cell::RefCell,
+    env::Args,
+    fmt::Display,
+    io::{stderr, stdin, Write},
+};
 
 thread_local! {
     static ARGV: RefCell<Args> = {

--- a/ext/crates/sseq/src/bigraded.rs
+++ b/ext/crates/sseq/src/bigraded.rs
@@ -1,5 +1,6 @@
-use once::OnceBiVec;
 use std::cmp::Ordering::*;
+
+use once::OnceBiVec;
 
 pub struct DenseBigradedModule {
     dimensions: OnceBiVec<OnceBiVec<usize>>,

--- a/ext/crates/sseq/src/coordinates/bidegree.rs
+++ b/ext/crates/sseq/src/coordinates/bidegree.rs
@@ -18,9 +18,11 @@ impl Bidegree {
     pub const fn s_t(s: u32, t: i32) -> Self {
         Self { s, t }
     }
+
     pub const fn t_s(t: i32, s: u32) -> Self {
         Self::s_t(s, t)
     }
+
     pub const fn n_s(n: i32, s: u32) -> Self {
         Self::s_t(s, n + s as i32)
     }

--- a/ext/crates/sseq/src/coordinates/element.rs
+++ b/ext/crates/sseq/src/coordinates/element.rs
@@ -1,5 +1,3 @@
-use crate::coordinates::{Bidegree, BidegreeGenerator};
-
 use std::fmt::{self, Display, Formatter};
 
 use algebra::{
@@ -7,6 +5,8 @@ use algebra::{
     MuAlgebra,
 };
 use fp::vector::Slice;
+
+use crate::coordinates::{Bidegree, BidegreeGenerator};
 
 /// An element of a bigraded vector space. Most commonly used to index elements of spectral
 /// sequences.

--- a/ext/crates/sseq/src/coordinates/generator.rs
+++ b/ext/crates/sseq/src/coordinates/generator.rs
@@ -1,8 +1,8 @@
-use super::{Bidegree, BidegreeElement};
-
 use std::fmt::{self, Display, Formatter};
 
 use serde::{Deserialize, Serialize};
+
+use super::{Bidegree, BidegreeElement};
 
 /// A *basis* element of a bigraded vector space. Most commonly used to index elements of spectral
 /// sequences.
@@ -21,9 +21,11 @@ impl BidegreeGenerator {
             idx,
         }
     }
+
     pub fn s_t(s: u32, t: i32, idx: usize) -> BidegreeGenerator {
         Self::new(Bidegree::s_t(s, t), idx)
     }
+
     pub fn n_s(n: i32, s: u32, idx: usize) -> BidegreeGenerator {
         Self::new(Bidegree::n_s(n, s), idx)
     }

--- a/ext/crates/sseq/src/coordinates/mod.rs
+++ b/ext/crates/sseq/src/coordinates/mod.rs
@@ -6,9 +6,8 @@ pub mod range;
 pub use bidegree::Bidegree;
 pub use element::BidegreeElement;
 pub use generator::BidegreeGenerator;
-pub use range::BidegreeRange;
-
 use maybe_rayon::prelude::*;
+pub use range::BidegreeRange;
 
 /// Given a function `f(s, t)`, compute it for every `s` in `[min_s, max_s]` and every `t` in
 /// `[min_t, max_t(s)]`.  Further, we only compute `f(s, t)` when `f(s - 1, t')` has been computed

--- a/ext/crates/sseq/src/lib.rs
+++ b/ext/crates/sseq/src/lib.rs
@@ -3,6 +3,7 @@ pub mod coordinates;
 mod differential;
 mod sseq;
 
-pub use crate::sseq::*;
 pub use bigraded::*;
 pub use differential::*;
+
+pub use crate::sseq::*;

--- a/ext/crates/sseq/src/sseq.rs
+++ b/ext/crates/sseq/src/sseq.rs
@@ -1,12 +1,13 @@
-use crate::bigraded::DenseBigradedModule;
-use crate::differential::Differential;
+use std::{marker::PhantomData, sync::Arc};
+
 use bivec::BiVec;
 use fp::{
     matrix::{Matrix, Subquotient, Subspace},
     prime::ValidPrime,
     vector::{FpVector, Slice},
 };
-use std::{marker::PhantomData, sync::Arc};
+
+use crate::{bigraded::DenseBigradedModule, differential::Differential};
 
 /// The direction of the differentials
 pub trait SseqProfile {
@@ -20,12 +21,15 @@ pub struct Adams;
 
 impl SseqProfile for Adams {
     const MIN_R: i32 = 2;
+
     fn profile(r: i32, x: i32, y: i32) -> (i32, i32) {
         (x - 1, y + r)
     }
+
     fn profile_inverse(r: i32, x: i32, y: i32) -> (i32, i32) {
         (x + 1, y - r)
     }
+
     fn differential_length(_diff_x: i32, diff_y: i32) -> i32 {
         diff_y
     }
@@ -575,8 +579,9 @@ impl<P: SseqProfile> Sseq<P> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use expect_test::{expect, Expect};
+
+    use super::*;
 
     #[test]
     #[allow(clippy::cognitive_complexity)]

--- a/ext/examples/bruner.rs
+++ b/ext/examples/bruner.rs
@@ -17,9 +17,18 @@
 //! <https://archive.sigma2.no/pages/public/datasetDetail.jsf?id=10.11582/2022.00015>
 //! while the descirption of his save file is at <https://arxiv.org/abs/2109.13117>.
 
+use std::{
+    fs::File,
+    io::{BufRead, BufReader},
+    path::{Path, PathBuf},
+    str::FromStr,
+    sync::Arc,
+};
+
 use algebra::{
-    milnor_algebra::MilnorBasisElement, module::homomorphism::FreeModuleHomomorphism as FMH,
-    module::FreeModule as FM, module::Module, Algebra, MilnorAlgebra,
+    milnor_algebra::MilnorBasisElement,
+    module::{homomorphism::FreeModuleHomomorphism as FMH, FreeModule as FM, Module},
+    Algebra, MilnorAlgebra,
 };
 use anyhow::{Context, Error, Result};
 use ext::{
@@ -28,13 +37,6 @@ use ext::{
 };
 use fp::{matrix::Matrix, prime::TWO, vector::FpVector};
 use sseq::coordinates::{Bidegree, BidegreeGenerator};
-use std::{
-    fs::File,
-    io::{BufRead, BufReader},
-    path::{Path, PathBuf},
-    str::FromStr,
-    sync::Arc,
-};
 
 #[cfg(feature = "nassau")]
 type FreeModule = FM<MilnorAlgebra>;

--- a/ext/examples/chart.rs
+++ b/ext/examples/chart.rs
@@ -1,7 +1,9 @@
 use algebra::Algebra;
 use chart::SvgBackend;
-use ext::chain_complex::{ChainComplex, FreeChainComplex};
-use ext::utils::query_module;
+use ext::{
+    chain_complex::{ChainComplex, FreeChainComplex},
+    utils::query_module,
+};
 
 fn main() -> anyhow::Result<()> {
     let resolution = query_module(None, false)?;

--- a/ext/examples/d2_charts.rs
+++ b/ext/examples/d2_charts.rs
@@ -1,10 +1,11 @@
+use std::{fs::File, sync::Arc};
+
 use algebra::Algebra;
 use chart::{Backend as _, TikzBackend as Backend};
 use ext::{
     chain_complex::{ChainComplex, FreeChainComplex},
     secondary::{SecondaryLift, SecondaryResolution},
 };
-use std::{fs::File, sync::Arc};
 
 fn main() -> anyhow::Result<()> {
     let resolution = Arc::new(ext::utils::query_module(

--- a/ext/examples/define_module.rs
+++ b/ext/examples/define_module.rs
@@ -1,18 +1,19 @@
-use rustc_hash::FxHashMap as HashMap;
-use std::io::{stderr, Write};
-use std::sync::Arc;
+use std::{
+    io::{stderr, Write},
+    sync::Arc,
+};
 
-use serde_json::json;
-use serde_json::Value;
-
-use algebra::module::FDModule;
-use algebra::steenrod_evaluator::SteenrodEvaluator;
-use algebra::{AdemAlgebra, Algebra, GeneratedAlgebra};
-use bivec::BiVec;
-use fp::prime::{Prime, ValidPrime};
-use fp::vector::FpVector;
-
+use algebra::{
+    module::FDModule, steenrod_evaluator::SteenrodEvaluator, AdemAlgebra, Algebra, GeneratedAlgebra,
+};
 use anyhow::anyhow;
+use bivec::BiVec;
+use fp::{
+    prime::{Prime, ValidPrime},
+    vector::FpVector,
+};
+use rustc_hash::FxHashMap as HashMap;
+use serde_json::{json, Value};
 
 pub fn get_gens() -> anyhow::Result<BiVec<Vec<String>>> {
     // Query for generators
@@ -108,7 +109,11 @@ pub fn interactive_module_define_fdmodule(
         }
     }
 
-    eprintln!("Input actions. Write the value of the action in the form 'a x0 + b x1 + ...' where a, b are non-negative integers and x0, x1 are names of the generators. The coefficient can be omitted if it is 1");
+    eprintln!(
+        "Input actions. Write the value of the action in the form 'a x0 + b x1 + ...' where a, b \
+         are non-negative integers and x0, x1 are names of the generators. The coefficient can be \
+         omitted if it is 1"
+    );
 
     let len = gens.len();
     for input_deg in gens.range().rev() {
@@ -188,7 +193,10 @@ pub fn interactive_module_define_fpmodule(
     eprintln!("Input relations");
     match p.as_u32() {
         2 => eprintln!("Write relations in the form 'Sq6 * Sq2 * x + Sq7 * y'"),
-        _ => eprintln!("Write relations in the form 'Q5 * P(5) * x + 2 * P(1, 3) * Q2 * y', where P(...) and Qi are Milnor basis elements."),
+        _ => eprintln!(
+            "Write relations in the form 'Q5 * P(5) * x + 2 * P(1, 3) * Q2 * y', where P(...) and \
+             Qi are Milnor basis elements."
+        ),
     }
 
     let mut degree_lookup = HashMap::default();
@@ -274,12 +282,13 @@ pub fn interactive_module_define_fpmodule(
 
 fn main() -> anyhow::Result<()> {
     let module_type = query::with_default(
-        "Input module type (default 'finite dimensional module'):\n (fd) - finite dimensional module \n (fp) - finitely presented module\n",
+        "Input module type (default 'finite dimensional module'):\n (fd) - finite dimensional \
+         module \n (fp) - finitely presented module\n",
         "fd",
         |x| match x {
             "fd" | "fp" => Ok(x.to_string()),
-            _ => Err(format!("Invalid type '{x}'. Type must be 'fd' or 'fp'"))
-        }
+            _ => Err(format!("Invalid type '{x}'. Type must be 'fd' or 'fp'")),
+        },
     );
 
     let p: ValidPrime = query::with_default("p", "2", str::parse);

--- a/ext/examples/differentials.rs
+++ b/ext/examples/differentials.rs
@@ -1,7 +1,9 @@
 //! This prints all the differentials in the resolution.
 
-use ext::chain_complex::{ChainComplex, FreeChainComplex};
-use ext::utils::query_module;
+use ext::{
+    chain_complex::{ChainComplex, FreeChainComplex},
+    utils::query_module,
+};
 use sseq::coordinates::BidegreeGenerator;
 
 fn main() -> anyhow::Result<()> {

--- a/ext/examples/ext_m_n.rs
+++ b/ext/examples/ext_m_n.rs
@@ -1,8 +1,9 @@
+use std::sync::Arc;
+
 use algebra::{module::Module, Algebra};
 use ext::chain_complex::ChainComplex;
 use hom_cochain_complex::HomCochainComplex;
 use sseq::coordinates::Bidegree;
-use std::sync::Arc;
 
 fn main() -> anyhow::Result<()> {
     eprintln!("This script computes Ext(M, N)");
@@ -46,14 +47,16 @@ fn main() -> anyhow::Result<()> {
 }
 
 mod hom_cochain_complex {
-    use algebra::module::homomorphism::{HomPullback, ModuleHomomorphism};
-    use algebra::module::{HomModule, Module};
+    use std::sync::Arc;
+
+    use algebra::module::{
+        homomorphism::{HomPullback, ModuleHomomorphism},
+        HomModule, Module,
+    };
     use ext::chain_complex::FreeChainComplex;
     use fp::matrix::Subquotient;
     use once::OnceVec;
     use sseq::coordinates::Bidegree;
-
-    use std::sync::Arc;
 
     pub struct HomCochainComplex<CC: FreeChainComplex, M: Module<Algebra = CC::Algebra>> {
         source: Arc<CC>,

--- a/ext/examples/filtration_one.rs
+++ b/ext/examples/filtration_one.rs
@@ -3,8 +3,10 @@
 //!
 //! We omit outputs where the target bidegree is zero (or not yet computed)
 
-use ext::chain_complex::{ChainComplex, FreeChainComplex};
-use ext::utils::query_module;
+use ext::{
+    chain_complex::{ChainComplex, FreeChainComplex},
+    utils::query_module,
+};
 use sseq::coordinates::{Bidegree, BidegreeGenerator};
 
 fn main() -> anyhow::Result<()> {

--- a/ext/examples/lift_hom.rs
+++ b/ext/examples/lift_hom.rs
@@ -39,16 +39,17 @@
 //! $H^*(-)$ are contravariant functors. The words "source" and "target" refer to the map between
 //! Steenrod modules.
 
+use std::{path::PathBuf, sync::Arc};
+
 use algebra::module::Module;
 use anyhow::{anyhow, Context};
-use ext::chain_complex::{AugmentedChainComplex, ChainComplex, FreeChainComplex};
-use ext::resolution_homomorphism::ResolutionHomomorphism;
-use ext::utils;
+use ext::{
+    chain_complex::{AugmentedChainComplex, ChainComplex, FreeChainComplex},
+    resolution_homomorphism::ResolutionHomomorphism,
+    utils,
+};
 use fp::matrix::Matrix;
 use sseq::coordinates::{Bidegree, BidegreeGenerator};
-
-use std::path::PathBuf;
-use std::sync::Arc;
 
 fn main() -> anyhow::Result<()> {
     let source = Arc::new(utils::query_module_only("Source module", None, true)?);

--- a/ext/examples/mahowald_invariant.rs
+++ b/ext/examples/mahowald_invariant.rs
@@ -44,10 +44,13 @@
 //! [mahowald--ravenel]: https://www.sciencedirect.com/science/article/pii/004093839390055Z
 //! [bruner--greenlees]: https://projecteuclid.org/journals/experimental-mathematics/volume-4/issue-4/The-Bredon-L%C3%B6ffler-conjecture/em/1047674389.full
 
+use std::{fmt, iter, num::NonZeroU32, path::PathBuf, sync::Arc};
+
 use algebra::{
     module::{homomorphism::ModuleHomomorphism, Module},
     AlgebraType, SteenrodAlgebra,
 };
+use anyhow::Result;
 use ext::{
     chain_complex::{ChainComplex, FiniteChainComplex, FreeChainComplex},
     resolution::MuResolution,
@@ -55,15 +58,8 @@ use ext::{
     utils,
 };
 use fp::{matrix::Matrix, prime::TWO, vector::FpVector};
-
-use anyhow::Result;
 use serde_json::json;
 use sseq::coordinates::{Bidegree, BidegreeElement, BidegreeGenerator};
-use std::fmt;
-use std::iter;
-use std::num::NonZeroU32;
-use std::path::PathBuf;
-use std::sync::Arc;
 
 fn main() -> Result<()> {
     let s_2_path: Option<PathBuf> = query::optional("Save directory for S_2", str::parse);
@@ -274,8 +270,9 @@ impl fmt::Display for MahowaldInvariant {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use rstest::rstest;
+
+    use super::*;
 
     #[rstest]
     #[case(1, 0, 0, 0, 0, vec![1], 0)]

--- a/ext/examples/massey.rs
+++ b/ext/examples/massey.rs
@@ -3,11 +3,14 @@
 //! This is optimized to compute <a, b, -> for fixed a, b and all -, where a and b have small
 //! degree.
 
-use ext::chain_complex::{ChainComplex, ChainHomotopy, FreeChainComplex};
-use ext::resolution_homomorphism::ResolutionHomomorphism;
+use std::sync::Arc;
+
+use ext::{
+    chain_complex::{ChainComplex, ChainHomotopy, FreeChainComplex},
+    resolution_homomorphism::ResolutionHomomorphism,
+};
 use fp::matrix::{AugmentedMatrix, Matrix};
 use sseq::coordinates::{Bidegree, BidegreeElement, BidegreeGenerator};
-use std::sync::Arc;
 
 fn main() -> anyhow::Result<()> {
     let resolution = Arc::new(ext::utils::query_module(None, true)?);

--- a/ext/examples/num_gens.rs
+++ b/ext/examples/num_gens.rs
@@ -1,7 +1,5 @@
 //! This prints the number of generators in each $\Ext^{s, n + s}$ in the format `n,s,num_gens`.
-//!
-use ext::chain_complex::ChainComplex;
-use ext::utils::query_module;
+use ext::{chain_complex::ChainComplex, utils::query_module};
 
 fn main() -> anyhow::Result<()> {
     let resolution = query_module(None, false)?;

--- a/ext/examples/resolution_size.rs
+++ b/ext/examples/resolution_size.rs
@@ -1,6 +1,5 @@
 use algebra::module::Module;
-use ext::chain_complex::ChainComplex;
-use ext::utils::query_module;
+use ext::{chain_complex::ChainComplex, utils::query_module};
 
 fn main() -> anyhow::Result<()> {
     let res = query_module(None, false)?;

--- a/ext/examples/resolve.rs
+++ b/ext/examples/resolve.rs
@@ -13,7 +13,6 @@
 //! · ·   ·       ·               ·
 //! ·
 //! ```
-//!
 
 use ext::chain_complex::{ChainComplex, FreeChainComplex};
 use sseq::coordinates::Bidegree;

--- a/ext/examples/save_bruner.rs
+++ b/ext/examples/save_bruner.rs
@@ -1,13 +1,15 @@
 //! This saves a resolution to Bruner's format. This saves the resulting files to the current
 //! working directory. It is recommended that you run this in a dedicated subdirectory.
 
-use algebra::module::Module;
-use algebra::{Algebra, AlgebraType, MilnorAlgebra};
+use std::{
+    fmt::Write as _,
+    fs::File,
+    io::{BufWriter, Write as _},
+};
+
+use algebra::{module::Module, Algebra, AlgebraType, MilnorAlgebra};
 use ext::{chain_complex::ChainComplex, utils::query_module};
 use itertools::Itertools;
-use std::fmt::Write as _;
-use std::fs::File;
-use std::io::{BufWriter, Write as _};
 
 fn main() -> anyhow::Result<()> {
     let resolution = query_module(Some(AlgebraType::Milnor), false)?;

--- a/ext/examples/secondary.rs
+++ b/ext/examples/secondary.rs
@@ -45,13 +45,15 @@
 //! target/debug/examples/secondary S_2 /tmp/save 40 20;
 //! ```
 
-use algebra::module::Module;
-use sseq::coordinates::{Bidegree, BidegreeGenerator};
 use std::sync::Arc;
 
-use ext::chain_complex::{ChainComplex, FreeChainComplex};
-use ext::secondary::*;
-use ext::utils::query_module;
+use algebra::module::Module;
+use ext::{
+    chain_complex::{ChainComplex, FreeChainComplex},
+    secondary::*,
+    utils::query_module,
+};
+use sseq::coordinates::{Bidegree, BidegreeGenerator};
 
 fn main() -> anyhow::Result<()> {
     let resolution = Arc::new(query_module(Some(algebra::AlgebraType::Milnor), true)?);

--- a/ext/examples/secondary_massey.rs
+++ b/ext/examples/secondary_massey.rs
@@ -19,16 +19,17 @@
 
 use std::sync::Arc;
 
-use algebra::module::Module;
-use algebra::pair_algebra::PairAlgebra;
-use fp::matrix::{Matrix, Subspace};
-use fp::vector::FpVector;
-
-use ext::chain_complex::{ChainComplex, ChainHomotopy, FreeChainComplex};
-use ext::resolution_homomorphism::ResolutionHomomorphism;
-use ext::secondary::*;
-use ext::utils::{query_module, QueryModuleResolution};
-
+use algebra::{module::Module, pair_algebra::PairAlgebra};
+use ext::{
+    chain_complex::{ChainComplex, ChainHomotopy, FreeChainComplex},
+    resolution_homomorphism::ResolutionHomomorphism,
+    secondary::*,
+    utils::{query_module, QueryModuleResolution},
+};
+use fp::{
+    matrix::{Matrix, Subspace},
+    vector::FpVector,
+};
 use itertools::Itertools;
 use sseq::coordinates::{Bidegree, BidegreeElement};
 
@@ -123,7 +124,10 @@ fn get_hom(
 }
 
 fn main() -> anyhow::Result<()> {
-    eprintln!("We are going to compute <-, b, a> for all (-), where a is an element in Ext(M, k) and b and (-) are elements in Ext(k, k).");
+    eprintln!(
+        "We are going to compute <-, b, a> for all (-), where a is an element in Ext(M, k) and b \
+         and (-) are elements in Ext(k, k)."
+    );
 
     let resolution = Arc::new(query_module(Some(algebra::AlgebraType::Milnor), true)?);
 

--- a/ext/examples/secondary_product.rs
+++ b/ext/examples/secondary_product.rs
@@ -23,14 +23,13 @@
 use std::sync::Arc;
 
 use algebra::module::Module;
-use fp::matrix::Matrix;
-use fp::vector::FpVector;
-
-use ext::chain_complex::{ChainComplex, FreeChainComplex};
-use ext::resolution_homomorphism::ResolutionHomomorphism;
-use ext::secondary::*;
-use ext::utils::query_module;
-
+use ext::{
+    chain_complex::{ChainComplex, FreeChainComplex},
+    resolution_homomorphism::ResolutionHomomorphism,
+    secondary::*,
+    utils::query_module,
+};
+use fp::{matrix::Matrix, vector::FpVector};
 use itertools::Itertools;
 use sseq::coordinates::{Bidegree, BidegreeElement, BidegreeGenerator};
 

--- a/ext/examples/sq0.rs
+++ b/ext/examples/sq0.rs
@@ -2,11 +2,11 @@ use std::sync::Arc;
 
 use algebra::module::Module;
 use double::DoubleChainComplex;
-use ext::chain_complex::{
-    AugmentedChainComplex, BoundedChainComplex, ChainComplex, FreeChainComplex,
+use ext::{
+    chain_complex::{AugmentedChainComplex, BoundedChainComplex, ChainComplex, FreeChainComplex},
+    resolution_homomorphism::ResolutionHomomorphism,
+    utils,
 };
-use ext::resolution_homomorphism::ResolutionHomomorphism;
-use ext::utils;
 use fp::vector::FpVector;
 use itertools::Itertools;
 use sseq::coordinates::{Bidegree, BidegreeGenerator};
@@ -132,14 +132,15 @@ mod double {
     }
 
     pub mod double_module {
-        use super::DoubleAlgebra;
+        use std::sync::Arc;
 
         use algebra::module::{homomorphism::ModuleHomomorphism, Module};
         use fp::{
             matrix::{Matrix, MatrixSliceMut, QuasiInverse, Subspace},
             vector::{Slice, SliceMut},
         };
-        use std::sync::Arc;
+
+        use super::DoubleAlgebra;
 
         pub struct DoubleModule<M: Module> {
             inner: Arc<M>,
@@ -427,8 +428,8 @@ mod double {
             CC::Algebra: DoubleAlgebra,
         {
             type Algebra = CC::Algebra;
-            type Module = DoubleModule<CC::Module>;
             type Homomorphism = DoubleModuleHomomorphism<CC::Homomorphism>;
+            type Module = DoubleModule<CC::Module>;
 
             fn algebra(&self) -> Arc<Self::Algebra> {
                 self.inner.algebra()

--- a/ext/examples/steenrod.rs
+++ b/ext/examples/steenrod.rs
@@ -1,18 +1,21 @@
-use algebra::module::homomorphism::{FreeModuleHomomorphism, ModuleHomomorphism};
-use algebra::module::Module;
-use ext::chain_complex::{
-    AugmentedChainComplex, BoundedChainComplex, ChainComplex, FreeChainComplex,
+use std::{
+    io::{stderr, stdout, Write},
+    sync::Arc,
 };
-use ext::utils;
-use ext::yoneda::yoneda_representative_element;
-use fp::matrix::Matrix;
-use fp::vector::FpVector;
+
+use algebra::module::{
+    homomorphism::{FreeModuleHomomorphism, ModuleHomomorphism},
+    Module,
+};
+use ext::{
+    chain_complex::{AugmentedChainComplex, BoundedChainComplex, ChainComplex, FreeChainComplex},
+    utils,
+    yoneda::yoneda_representative_element,
+};
+use fp::{matrix::Matrix, vector::FpVector};
 use itertools::Itertools;
 use sseq::coordinates::{Bidegree, BidegreeElement};
 use tensor_product_chain_complex::TensorChainComplex;
-
-use std::io::{stderr, stdout, Write};
-use std::sync::Arc;
 
 fn main() -> anyhow::Result<()> {
     let resolution = Arc::new(utils::query_module_only("Module", None, false)?);
@@ -282,14 +285,15 @@ fn main() -> anyhow::Result<()> {
 }
 
 mod sum_module {
-    use bivec::BiVec;
-    use once::OnceBiVec;
-
-    use algebra::module::block_structure::{BlockStructure, GeneratorBasisEltPair};
-    use algebra::module::{Module, ZeroModule};
-    use fp::vector::SliceMut;
-
     use std::sync::Arc;
+
+    use algebra::module::{
+        block_structure::{BlockStructure, GeneratorBasisEltPair},
+        Module, ZeroModule,
+    };
+    use bivec::BiVec;
+    use fp::vector::SliceMut;
+    use once::OnceBiVec;
 
     pub struct SumModule<M: Module> {
         // We need these because modules might be empty
@@ -427,10 +431,9 @@ mod sum_module {
     mod tests {
         #![allow(non_snake_case)]
 
-        use super::*;
+        use algebra::{module::FDModule, AdemAlgebra};
 
-        use algebra::module::FDModule;
-        use algebra::AdemAlgebra;
+        use super::*;
 
         #[test]
         fn test_sum_modules() {
@@ -472,17 +475,21 @@ mod sum_module {
 }
 
 mod tensor_product_chain_complex {
-    use super::sum_module::SumModule;
-    use algebra::module::homomorphism::ModuleHomomorphism;
-    use algebra::module::{Module, TensorModule, ZeroModule};
-    use algebra::{Algebra, Bialgebra};
-    use ext::chain_complex::ChainComplex;
-    use fp::matrix::AugmentedMatrix;
-    use fp::vector::{FpVector, Slice, SliceMut};
-    use sseq::coordinates::Bidegree;
     use std::sync::Arc;
 
+    use algebra::{
+        module::{homomorphism::ModuleHomomorphism, Module, TensorModule, ZeroModule},
+        Algebra, Bialgebra,
+    };
+    use ext::chain_complex::ChainComplex;
+    use fp::{
+        matrix::AugmentedMatrix,
+        vector::{FpVector, Slice, SliceMut},
+    };
     use once::{OnceBiVec, OnceVec};
+    use sseq::coordinates::Bidegree;
+
+    use super::sum_module::SumModule;
 
     pub type Stm<M, N> = SumModule<TensorModule<M, N>>;
 
@@ -589,8 +596,8 @@ mod tensor_product_chain_complex {
         CC2: ChainComplex<Algebra = A>,
     {
         type Algebra = A;
-        type Module = Stm<CC1::Module, CC2::Module>;
         type Homomorphism = TensorChainMap<A, CC1, CC2>;
+        type Module = Stm<CC1::Module, CC2::Module>;
 
         fn algebra(&self) -> Arc<A> {
             self.left_cc.algebra()
@@ -703,9 +710,11 @@ mod tensor_product_chain_complex {
         fn source(&self) -> Arc<Self::Source> {
             Arc::clone(&self.source)
         }
+
         fn target(&self) -> Arc<Self::Target> {
             Arc::clone(&self.target)
         }
+
         fn degree_shift(&self) -> i32 {
             0
         }
@@ -962,13 +971,13 @@ mod tensor_product_chain_complex {
 
     #[cfg(test)]
     mod tests {
-        use super::*;
-
-        use ext::resolution_homomorphism::ResolutionHomomorphism;
-        use ext::utils::construct;
-        use ext::yoneda::yoneda_representative_element;
-
+        use ext::{
+            resolution_homomorphism::ResolutionHomomorphism, utils::construct,
+            yoneda::yoneda_representative_element,
+        };
         use rstest::rstest;
+
+        use super::*;
 
         #[rstest]
         #[trace]

--- a/ext/examples/tensor.rs
+++ b/ext/examples/tensor.rs
@@ -1,11 +1,13 @@
-use algebra::module::{steenrod_module, FDModule, TensorModule};
-use algebra::{AdemAlgebra, SteenrodAlgebra};
+use std::sync::Arc;
+
+use algebra::{
+    module::{steenrod_module, FDModule, TensorModule},
+    AdemAlgebra, SteenrodAlgebra,
+};
+use anyhow::anyhow;
 use ext::utils::parse_module_name;
 use fp::prime::{Prime, ValidPrime};
-
-use anyhow::anyhow;
 use serde_json::json;
-use std::sync::Arc;
 
 fn main() -> anyhow::Result<()> {
     let left = query::with_default("Left module", "S_2", parse_module_name);

--- a/ext/examples/unstable_chart.rs
+++ b/ext/examples/unstable_chart.rs
@@ -18,11 +18,15 @@
 
 use std::{path::PathBuf, sync::Arc};
 
-use algebra::module::{Module, SuspensionModule};
-use algebra::Algebra;
+use algebra::{
+    module::{Module, SuspensionModule},
+    Algebra,
+};
 use chart::{Backend, Orientation, TikzBackend};
-use ext::chain_complex::{FiniteChainComplex, FreeChainComplex};
-use ext::resolution::UnstableResolution;
+use ext::{
+    chain_complex::{FiniteChainComplex, FreeChainComplex},
+    resolution::UnstableResolution,
+};
 use sseq::coordinates::Bidegree;
 
 fn main() -> anyhow::Result<()> {

--- a/ext/examples/unstable_suspension.rs
+++ b/ext/examples/unstable_suspension.rs
@@ -19,9 +19,10 @@
 use std::{path::PathBuf, sync::Arc};
 
 use algebra::module::{Module, SuspensionModule};
-use ext::chain_complex::{FiniteChainComplex, FreeChainComplex};
 use ext::{
-    resolution::UnstableResolution, resolution_homomorphism::UnstableResolutionHomomorphism,
+    chain_complex::{FiniteChainComplex, FreeChainComplex},
+    resolution::UnstableResolution,
+    resolution_homomorphism::UnstableResolutionHomomorphism,
 };
 use fp::vector::FpVector;
 use sseq::coordinates::Bidegree;

--- a/ext/examples/yoneda.rs
+++ b/ext/examples/yoneda.rs
@@ -1,10 +1,12 @@
-use algebra::module::Module;
-use ext::chain_complex::{ChainComplex, FreeChainComplex};
-use ext::utils;
-use ext::yoneda::yoneda_representative_element;
-use sseq::coordinates::Bidegree;
-
 use std::sync::Arc;
+
+use algebra::module::Module;
+use ext::{
+    chain_complex::{ChainComplex, FreeChainComplex},
+    utils,
+    yoneda::yoneda_representative_element,
+};
+use sseq::coordinates::Bidegree;
 
 fn main() -> anyhow::Result<()> {
     let resolution = Arc::new(utils::query_module_only("Module", None, false)?);

--- a/ext/src/chain_complex/chain_homotopy.rs
+++ b/ext/src/chain_complex/chain_homotopy.rs
@@ -1,18 +1,22 @@
-use crate::chain_complex::{ChainComplex, FreeChainComplex};
-use crate::resolution_homomorphism::ResolutionHomomorphism;
-use crate::save::SaveKind;
-use algebra::module::homomorphism::{FreeModuleHomomorphism, ModuleHomomorphism};
-use algebra::module::Module;
-use fp::prime::ValidPrime;
-use fp::vector::FpVector;
+use std::{
+    path::{Path, PathBuf},
+    sync::{Arc, Mutex},
+};
+
+use algebra::module::{
+    homomorphism::{FreeModuleHomomorphism, ModuleHomomorphism},
+    Module,
+};
+use fp::{prime::ValidPrime, vector::FpVector};
+use maybe_rayon::prelude::*;
 use once::OnceBiVec;
 use sseq::coordinates::{Bidegree, BidegreeRange};
 
-use std::path::{Path, PathBuf};
-use std::sync::Arc;
-use std::sync::Mutex;
-
-use maybe_rayon::prelude::*;
+use crate::{
+    chain_complex::{ChainComplex, FreeChainComplex},
+    resolution_homomorphism::ResolutionHomomorphism,
+    save::SaveKind,
+};
 
 // Another instance of https://github.com/rust-lang/rust/issues/91380
 /// A chain homotopy from $f to g$, or equivalently a null-homotopy of $h = f - g$. A chain map is

--- a/ext/src/chain_complex/finite_chain_complex.rs
+++ b/ext/src/chain_complex/finite_chain_complex.rs
@@ -1,8 +1,12 @@
-use crate::chain_complex::{AugmentedChainComplex, BoundedChainComplex, ChainComplex};
-use algebra::module::homomorphism::{FullModuleHomomorphism, ModuleHomomorphism, ZeroHomomorphism};
-use algebra::module::{Module, ZeroModule};
-use sseq::coordinates::Bidegree;
 use std::sync::Arc;
+
+use algebra::module::{
+    homomorphism::{FullModuleHomomorphism, ModuleHomomorphism, ZeroHomomorphism},
+    Module, ZeroModule,
+};
+use sseq::coordinates::Bidegree;
+
+use crate::chain_complex::{AugmentedChainComplex, BoundedChainComplex, ChainComplex};
 
 pub struct FiniteChainComplex<M, F = FullModuleHomomorphism<M>>
 where
@@ -122,12 +126,13 @@ where
     F: ModuleHomomorphism<Source = M, Target = M>,
 {
     type Algebra = M::Algebra;
-    type Module = M;
     type Homomorphism = F;
+    type Module = M;
 
     fn algebra(&self) -> Arc<Self::Algebra> {
         self.zero_module.algebra()
     }
+
     fn min_degree(&self) -> i32 {
         self.zero_module.min_degree()
     }
@@ -196,8 +201,8 @@ where
     F2: ModuleHomomorphism<Source = M, Target = CC::Module>,
 {
     type Algebra = M::Algebra;
-    type Module = M;
     type Homomorphism = F1;
+    type Module = M;
 
     fn algebra(&self) -> Arc<M::Algebra> {
         self.cc.algebra()
@@ -271,8 +276,8 @@ where
     F1: ModuleHomomorphism<Source = M, Target = M>,
     F2: ModuleHomomorphism<Source = M, Target = CC::Module>,
 {
-    type TargetComplex = CC;
     type ChainMap = F2;
+    type TargetComplex = CC;
 
     fn target(&self) -> Arc<Self::TargetComplex> {
         Arc::clone(&self.target_cc)

--- a/ext/src/chain_complex/mod.rs
+++ b/ext/src/chain_complex/mod.rs
@@ -1,22 +1,28 @@
 mod chain_homotopy;
 mod finite_chain_complex;
 
-use crate::utils::unicode_num;
-use algebra::module::homomorphism::{ModuleHomomorphism, MuFreeModuleHomomorphism};
-use algebra::module::{Module, MuFreeModule};
-use algebra::{Algebra, MuAlgebra};
-use bivec::BiVec;
-use fp::matrix::Matrix;
-use fp::prime::ValidPrime;
-use fp::vector::{Slice, SliceMut};
-use sseq::coordinates::{Bidegree, BidegreeElement, BidegreeGenerator};
 use std::sync::Arc;
 
-use itertools::Itertools;
-
+use algebra::{
+    module::{
+        homomorphism::{ModuleHomomorphism, MuFreeModuleHomomorphism},
+        Module, MuFreeModule,
+    },
+    Algebra, MuAlgebra,
+};
+use bivec::BiVec;
 // pub use hom_complex::HomComplex;
 pub use chain_homotopy::ChainHomotopy;
 pub use finite_chain_complex::{FiniteAugmentedChainComplex, FiniteChainComplex};
+use fp::{
+    matrix::Matrix,
+    prime::ValidPrime,
+    vector::{Slice, SliceMut},
+};
+use itertools::Itertools;
+use sseq::coordinates::{Bidegree, BidegreeElement, BidegreeGenerator};
+
+use crate::utils::unicode_num;
 
 pub enum ChainComplexGrading {
     Homological,

--- a/ext/src/lib.rs
+++ b/ext/src/lib.rs
@@ -176,8 +176,9 @@ pub mod save;
 
 pub mod yoneda;
 
-use crate::chain_complex::FiniteChainComplex;
 use algebra::module::SteenrodModule;
+
+use crate::chain_complex::FiniteChainComplex;
 pub type CCC = FiniteChainComplex<SteenrodModule>;
 
 pub mod nassau;

--- a/ext/src/resolution_homomorphism.rs
+++ b/ext/src/resolution_homomorphism.rs
@@ -1,24 +1,27 @@
 //! This module defines [`MuResolutionHomomorphism`], which is a chain map from a
 //! [`FreeChainComplex`].
-use std::ops::Range;
-use std::path::PathBuf;
-use std::sync::Arc;
+use std::{ops::Range, path::PathBuf, sync::Arc};
 
-use crate::chain_complex::{
-    AugmentedChainComplex, BoundedChainComplex, ChainComplex, FreeChainComplex,
+use algebra::{
+    module::{
+        homomorphism::{ModuleHomomorphism, MuFreeModuleHomomorphism},
+        Module,
+    },
+    MuAlgebra,
 };
-use crate::save::SaveKind;
-use algebra::module::homomorphism::{ModuleHomomorphism, MuFreeModuleHomomorphism};
-use algebra::module::Module;
-use algebra::MuAlgebra;
-use fp::matrix::Matrix;
-use fp::vector::{FpVector, SliceMut};
+use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
+use fp::{
+    matrix::Matrix,
+    vector::{FpVector, SliceMut},
+};
+use maybe_rayon::prelude::*;
 use once::OnceBiVec;
 use sseq::coordinates::{Bidegree, BidegreeGenerator, BidegreeRange};
 
-use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
-
-use maybe_rayon::prelude::*;
+use crate::{
+    chain_complex::{AugmentedChainComplex, BoundedChainComplex, ChainComplex, FreeChainComplex},
+    save::SaveKind,
+};
 
 pub type ResolutionHomomorphism<CC1, CC2> = MuResolutionHomomorphism<false, CC1, CC2>;
 pub type UnstableResolutionHomomorphism<CC1, CC2> = MuResolutionHomomorphism<true, CC1, CC2>;
@@ -426,7 +429,8 @@ where
         let shift = Bidegree::s_t(0, f.degree_shift());
 
         let max_degree = source_module.max_generator_degree().expect(
-            "MuResolutionHomomorphism::from_module_homomorphism requires finite max_generator_degree",
+            "MuResolutionHomomorphism::from_module_homomorphism requires finite \
+             max_generator_degree",
         );
 
         let hom = Self::new(name, source, target, shift);

--- a/ext/src/save.rs
+++ b/ext/src/save.rs
@@ -1,20 +1,21 @@
-use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
-use sseq::coordinates::Bidegree;
-use std::collections::HashSet;
-use std::fs::File;
-use std::io::{BufRead, BufReader, BufWriter, Error, ErrorKind, Read, Write};
-use std::path::PathBuf;
-use std::sync::{Arc, Mutex};
+use std::{
+    collections::HashSet,
+    fs::File,
+    io::{BufRead, BufReader, BufWriter, Error, ErrorKind, Read, Write},
+    path::PathBuf,
+    sync::{Arc, Mutex},
+};
 
 use algebra::Algebra;
 use anyhow::Context;
+use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
+use sseq::coordinates::Bidegree;
 
 /// A DashSet<PathBuf>> of files that are currently opened and being written to. When calling this
 /// function for the first time, we set the ctrlc handler to delete currently opened files, then
 /// exit.
 fn open_files() -> &'static Mutex<HashSet<PathBuf>> {
-    use std::mem::MaybeUninit;
-    use std::sync::Once;
+    use std::{mem::MaybeUninit, sync::Once};
 
     static mut OPEN_FILES: MaybeUninit<Mutex<HashSet<PathBuf>>> = MaybeUninit::uninit();
     static ONCE: Once = Once::new();

--- a/ext/src/secondary.rs
+++ b/ext/src/secondary.rs
@@ -1,27 +1,36 @@
-use crate::chain_complex::{ChainComplex, ChainHomotopy, FreeChainComplex};
-use crate::resolution_homomorphism::ResolutionHomomorphism;
-use crate::save::{SaveFile, SaveKind};
-use crate::utils::Timer;
+use std::{
+    io::{Read, Write},
+    path::Path,
+    sync::Arc,
+};
 
-use algebra::module::homomorphism::{FreeModuleHomomorphism, ModuleHomomorphism};
-use algebra::module::{FreeModule, Module};
-use algebra::pair_algebra::PairAlgebra;
-use algebra::Algebra;
+use algebra::{
+    module::{
+        homomorphism::{FreeModuleHomomorphism, ModuleHomomorphism},
+        FreeModule, Module,
+    },
+    pair_algebra::PairAlgebra,
+    Algebra,
+};
 use bivec::BiVec;
-use fp::matrix::Matrix;
-use fp::prime::ValidPrime;
-use fp::vector::{FpVector, Slice, SliceMut};
+use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
+use dashmap::DashMap;
+use fp::{
+    matrix::Matrix,
+    prime::ValidPrime,
+    vector::{FpVector, Slice, SliceMut},
+};
+use itertools::Itertools;
+use maybe_rayon::prelude::*;
 use once::OnceBiVec;
 use sseq::coordinates::{Bidegree, BidegreeGenerator, BidegreeRange};
 
-use std::io::{Read, Write};
-use std::path::Path;
-use std::sync::Arc;
-
-use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
-use dashmap::DashMap;
-use itertools::Itertools;
-use maybe_rayon::prelude::*;
+use crate::{
+    chain_complex::{ChainComplex, ChainHomotopy, FreeChainComplex},
+    resolution_homomorphism::ResolutionHomomorphism,
+    save::{SaveFile, SaveKind},
+    utils::Timer,
+};
 
 pub static TAU_BIDEGREE: Bidegree = Bidegree::n_s(0, 1);
 
@@ -1150,6 +1159,7 @@ where
     type Source = S;
     type Target = U;
     type Underlying = ChainHomotopy<S, T, U>;
+
     const HIT_GENERATOR: bool = true;
 
     fn underlying(&self) -> Arc<Self::Underlying> {
@@ -1379,9 +1389,10 @@ where
 
 #[cfg(test)]
 mod test {
+    use serde_json::json;
+
     use super::*;
     use crate::utils;
-    use serde_json::json;
 
     #[test]
     #[should_panic(

--- a/ext/src/utils.rs
+++ b/ext/src/utils.rs
@@ -1,20 +1,23 @@
 //! A module containing various utility functions related to user interaction in some way.
-use crate::chain_complex::{
-    AugmentedChainComplex, BoundedChainComplex, ChainComplex, FiniteChainComplex,
+use std::{
+    convert::{TryFrom, TryInto},
+    path::PathBuf,
+    sync::Arc,
 };
 
-use crate::resolution::{Resolution, UnstableResolution};
-use crate::CCC;
-use algebra::module::{steenrod_module, FDModule, Module, SteenrodModule};
-use algebra::{AlgebraType, MilnorAlgebra, SteenrodAlgebra};
-
+use algebra::{
+    module::{steenrod_module, FDModule, Module, SteenrodModule},
+    AlgebraType, MilnorAlgebra, SteenrodAlgebra,
+};
 use anyhow::{anyhow, Context};
 use serde_json::Value;
 use sseq::coordinates::{Bidegree, BidegreeGenerator};
 
-use std::convert::{TryFrom, TryInto};
-use std::path::PathBuf;
-use std::sync::Arc;
+use crate::{
+    chain_complex::{AugmentedChainComplex, BoundedChainComplex, ChainComplex, FiniteChainComplex},
+    resolution::{Resolution, UnstableResolution},
+    CCC,
+};
 
 // We build docs with --all-features so the docs are at the feature = "nassau" version
 #[cfg(not(feature = "nassau"))]
@@ -216,9 +219,9 @@ where
     let cofiber = &json["cofiber"];
     if !cofiber.is_null() {
         assert!(!U, "Cofiber not supported for unstable resolution");
-        use crate::chain_complex::ChainMap;
-        use crate::yoneda::yoneda_representative;
         use algebra::module::homomorphism::FreeModuleHomomorphism;
+
+        use crate::{chain_complex::ChainMap, yoneda::yoneda_representative};
 
         let shift = json["shift"].as_i64().unwrap_or(0) as i32;
 
@@ -462,8 +465,7 @@ pub fn get_unit(
 
 #[cfg(feature = "logging")]
 mod logging {
-    use std::io::Write;
-    use std::time::Instant;
+    use std::{io::Write, time::Instant};
 
     /// If the `logging` feature is enabled, this can be used to time how long an operation takes.
     /// If the `logging` features is disabled, this is a no-op.
@@ -567,8 +569,7 @@ mod logging {
     }
 }
 
-pub use logging::LogWriter;
-pub use logging::Timer;
+pub use logging::{LogWriter, Timer};
 
 /// The value of the SECONDARY_JOB environment variable. This is used for distributing the
 /// `secondary`. If set, only data with `s = SECONDARY_JOB` will be computed. The minimum value of

--- a/ext/src/yoneda.rs
+++ b/ext/src/yoneda.rs
@@ -1,24 +1,30 @@
-use crate::chain_complex::{
-    AugmentedChainComplex, BoundedChainComplex, ChainComplex, ChainMap,
-    FiniteAugmentedChainComplex, FiniteChainComplex, FreeChainComplex,
-};
-use crate::resolution_homomorphism::ResolutionHomomorphism;
-use algebra::module::homomorphism::{
-    FreeModuleHomomorphism, FullModuleHomomorphism, IdentityHomomorphism, ModuleHomomorphism,
-};
-use algebra::module::homomorphism::{QuotientHomomorphism, QuotientHomomorphismSource};
-use algebra::module::QuotientModule as QM;
-use algebra::module::{FDModule, FreeModule, Module};
-use algebra::{AdemAlgebra, Algebra, GeneratedAlgebra, MilnorAlgebra, SteenrodAlgebra};
+use std::sync::Arc;
 
-use fp::matrix::{AugmentedMatrix, Matrix, Subspace};
-use fp::vector::FpVector;
-
+use algebra::{
+    module::{
+        homomorphism::{
+            FreeModuleHomomorphism, FullModuleHomomorphism, IdentityHomomorphism,
+            ModuleHomomorphism, QuotientHomomorphism, QuotientHomomorphismSource,
+        },
+        FDModule, FreeModule, Module, QuotientModule as QM,
+    },
+    AdemAlgebra, Algebra, GeneratedAlgebra, MilnorAlgebra, SteenrodAlgebra,
+};
 use bivec::BiVec;
-
+use fp::{
+    matrix::{AugmentedMatrix, Matrix, Subspace},
+    vector::FpVector,
+};
 use rustc_hash::FxHashSet as HashSet;
 use sseq::coordinates::Bidegree;
-use std::sync::Arc;
+
+use crate::{
+    chain_complex::{
+        AugmentedChainComplex, BoundedChainComplex, ChainComplex, ChainMap,
+        FiniteAugmentedChainComplex, FiniteChainComplex, FreeChainComplex,
+    },
+    resolution_homomorphism::ResolutionHomomorphism,
+};
 
 const PENALTY_UNIT: i32 = 10000;
 

--- a/ext/tests/extend_identity.rs
+++ b/ext/tests/extend_identity.rs
@@ -1,15 +1,18 @@
-use algebra::module::homomorphism::{FullModuleHomomorphism, IdentityHomomorphism};
-use algebra::module::Module;
-use ext::chain_complex::{AugmentedChainComplex, ChainComplex};
-use ext::resolution_homomorphism::ResolutionHomomorphism;
-use ext::utils::{construct, Config};
+use std::{convert::TryInto, sync::Arc};
+
+use algebra::module::{
+    homomorphism::{FullModuleHomomorphism, IdentityHomomorphism},
+    Module,
+};
+use ext::{
+    chain_complex::{AugmentedChainComplex, ChainComplex},
+    resolution_homomorphism::ResolutionHomomorphism,
+    utils::{construct, Config},
+};
 use fp::vector::FpVector;
+use rstest::rstest;
 use serde_json::json;
 use sseq::coordinates::Bidegree;
-use std::convert::TryInto;
-use std::sync::Arc;
-
-use rstest::rstest;
 
 #[rstest]
 #[trace]

--- a/ext/tests/milnor_vs_adem.rs
+++ b/ext/tests/milnor_vs_adem.rs
@@ -1,5 +1,7 @@
-use ext::chain_complex::{ChainComplex, FreeChainComplex};
-use ext::utils::{construct, construct_standard};
+use ext::{
+    chain_complex::{ChainComplex, FreeChainComplex},
+    utils::{construct, construct_standard},
+};
 use rstest::rstest;
 use sseq::coordinates::Bidegree;
 

--- a/ext/tests/milnor_vs_nassau.rs
+++ b/ext/tests/milnor_vs_nassau.rs
@@ -1,5 +1,7 @@
-use ext::chain_complex::{ChainComplex, FreeChainComplex};
-use ext::utils::{construct_nassau, construct_standard};
+use ext::{
+    chain_complex::{ChainComplex, FreeChainComplex},
+    utils::{construct_nassau, construct_standard},
+};
 use rstest::rstest;
 use sseq::coordinates::Bidegree;
 

--- a/ext/tests/non_zero_min_degree.rs
+++ b/ext/tests/non_zero_min_degree.rs
@@ -1,6 +1,8 @@
 use algebra::module::Module;
-use ext::chain_complex::{AugmentedChainComplex, ChainComplex};
-use ext::utils::construct;
+use ext::{
+    chain_complex::{AugmentedChainComplex, ChainComplex},
+    utils::construct,
+};
 use sseq::coordinates::Bidegree;
 
 #[test]

--- a/ext/tests/resolve_iterate.rs
+++ b/ext/tests/resolve_iterate.rs
@@ -1,7 +1,8 @@
 use algebra::AlgebraType;
-use ext::chain_complex::{ChainComplex, FreeChainComplex};
-use ext::utils::construct;
-use ext::utils::load_module_json;
+use ext::{
+    chain_complex::{ChainComplex, FreeChainComplex},
+    utils::{construct, load_module_json},
+};
 use rstest::rstest;
 use sseq::coordinates::Bidegree;
 

--- a/ext/tests/save_load_resolution.rs
+++ b/ext/tests/save_load_resolution.rs
@@ -1,12 +1,16 @@
-use algebra::module::homomorphism::ModuleHomomorphism;
-use ext::chain_complex::{ChainComplex, FreeChainComplex};
-use ext::save::SaveKind;
-use ext::secondary::{SecondaryLift, SecondaryResolution};
-use ext::utils::construct_standard;
-use sseq::coordinates::Bidegree;
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 
-use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use algebra::module::homomorphism::ModuleHomomorphism;
+use ext::{
+    chain_complex::{ChainComplex, FreeChainComplex},
+    save::SaveKind,
+    secondary::{SecondaryLift, SecondaryResolution},
+    utils::construct_standard,
+};
+use sseq::coordinates::Bidegree;
 
 fn set_readonly(p: &Path, readonly: bool) {
     let mut perm = p.metadata().unwrap().permissions();
@@ -236,8 +240,10 @@ fn test_load_secondary() {
 #[test]
 #[should_panic]
 fn test_checksum() {
-    use std::fs::OpenOptions;
-    use std::io::{Seek, SeekFrom, Write};
+    use std::{
+        fs::OpenOptions,
+        io::{Seek, SeekFrom, Write},
+    };
 
     let tempdir = tempfile::TempDir::new().unwrap();
 

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,9 @@
+unstable_features = true
+format_code_in_doc_comments = true
+format_macro_matchers = true
+format_macro_bodies = true
+format_strings = true
+imports_granularity = "crate"
+reorder_impl_items = true
+reorder_imports = true
+group_imports = "StdExternalCrate"

--- a/web_ext/sseq_gui/src/actions.rs
+++ b/web_ext/sseq_gui/src/actions.rs
@@ -1,5 +1,3 @@
-use crate::resolution_wrapper::Resolution;
-use crate::sseq::{ClassState, ProductItem, SseqWrapper};
 use algebra::module::Module;
 use bivec::BiVec;
 use enum_dispatch::enum_dispatch;
@@ -8,6 +6,11 @@ use fp::vector::FpVector;
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use sseq::coordinates::{Bidegree, BidegreeGenerator};
+
+use crate::{
+    resolution_wrapper::Resolution,
+    sseq::{ClassState, ProductItem, SseqWrapper},
+};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Message {

--- a/web_ext/sseq_gui/src/main.rs
+++ b/web_ext/sseq_gui/src/main.rs
@@ -1,11 +1,9 @@
 use std::{fs, thread};
+
+use sseq_gui::{actions::*, managers::*, Sender};
 use textwrap::Wrapper;
 use time::OffsetDateTime;
 use ws::{listen, Handler, Request, Response, Result as WsResult, Sender as WsSender};
-
-use sseq_gui::actions::*;
-use sseq_gui::managers::*;
-use sseq_gui::Sender;
 
 /// List of files that our webserver will serve to the user
 const FILE_LIST: &[(&str, &str, &[u8])] = &[

--- a/web_ext/sseq_gui/src/managers.rs
+++ b/web_ext/sseq_gui/src/managers.rs
@@ -1,18 +1,14 @@
-use crate::actions::*;
-use crate::sseq::SseqWrapper;
-
-use crate::resolution_wrapper::Resolution;
-use algebra::module::Module;
-use algebra::Algebra;
-use ext::chain_complex::{BoundedChainComplex, ChainComplex};
-use ext::utils::load_module_json;
-use ext::CCC;
-
+use algebra::{module::Module, Algebra};
 use anyhow::{anyhow, Context};
+use ext::{
+    chain_complex::{BoundedChainComplex, ChainComplex},
+    utils::load_module_json,
+    CCC,
+};
 use serde_json::json;
 use sseq::coordinates::Bidegree;
 
-use crate::Sender;
+use crate::{actions::*, resolution_wrapper::Resolution, sseq::SseqWrapper, Sender};
 
 /// ResolutionManager is a struct that manipulates a Resolution. It is constructed with a "sender"
 /// which is used to relay the results of the computation. This sender should send all messages to

--- a/web_ext/sseq_gui/src/resolution_wrapper.rs
+++ b/web_ext/sseq_gui/src/resolution_wrapper.rs
@@ -1,19 +1,20 @@
+use std::sync::Arc;
+
+use algebra::{
+    module::{homomorphism::FreeModuleHomomorphism, FreeModule, Module},
+    Algebra,
+};
+use ext::{
+    chain_complex::{AugmentedChainComplex, ChainComplex, FreeChainComplex},
+    resolution::Resolution as ResolutionInner,
+    resolution_homomorphism::ResolutionHomomorphism as ResolutionHomomorphism_,
+};
+use fp::{matrix::Matrix, prime::ValidPrime};
+use once::{OnceBiVec, OnceVec};
 use rustc_hash::FxHashSet as HashSet;
 use serde::Deserialize;
 use serde_json::Value;
 use sseq::coordinates::Bidegree;
-use std::sync::Arc;
-
-use algebra::module::homomorphism::FreeModuleHomomorphism;
-use algebra::module::{FreeModule, Module};
-use algebra::Algebra;
-use ext::chain_complex::{AugmentedChainComplex, ChainComplex, FreeChainComplex};
-use ext::resolution::Resolution as ResolutionInner;
-use fp::matrix::Matrix;
-use fp::prime::ValidPrime;
-use once::{OnceBiVec, OnceVec};
-
-use ext::resolution_homomorphism::ResolutionHomomorphism as ResolutionHomomorphism_;
 
 use crate::actions::{Action, Message};
 pub type ResolutionHomomorphism<CC> =

--- a/web_ext/sseq_gui/src/sseq.rs
+++ b/web_ext/sseq_gui/src/sseq.rs
@@ -1,16 +1,15 @@
-use crate::actions::*;
-use crate::Sender;
+use std::{cmp::max, collections::BTreeMap};
+
 use bivec::BiVec;
-use fp::prime::ValidPrime;
-use fp::vector::FpVector;
 use fp::{
     matrix::{Matrix, Subquotient},
-    vector::Slice,
+    prime::ValidPrime,
+    vector::{FpVector, Slice},
 };
 use serde::{Deserialize, Serialize};
 use sseq::{Adams, Sseq, SseqProfile};
-use std::cmp::max;
-use std::collections::BTreeMap;
+
+use crate::{actions::*, Sender};
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize)]
 pub enum ClassState {

--- a/web_ext/sseq_gui/src/wasm_bindings.rs
+++ b/web_ext/sseq_gui/src/wasm_bindings.rs
@@ -1,7 +1,7 @@
-use crate::actions::*;
-use crate::managers::*;
 use js_sys::Function;
 use wasm_bindgen::prelude::*;
+
+use crate::{actions::*, managers::*};
 
 #[derive(Clone)]
 pub struct Sender {

--- a/web_ext/steenrod_calculator/src/lib.rs
+++ b/web_ext/steenrod_calculator/src/lib.rs
@@ -1,5 +1,4 @@
-use algebra::steenrod_evaluator::SteenrodEvaluator;
-use algebra::Algebra;
+use algebra::{steenrod_evaluator::SteenrodEvaluator, Algebra};
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]


### PR DESCRIPTION
This is a result of running `cargo +nightly fmt` on the repository with the following rustfmt.toml:

```toml
unstable_features = true
format_code_in_doc_comments = true
format_macro_matchers = true
format_macro_bodies = true
format_strings = true
imports_granularity = "crate"
reorder_impl_items = true
reorder_imports = true
group_imports = "StdExternalCrate"
```

In the future I plan to use this configuration for my PRs. I feel it's a bit more systematic than the default settings