### PR TITLE
Ensure odd primes aren't defined when `odd-primes` is disabled

### DIFF
--- a/ext/crates/fp/src/prime/mod.rs
+++ b/ext/crates/fp/src/prime/mod.rs
@@ -11,11 +11,16 @@ use serde::{de::Error, Deserialize, Deserializer, Serialize, Serializer};
 pub mod binomial;
 pub mod iter;
 
-pub use binomial::Binomial;
+#[cfg(not(feature = "odd-primes"))]
+pub mod primes_2;
+#[cfg(feature = "odd-primes")]
+pub mod primes_generic;
 
-pub mod primes {
-    pub use super::{ValidPrime, P2, P3, P5, P7};
-}
+pub use binomial::Binomial;
+#[cfg(not(feature = "odd-primes"))]
+pub use primes_2::*;
+#[cfg(feature = "odd-primes")]
+pub use primes_generic::*;
 
 pub const TWO: ValidPrime = ValidPrime::new(2);
 
@@ -135,11 +140,6 @@ macro_rules! def_prime_static {
     };
 }
 
-def_prime_static!(P2, 2);
-def_prime_static!(P3, 3);
-def_prime_static!(P5, 5);
-def_prime_static!(P7, 7);
-
 macro_rules! impl_op_pn_u32 {
     ($pn:ty, $trt:ident, $mth:ident, $trt_assign:ident, $mth_assign:ident, $operator:tt) => {
         impl $trt<$pn> for u32 {
@@ -210,11 +210,6 @@ macro_rules! impl_prime_ops {
     };
 }
 
-impl_prime_ops!(P2);
-impl_prime_ops!(P3);
-impl_prime_ops!(P5);
-impl_prime_ops!(P7);
-
 macro_rules! impl_try_from {
     // We need the type both as a type and as an expression.
     ($pn:ty, $pn_ex:expr) => {
@@ -232,151 +227,11 @@ macro_rules! impl_try_from {
     };
 }
 
-impl_try_from!(P2, P2);
-impl_try_from!(P3, P3);
-impl_try_from!(P5, P5);
-impl_try_from!(P7, P7);
-
-#[cfg(feature = "odd-primes")]
-mod validprime {
-    use std::str::FromStr;
-
-    use super::*;
-
-    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-    pub struct ValidPrime {
-        p: u32,
-    }
-
-    pub const fn is_prime(p: u32) -> bool {
-        // (2..p).all(|k| p % k != 0), but make it const
-        let mut k = 2;
-        while k < p {
-            if p % k == 0 {
-                return false;
-            }
-            k += 1;
-        }
-        true
-    }
-
-    impl ValidPrime {
-        pub const fn new(p: u32) -> ValidPrime {
-            // We need the size restriction for a few reasons.
-            //
-            // First, we need `bit_length(p)` to be smaller than 64. Otherwise, shifting a u64 by 64
-            // bits is considered an overflow. We could special case these shifts to be setting to
-            // 0, but that doesn't seem worth it.
-            //
-            // More importantly, the existence of `Prime::as_i32` means that we need `p` to fit in
-            // an i32. We want this method because there are a few places in the codebase that
-            // use it. It might be possible to go and change all of those to use `as_u32` instead,
-            // but it doesn't seem worth it for now.
-            assert!(p < (1 << 31), "Tried to construct a prime larger than 2^31");
-            assert!(is_prime(p), "Tried to construct a composite dynamic prime");
-            ValidPrime { p }
-        }
-
-        pub const fn new_unchecked(p: u32) -> ValidPrime {
-            ValidPrime { p }
-        }
-    }
-
-    impl Prime for ValidPrime {
-        fn as_i32(self) -> i32 {
-            self.p as i32
-        }
-
-        fn to_dyn(self) -> ValidPrime {
-            self
-        }
-    }
-
-    impl_prime_ops!(ValidPrime);
-
-    impl TryFrom<u32> for ValidPrime {
-        type Error = PrimeError;
-
-        fn try_from(p: u32) -> Result<Self, PrimeError> {
-            if is_prime(p) {
-                Ok(ValidPrime { p })
-            } else {
-                Err(PrimeError::InvalidPrime(p))
-            }
-        }
-    }
-
-    impl FromStr for ValidPrime {
-        type Err = PrimeError;
-
-        fn from_str(s: &str) -> Result<Self, Self::Err> {
-            let p: u32 = s.parse().map_err(PrimeError::NotAnInteger)?;
-            ValidPrime::try_from(p)
-        }
-    }
-
-    impl Serialize for ValidPrime {
-        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-        where
-            S: Serializer,
-        {
-            self.as_u32().serialize(serializer)
-        }
-    }
-
-    impl<'de> Deserialize<'de> for ValidPrime {
-        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-        where
-            D: Deserializer<'de>,
-        {
-            let p: u32 = u32::deserialize(deserializer)?;
-            ValidPrime::try_from(p).map_err(D::Error::custom)
-        }
-    }
-}
-
-#[cfg(not(feature = "odd-primes"))]
-mod validprime {
-    use std::str::FromStr;
-
-    use super::PrimeError;
-
-    pub type ValidPrime = super::P2;
-
-    pub const fn is_prime(p: u32) -> bool {
-        p == 2
-    }
-
-    impl ValidPrime {
-        pub const fn new(_p: u32) -> ValidPrime {
-            // Disregard the argument, assume the prime is 2. This has the advantage of us being
-            // able to use the same tests independently of whether odd-primes is enabled or not.
-            //
-            // This is sound but can cause some problems for the user that could be hard to
-            // diagnose. Maybe use debug_assert! and fix the tests?
-            super::P2
-        }
-
-        pub const fn new_unchecked(_p: u32) -> ValidPrime {
-            super::P2
-        }
-    }
-
-    impl FromStr for ValidPrime {
-        type Err = PrimeError;
-
-        fn from_str(s: &str) -> Result<Self, Self::Err> {
-            let p = s.parse().map_err(PrimeError::NotAnInteger)?;
-            if p == 2 {
-                Ok(super::P2)
-            } else {
-                Err(PrimeError::InvalidPrime(p))
-            }
-        }
-    }
-}
-
-pub use validprime::{is_prime, ValidPrime};
+// Strange but required to export macro properly
+use def_prime_static;
+use impl_op_pn_u32;
+use impl_prime_ops;
+use impl_try_from;
 
 /// Compute b^e mod p. This is a const version of `Prime::pow_mod`.
 pub const fn power_mod(p: u32, mut b: u32, mut e: u32) -> u32 {

--- a/ext/crates/fp/src/prime/primes_2.rs
+++ b/ext/crates/fp/src/prime/primes_2.rs
@@ -1,0 +1,41 @@
+use std::str::FromStr;
+
+use super::*;
+
+def_prime_static!(P2, 2);
+impl_prime_ops!(P2);
+impl_try_from!(P2, P2);
+
+pub type ValidPrime = P2;
+
+pub const fn is_prime(p: u32) -> bool {
+    p == 2
+}
+
+impl ValidPrime {
+    pub const fn new(_p: u32) -> ValidPrime {
+        // Disregard the argument, assume the prime is 2. This has the advantage of us being
+        // able to use the same tests independently of whether odd-primes is enabled or not.
+        //
+        // This is sound but can cause some problems for the user that could be hard to
+        // diagnose. Maybe use debug_assert! and fix the tests?
+        P2
+    }
+
+    pub const fn new_unchecked(_p: u32) -> ValidPrime {
+        P2
+    }
+}
+
+impl FromStr for ValidPrime {
+    type Err = PrimeError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let p = s.parse().map_err(PrimeError::NotAnInteger)?;
+        if p == 2 {
+            Ok(P2)
+        } else {
+            Err(PrimeError::InvalidPrime(p))
+        }
+    }
+}

--- a/ext/crates/fp/src/prime/primes_generic.rs
+++ b/ext/crates/fp/src/prime/primes_generic.rs
@@ -1,0 +1,109 @@
+use std::str::FromStr;
+
+use super::*;
+
+def_prime_static!(P2, 2);
+def_prime_static!(P3, 3);
+def_prime_static!(P5, 5);
+def_prime_static!(P7, 7);
+
+impl_prime_ops!(P2);
+impl_prime_ops!(P3);
+impl_prime_ops!(P5);
+impl_prime_ops!(P7);
+
+impl_try_from!(P2, P2);
+impl_try_from!(P3, P3);
+impl_try_from!(P5, P5);
+impl_try_from!(P7, P7);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct ValidPrime {
+    p: u32,
+}
+
+pub const fn is_prime(p: u32) -> bool {
+    // (2..p).all(|k| p % k != 0), but make it const
+    let mut k = 2;
+    while k < p {
+        if p % k == 0 {
+            return false;
+        }
+        k += 1;
+    }
+    true
+}
+
+impl ValidPrime {
+    pub const fn new(p: u32) -> ValidPrime {
+        // We need the size restriction for a few reasons.
+        //
+        // First, we need `bit_length(p)` to be smaller than 64. Otherwise, shifting a u64 by 64
+        // bits is considered an overflow. We could special case these shifts to be setting to
+        // 0, but that doesn't seem worth it.
+        //
+        // More importantly, the existence of `Prime::as_i32` means that we need `p` to fit in
+        // an i32. We want this method because there are a few places in the codebase that
+        // use it. It might be possible to go and change all of those to use `as_u32` instead,
+        // but it doesn't seem worth it for now.
+        assert!(p < (1 << 31), "Tried to construct a prime larger than 2^31");
+        assert!(is_prime(p), "Tried to construct a composite dynamic prime");
+        ValidPrime { p }
+    }
+
+    pub const fn new_unchecked(p: u32) -> ValidPrime {
+        ValidPrime { p }
+    }
+}
+
+impl Prime for ValidPrime {
+    fn as_i32(self) -> i32 {
+        self.p as i32
+    }
+
+    fn to_dyn(self) -> ValidPrime {
+        self
+    }
+}
+
+impl_prime_ops!(ValidPrime);
+
+impl TryFrom<u32> for ValidPrime {
+    type Error = PrimeError;
+
+    fn try_from(p: u32) -> Result<Self, PrimeError> {
+        if is_prime(p) {
+            Ok(ValidPrime { p })
+        } else {
+            Err(PrimeError::InvalidPrime(p))
+        }
+    }
+}
+
+impl FromStr for ValidPrime {
+    type Err = PrimeError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let p: u32 = s.parse().map_err(PrimeError::NotAnInteger)?;
+        ValidPrime::try_from(p)
+    }
+}
+
+impl Serialize for ValidPrime {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.as_u32().serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for ValidPrime {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let p: u32 = u32::deserialize(deserializer)?;
+        ValidPrime::try_from(p).map_err(D::Error::custom)
+    }
+}

--- a/ext/crates/fp/src/vector/vector_generic.rs
+++ b/ext/crates/fp/src/vector/vector_generic.rs
@@ -19,7 +19,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use super::iter::{FpVectorIterator, FpVectorNonZeroIteratorP};
 use crate::{
     limb::{entries_per_limb, Limb},
-    prime::{primes::*, Prime, ValidPrime},
+    prime::{Prime, ValidPrime, P2, P3, P5, P7},
     vector::inner::{FpVectorP, SliceMutP, SliceP},
 };
 


### PR DESCRIPTION
Since we moved to typed primes instead of `const u32`s in #145, it makes more sense to have 2 be the only prime that's defined when `odd-primes` is disabled. This gives us a type-level sanity check that all prime operations will be over 2, no matter which `P: Prime` is used as the generic.