### PR TITLE
Introduce instrumentation using `tracing`

### DIFF
--- a/ext/Cargo.toml
+++ b/ext/Cargo.toml
@@ -31,6 +31,8 @@ itertools = { version = "0.10.0", default-features = false, features = [
 ] }
 rustc-hash = "1.1.0"
 serde_json = { version = "1.0.0", features = ["preserve_order"] }
+tracing = "0.1.40"
+tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 
 zstd = { version = "0.9.0", optional = true }
 

--- a/ext/examples/resolve_through_stem.rs
+++ b/ext/examples/resolve_through_stem.rs
@@ -23,6 +23,8 @@ use ext::chain_complex::FreeChainComplex;
 use sseq::coordinates::Bidegree;
 
 fn main() -> anyhow::Result<()> {
+    ext::utils::init_logging();
+
     let res = ext::utils::query_module_only("Module", None, false)?;
 
     let max = Bidegree::n_s(

--- a/ext/examples/secondary.rs
+++ b/ext/examples/secondary.rs
@@ -56,6 +56,8 @@ use ext::{
 use sseq::coordinates::{Bidegree, BidegreeGenerator};
 
 fn main() -> anyhow::Result<()> {
+    ext::utils::init_logging();
+
     let resolution = Arc::new(query_module(Some(algebra::AlgebraType::Milnor), true)?);
 
     let lift = SecondaryResolution::new(Arc::clone(&resolution));
@@ -64,9 +66,7 @@ fn main() -> anyhow::Result<()> {
         return Ok(());
     }
 
-    let timer = ext::utils::Timer::start();
     lift.extend_all();
-    timer.end(format_args!("Total computation time"));
 
     let d2_shift = Bidegree::n_s(-1, 2);
 

--- a/ext/examples/secondary_massey.rs
+++ b/ext/examples/secondary_massey.rs
@@ -124,6 +124,8 @@ fn get_hom(
 }
 
 fn main() -> anyhow::Result<()> {
+    ext::utils::init_logging();
+
     eprintln!(
         "We are going to compute <-, b, a> for all (-), where a is an element in Ext(M, k) and b \
          and (-) are elements in Ext(k, k)."
@@ -235,9 +237,7 @@ fn main() -> anyhow::Result<()> {
         return Ok(());
     }
 
-    let timer = ext::utils::Timer::start();
     ch_lift.extend_all();
-    timer.end(format_args!("Total computation time"));
 
     fn get_page_data(sseq: &sseq::Sseq, b: Bidegree) -> &fp::matrix::Subquotient {
         let d = sseq.page_data(b.n(), b.s() as i32);

--- a/ext/examples/secondary_product.rs
+++ b/ext/examples/secondary_product.rs
@@ -34,6 +34,8 @@ use itertools::Itertools;
 use sseq::coordinates::{Bidegree, BidegreeElement, BidegreeGenerator};
 
 fn main() -> anyhow::Result<()> {
+    ext::utils::init_logging();
+
     let resolution = Arc::new(query_module(Some(algebra::AlgebraType::Milnor), true)?);
 
     let (is_unit, unit) = ext::utils::get_unit(Arc::clone(&resolution))?;
@@ -108,11 +110,7 @@ fn main() -> anyhow::Result<()> {
         return Ok(());
     }
 
-    let timer = ext::utils::Timer::start();
-
     hom_lift.extend_all();
-
-    timer.end(format_args!("Total computation time"));
 
     // Compute E3 page
     let res_sseq = Arc::new(res_lift.e3_page());

--- a/ext/src/nassau.rs
+++ b/ext/src/nassau.rs
@@ -42,7 +42,7 @@ use sseq::coordinates::Bidegree;
 use crate::{
     chain_complex::{AugmentedChainComplex, ChainComplex, FiniteChainComplex, FreeChainComplex},
     save::SaveKind,
-    utils::{LogWriter, Timer},
+    utils::LogWriter,
 };
 
 /// See [`resolution::SenderData`](../resolution/struct.SenderData.html). This differs by not having the `new` field.
@@ -480,10 +480,9 @@ impl<M: ZeroModule<Algebra = MilnorAlgebra>> Resolution<M> {
         });
     }
 
+    #[tracing::instrument(skip_all, fields(signature = ?signature, throughput))]
     fn write_qi(
         f: &mut Option<impl Write>,
-        b: Bidegree,
-        subalgebra: &MilnorSubalgebra,
         scratch: &mut FpVector,
         signature: &[PPartEntry],
         next_mask: &[usize],
@@ -527,9 +526,10 @@ impl<M: ZeroModule<Algebra = MilnorAlgebra>> Resolution<M> {
             scratch.to_bytes(f)?;
         }
 
-        own_f.finalize(format_args!(
-            "Written quasi-inverse for bidegree {b} and signature {signature:?}, with {subalgebra}"
-        ));
+        tracing::Span::current().record(
+            "throughput",
+            tracing::field::display(own_f.into_throughput()),
+        );
         Ok(())
     }
 
@@ -553,19 +553,18 @@ impl<M: ZeroModule<Algebra = MilnorAlgebra>> Resolution<M> {
         Ok(())
     }
 
+    #[tracing::instrument(skip(self), fields(b = %b, subalgebra = %subalgebra, num_new_gens, density))]
     fn step_resolution_with_subalgebra(
         &self,
         b: Bidegree,
         subalgebra: MilnorSubalgebra,
     ) -> anyhow::Result<()> {
-        let timer = Timer::start();
         let end = || {
-            timer.end(format_args!(
-                "Computed bidegree {b} with {subalgebra}, num new gens = {num_new_gens}, density \
-                 = {density:.2}%",
-                num_new_gens = self.number_of_gens_in_bidegree(b),
-                density = self.differentials[b.s()].differential_density(b.t()) * 100.0,
-            ));
+            tracing::Span::current().record("num_new_gens", self.number_of_gens_in_bidegree(b));
+            tracing::Span::current().record(
+                "density",
+                self.differentials[b.s()].differential_density(b.t()) * 100.0,
+            );
         };
 
         let p = self.prime();
@@ -615,8 +614,6 @@ impl<M: ZeroModule<Algebra = MilnorAlgebra>> Resolution<M> {
 
         Self::write_qi(
             &mut f,
-            b,
-            &subalgebra,
             &mut scratch,
             &zero_sig,
             &next_mask,
@@ -699,8 +696,6 @@ impl<M: ZeroModule<Algebra = MilnorAlgebra>> Resolution<M> {
             }
             Self::write_qi(
                 &mut f,
-                b,
-                &subalgebra,
                 &mut scratch,
                 &signature,
                 &next_mask,
@@ -891,13 +886,17 @@ impl<M: ZeroModule<Algebra = MilnorAlgebra>> Resolution<M> {
     }
 
     /// This function resolves up till a fixed stem instead of a fixed t.
+    #[tracing::instrument(skip(self), fields(self = self.name, max = %max))]
     pub fn compute_through_stem(&self, max: Bidegree) {
         let _lock = self.lock.lock();
 
         self.extend_through_degree(max.s());
         self.algebra().compute_basis(max.t());
 
+        let tracing_span = tracing::Span::current();
         maybe_rayon::in_place_scope(|scope| {
+            let _tracing_guard = tracing_span.enter();
+
             // This algorithm is not optimal, as we compute (s, t) only after computing (s - 1, t)
             // and (s, t - 1). In theory, it suffices to wait for (s, t - 1) and (s - 1, t - 1),
             // but having the dimensions of the modules change halfway through the computation is
@@ -916,7 +915,9 @@ impl<M: ZeroModule<Algebra = MilnorAlgebra>> Resolution<M> {
                 if self.has_computed_bidegree(b) {
                     SenderData::send(b, sender);
                 } else {
+                    let tracing_span = tracing_span.clone();
                     scope.spawn(move |_| {
+                        let _tracing_guard = tracing_span.enter();
                         self.step_resolution(b);
                         SenderData::send(b, sender);
                     });
@@ -974,6 +975,7 @@ impl<M: ZeroModule<Algebra = MilnorAlgebra>> ChainComplex for Resolution<M> {
         Arc::clone(&self.differentials[s as usize])
     }
 
+    #[tracing::instrument(skip(self), fields(self = self.name, max = %max))]
     fn compute_through_bidegree(&self, max: Bidegree) {
         let _lock = self.lock.lock();
 

--- a/ext/src/resolution_homomorphism.rs
+++ b/ext/src/resolution_homomorphism.rs
@@ -114,6 +114,7 @@ where
     /// This assumes in yet-uncomputed bidegrees, the homology of the source consists only of
     /// decomposables (e.g. it is trivial). More precisely, we assume
     /// [`MuResolutionHomomorphism::extend_step_raw`] can be called with `extra_images = None`.
+    #[tracing::instrument(fields(self = self.name, max = %max))]
     pub fn extend(&self, max: Bidegree) {
         self.extend_profile(BidegreeRange::new(&(), max.s() + 1, &|_, _| max.t() + 1))
     }
@@ -124,6 +125,7 @@ where
     /// This assumes in yet-uncomputed bidegrees, the homology of the source consists only of
     /// decomposables (e.g. it is trivial). More precisely, we assume
     /// [`MuResolutionHomomorphism::extend_step_raw`] can be called with `extra_images = None`.
+    #[tracing::instrument(fields(self = self.name, max = %max))]
     pub fn extend_through_stem(&self, max: Bidegree) {
         self.extend_profile(BidegreeRange::new(&(), max.s() + 1, &|_, s| {
             max.n() + s as i32 + 1
@@ -136,6 +138,7 @@ where
     /// This assumes in yet-uncomputed bidegrees, the homology of the source consists only of
     /// decomposables (e.g. it is trivial). More precisely, we assume
     /// [`MuResolutionHomomorphism::extend_step_raw`] can be called with `extra_images = None`.
+    #[tracing::instrument(fields(self = self.name))]
     pub fn extend_all(&self) {
         self.extend_profile(BidegreeRange::new(
             self,

--- a/ext/src/utils.rs
+++ b/ext/src/utils.rs
@@ -463,41 +463,13 @@ pub fn get_unit(
     Ok((is_unit, unit))
 }
 
-#[cfg(feature = "logging")]
 mod logging {
-    use std::{io::Write, time::Instant};
-
-    /// If the `logging` feature is enabled, this can be used to time how long an operation takes.
-    /// If the `logging` features is disabled, this is a no-op.
-    ///
-    /// # Example
-    /// ```
-    /// # use logging::Timer;
-    /// let timer = Timer::start();
-    /// // slow_function();
-    /// timer.end(format_args!("Ran slow_function"));
-    /// ```
-    pub struct Timer(Instant);
-
-    impl Timer {
-        pub fn start() -> Self {
-            Self(Instant::now())
-        }
-
-        pub fn end(self, msg: std::fmt::Arguments) {
-            let duration = self.0.elapsed();
-            eprintln!(
-                "[{:>6}.{:>06} s] {msg}",
-                duration.as_secs(),
-                duration.subsec_micros(),
-            );
-        }
-    }
+    use std::io::Write;
 
     pub struct LogWriter<T> {
         writer: T,
         bytes: u64,
-        timer: Timer,
+        start: std::time::Instant,
     }
 
     impl<T: Write> Write for LogWriter<T> {
@@ -517,59 +489,58 @@ mod logging {
             LogWriter {
                 writer,
                 bytes: 0,
-                timer: Timer::start(),
+                start: std::time::Instant::now(),
             }
         }
     }
 
+    pub struct Throughput(f64);
+
+    impl std::fmt::Display for Throughput {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "{:.2} MiB/s", self.0)
+        }
+    }
+
     impl<T: Write> LogWriter<T> {
-        pub fn finalize(mut self, msg: std::fmt::Arguments) {
+        /// Return the throughput in MiB/s
+        pub fn into_throughput(mut self) -> Throughput {
             self.writer.flush().unwrap();
-            let duration = self.timer.0.elapsed();
+            let duration = self.start.elapsed();
             let mib = self.bytes as f64 / (1024 * 1024) as f64;
-            let mib_per_second = mib / duration.as_secs_f64();
-            self.timer
-                .end(format_args!("[{mib_per_second:>9.3} MiB/s] {msg}"));
+            Throughput(mib / duration.as_secs_f64())
         }
+    }
+
+    #[cfg(feature = "logging")]
+    pub fn ext_tracing_subscriber() -> impl tracing::Subscriber {
+        use tracing_subscriber::{
+            filter::EnvFilter,
+            fmt::{format::FmtSpan, Subscriber},
+        };
+
+        Subscriber::builder()
+            .pretty()
+            .with_writer(std::io::stdout)
+            .with_max_level(tracing::Level::INFO)
+            .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE)
+            .with_thread_ids(true)
+            .with_env_filter(EnvFilter::try_from_default_env().unwrap())
+            .finish()
+    }
+
+    #[cfg(not(feature = "logging"))]
+    pub fn ext_tracing_subscriber() -> impl tracing::Subscriber {
+        tracing::subscriber::NoSubscriber::new()
+    }
+
+    pub fn init_logging() {
+        tracing::subscriber::set_global_default(ext_tracing_subscriber())
+            .expect("Failed to enable logging");
     }
 }
 
-#[cfg(not(feature = "logging"))]
-mod logging {
-    use std::io::Write;
-
-    pub struct Timer;
-
-    impl Timer {
-        pub fn start() -> Self {
-            Self {}
-        }
-
-        pub fn end(self, _msg: std::fmt::Arguments) {}
-    }
-
-    pub struct LogWriter<T>(T);
-
-    impl<T: Write> Write for LogWriter<T> {
-        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-            self.0.write(buf)
-        }
-
-        fn flush(&mut self) -> std::io::Result<()> {
-            self.0.flush()
-        }
-    }
-
-    impl<T> LogWriter<T> {
-        pub fn new(writer: T) -> Self {
-            LogWriter(writer)
-        }
-
-        pub fn finalize(self, _msg: std::fmt::Arguments) {}
-    }
-}
-
-pub use logging::{LogWriter, Timer};
+pub use logging::{ext_tracing_subscriber, init_logging, LogWriter};
 
 /// The value of the SECONDARY_JOB environment variable. This is used for distributing the
 /// `secondary`. If set, only data with `s = SECONDARY_JOB` will be computed. The minimum value of

--- a/ext/src/yoneda.rs
+++ b/ext/src/yoneda.rs
@@ -189,6 +189,7 @@ where
 }
 
 #[allow(clippy::cognitive_complexity)]
+#[tracing::instrument(skip_all)]
 pub fn yoneda_representative_with_strategy<CC>(
     cc: Arc<CC>,
     map: ChainMap<FreeModuleHomomorphism<impl Module<Algebra = CC::Algebra>>>,
@@ -255,7 +256,8 @@ where
         .collect::<Vec<_>>();
 
     for s in (1..=s_max).rev() {
-        let timer = crate::utils::Timer::start();
+        let span = tracing::info_span!("Cleaning yoneda representative", s);
+        let _tracing_guard = span.enter();
         let t_max = t_max[s as usize];
         let mut differential_images: BiVec<Subspace> = {
             let mut result = BiVec::new(t_min);
@@ -501,8 +503,6 @@ where
                 check!(t);
             }
         }
-
-        timer.end(format_args!("Cleaned yoneda representative for s = {s}"));
     }
 
     let modules = modules.into_iter().map(Arc::new).collect::<Vec<_>>();


### PR DESCRIPTION
This is a more systematic solution than our previous homemade logging mechanism. I was worrying that the overhead might be too large, but the performance impact is only on a per-callsite basis. Even adding a few spans in the hottest code in `fp` doesn't measurably affect runtime.