### PR TITLE
Set up `devenv` environment

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,3 @@
+source_url "https://raw.githubusercontent.com/cachix/devenv/95f329d49a8a5289d31e0982652f7058a189bfca/direnvrc" "sha256-d+8cBpDfDBj41inrADaJt+bDWhOktwslgoP5YiGJ1v0="
+
+use devenv

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,14 @@ chart/python/*.egg-info
 
 #vscode
 **/.vscode
+**/*.code-workspace
+
+# Devenv
+.devenv*
+devenv.local.nix
+
+# direnv
+.direnv
+
+# pre-commit
+.pre-commit-config.yaml

--- a/devenv.nix
+++ b/devenv.nix
@@ -1,0 +1,13 @@
+{ pkgs, lib, config, inputs, ... }:
+
+{
+  # https://devenv.sh/basics/
+  env.RUST_LOG = "info";
+
+  # https://devenv.sh/packages/
+  packages = [
+    pkgs.git
+  ];
+
+  # See full reference at https://devenv.sh/reference/options/
+}

--- a/devenv.yaml
+++ b/devenv.yaml
@@ -1,0 +1,11 @@
+inputs:
+  fenix:
+    url: github:nix-community/fenix
+    inputs:
+      nixpkgs:
+        follows: nixpkgs
+  nixpkgs:
+    url: github:cachix/devenv-nixpkgs/rolling
+imports:
+- ./ext
+- ./web_ext/sseq_gui

--- a/ext/devenv.nix
+++ b/ext/devenv.nix
@@ -1,0 +1,42 @@
+{ pkgs, lib, config, inputs, ... }:
+
+{
+  # https://devenv.sh/basics/
+  env.RUST_LOG = "info";
+
+  # https://devenv.sh/packages/
+  packages = [
+    pkgs.git
+    pkgs.hyperfine
+    pkgs.python3Packages.pytest
+  ];
+
+  # https://devenv.sh/tests/
+  enterTest = ''
+    # Lints
+    make lint
+
+    # Tests
+    make test
+    make benchmarks
+    make benchmarks-nassau
+    make benchmarks-concurrent
+
+    # Miri
+    make miri
+  '';
+
+  # https://devenv.sh/languages/
+  languages = {
+    rust = {
+      enable = true;
+      channel = "nightly";
+      components = [ "rustc" "cargo" "clippy" "rustfmt" "rust-analyzer" "miri" ];
+    };
+    python = {
+      enable = true;
+    };
+  };
+
+  # See full reference at https://devenv.sh/reference/options/
+}

--- a/ext/devenv.yaml
+++ b/ext/devenv.yaml
@@ -1,0 +1,9 @@
+inputs:
+  nixpkgs:
+    url: github:cachix/devenv-nixpkgs/rolling
+  fenix:
+    url: github:nix-community/fenix
+    inputs:
+      nixpkgs:
+        follows: nixpkgs
+

--- a/web_ext/sseq_gui/devenv.nix
+++ b/web_ext/sseq_gui/devenv.nix
@@ -1,0 +1,57 @@
+{ pkgs, lib, config, inputs, ... }:
+
+{
+  # https://devenv.sh/basics/
+  env.RUST_LOG = "info";
+
+  # https://devenv.sh/packages/
+  packages = [
+    pkgs.git
+    pkgs.hyperfine
+    pkgs.python3Packages.flake8
+    pkgs.python3Packages.black
+    pkgs.python3Packages.pytest
+    pkgs.python3Packages.selenium
+
+    pkgs.openssl
+  ];
+
+  # https://devenv.sh/tests/
+  enterTest = ''
+    # Lints
+    make lint
+    make lint-selenium
+
+    # Webserver
+    cargo install wasm-bindgen-cli --debug --version 0.2.78
+    make lint-wasm
+    make wasm
+
+    # Selenium
+    make serve-wasm &
+    (sleep 1 && make selenium)
+
+    cargo build &&
+    (target/debug/sseq_gui &
+    (sleep 1 && make selenium))
+
+    cargo build --features concurrent &&
+    (target/debug/sseq_gui &
+    (sleep 1 && make selenium))
+  '';
+
+  # https://devenv.sh/languages/
+  languages = {
+    rust = {
+      enable = true;
+      channel = "nightly";
+      components = [ "rustc" "cargo" "clippy" "rustfmt" "rust-analyzer" ];
+      targets = [ "wasm32-unknown-unknown" ];
+    };
+    python = {
+      enable = true;
+    };
+  };
+
+  # See full reference at https://devenv.sh/reference/options/
+}

--- a/web_ext/sseq_gui/devenv.yaml
+++ b/web_ext/sseq_gui/devenv.yaml
@@ -1,0 +1,9 @@
+inputs:
+  nixpkgs:
+    url: github:cachix/devenv-nixpkgs/rolling
+  fenix:
+    url: github:nix-community/fenix
+    inputs:
+      nixpkgs:
+        follows: nixpkgs
+


### PR DESCRIPTION
I recently switched operating systems and I'm finding it much cleaner to use a dev environment than to install all the tooling system-wide. It also does wonders for reproducibility.

I chose `devenv` because of its convenience. The one remaining issue for me is the selenium test failing when running `devenv test` in `web_ext/sseq_gui`, but I just rely on CI for that.