### PR TITLE
Move to an owned representation for `BidegreeElement`

### DIFF
--- a/ext/crates/sseq/src/coordinates/element.rs
+++ b/ext/crates/sseq/src/coordinates/element.rs
@@ -4,22 +4,22 @@ use algebra::{
     module::{Module, MuFreeModule},
     MuAlgebra,
 };
-use fp::vector::Slice;
+use fp::vector::{FpVector, Slice};
 
 use crate::coordinates::{Bidegree, BidegreeGenerator};
 
 /// An element of a bigraded vector space. Most commonly used to index elements of spectral
 /// sequences.
 #[derive(Debug, Clone)]
-pub struct BidegreeElement<'a> {
+pub struct BidegreeElement {
     /// Bidegree of the element
     degree: Bidegree,
     /// Representing vector
-    vec: Slice<'a>,
+    vec: FpVector,
 }
 
-impl<'a> BidegreeElement<'a> {
-    pub fn new(degree: Bidegree, vec: Slice) -> BidegreeElement {
+impl BidegreeElement {
+    pub fn new(degree: Bidegree, vec: FpVector) -> BidegreeElement {
         BidegreeElement { degree, vec }
     }
 
@@ -40,6 +40,10 @@ impl<'a> BidegreeElement<'a> {
     }
 
     pub fn vec(&self) -> Slice {
+        self.vec.as_slice()
+    }
+
+    pub fn into_vec(self) -> FpVector {
         self.vec
     }
 
@@ -103,7 +107,7 @@ impl<'a> BidegreeElement<'a> {
     }
 }
 
-impl Display for BidegreeElement<'_> {
+impl Display for BidegreeElement {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "({}, {}, {})", self.n(), self.s(), self.vec())
     }

--- a/ext/crates/sseq/src/coordinates/generator.rs
+++ b/ext/crates/sseq/src/coordinates/generator.rs
@@ -68,7 +68,7 @@ impl From<(Bidegree, usize)> for BidegreeGenerator {
     }
 }
 
-impl TryFrom<BidegreeElement<'_>> for BidegreeGenerator {
+impl TryFrom<BidegreeElement> for BidegreeGenerator {
     type Error = ();
 
     fn try_from(value: BidegreeElement) -> Result<Self, Self::Error> {

--- a/ext/crates/sseq/src/coordinates/mod.rs
+++ b/ext/crates/sseq/src/coordinates/mod.rs
@@ -80,10 +80,10 @@ mod test {
         let b = Bidegree::n_s(23, 9);
         let mut vec = FpVector::new(ValidPrime::new(2), 2);
         vec.set_entry(1, 1);
-        let h1_pd0 = BidegreeElement::new(b, vec.as_slice());
+        let h1_pd0 = BidegreeElement::new(b, vec.clone());
         assert_eq!(Ok(BidegreeGenerator::new(b, 1)), h1_pd0.try_into());
         vec.set_entry(0, 1);
-        let h0_squared_i = BidegreeElement::new(b, vec.as_slice());
+        let h0_squared_i = BidegreeElement::new(b, vec.clone());
         assert_eq!(
             Result::<BidegreeGenerator, ()>::Err(()),
             h0_squared_i.try_into()

--- a/ext/examples/mahowald_invariant.rs
+++ b/ext/examples/mahowald_invariant.rs
@@ -243,7 +243,7 @@ impl fmt::Display for MahowaldInvariant {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> fmt::Result {
         let output_t = self.output_t;
         let f2_vec_to_sum = |v: &FpVector| {
-            let elt = BidegreeElement::new(Bidegree::s_t(self.gen.s(), output_t), v.as_slice());
+            let elt = BidegreeElement::new(Bidegree::s_t(self.gen.s(), output_t), v.clone());
             elt.to_basis_string()
         };
         let indeterminacy_info = if self.indeterminacy_basis.is_empty() {

--- a/ext/examples/massey.rs
+++ b/ext/examples/massey.rs
@@ -122,7 +122,7 @@ fn main() -> anyhow::Result<()> {
         let kernel = product.compute_kernel();
 
         for row in kernel.iter() {
-            let c_element = BidegreeElement::new(c, row);
+            let c_element = BidegreeElement::new(c, row.to_owned());
             print!(
                 "<a, b, {c_string}> = [",
                 c_string = c_element.to_basis_string()

--- a/ext/examples/secondary_massey.rs
+++ b/ext/examples/secondary_massey.rs
@@ -395,7 +395,8 @@ fn main() -> anyhow::Result<()> {
                     if ext_part.iter_nonzero().count() > 0 {
                         print!(
                             "[{basis_string}]",
-                            basis_string = BidegreeElement::new(c, ext_part).to_basis_string()
+                            basis_string =
+                                BidegreeElement::new(c, ext_part.to_owned()).to_basis_string()
                         );
                         true
                     } else {
@@ -413,7 +414,7 @@ fn main() -> anyhow::Result<()> {
 
                     let basis_string = BidegreeElement::new(
                         c + TAU_BIDEGREE,
-                        gen.slice(target_num_gens, target_all_gens),
+                        gen.slice(target_num_gens, target_all_gens).to_owned(),
                     )
                     .to_basis_string();
                     if num_entries == 1 {

--- a/ext/examples/secondary_product.rs
+++ b/ext/examples/secondary_product.rs
@@ -178,7 +178,7 @@ fn main() -> anyhow::Result<()> {
                 "{name} [{basis_string}] = {} + τ {}",
                 output.slice(0, target_num_gens),
                 output.slice(target_num_gens, target_num_gens + tau_num_gens),
-                basis_string = BidegreeElement::new(b, gen).to_basis_string(),
+                basis_string = BidegreeElement::new(b, gen.to_owned()).to_basis_string(),
             );
         }
     }

--- a/ext/examples/steenrod.rs
+++ b/ext/examples/steenrod.rs
@@ -171,8 +171,8 @@ fn main() -> anyhow::Result<()> {
         print!(
             "Sq^{} {basis_string} = [{result}]",
             (b - shift_s).s(),
-            basis_string = BidegreeElement::new(b, FpVector::from_slice(p, &class).as_slice())
-                .to_basis_string(),
+            basis_string =
+                BidegreeElement::new(b, FpVector::from_slice(p, &class)).to_basis_string(),
             result = (0..num_gens)
                 .map(|k| format!("{}", final_map.output(doubled_b.t(), k).entry(0)))
                 .format(", "),

--- a/ext/src/chain_complex/mod.rs
+++ b/ext/src/chain_complex/mod.rs
@@ -140,7 +140,7 @@ where
         let target = d.target();
         let result_vector = d.output(gen.t(), gen.idx());
 
-        BidegreeElement::new(gen.degree(), result_vector.as_slice())
+        BidegreeElement::new(gen.degree(), result_vector.clone())
             .to_string_module(&*target, compact)
     }
 }


### PR DESCRIPTION
It's easier to have the `BidegreeElement` be self-contained, just in case the `FpVector` used to create the slice doesn't live long enough for our purposes. I doubt they will ever take up more than a single limb anyway. This could make the case for the implementation of some `smallvec`-based backing for small `FpVector`s