### PR TITLE
Rename most "cocycle" -> "boundary"

### DIFF
--- a/ext/examples/differentials.rs
+++ b/ext/examples/differentials.rs
@@ -12,8 +12,8 @@ fn main() -> anyhow::Result<()> {
     for b in resolution.iter_stem() {
         for i in 0..resolution.number_of_gens_in_bidegree(b) {
             let gen = BidegreeGenerator::new(b, i);
-            let cocycle = resolution.cocycle_string(gen, true);
-            println!("d x_{gen:#} = {cocycle}");
+            let boundary = resolution.boundary_string(gen, true);
+            println!("d x_{gen:#} = {boundary}");
         }
     }
     Ok(())

--- a/ext/src/chain_complex/mod.rs
+++ b/ext/src/chain_complex/mod.rs
@@ -135,7 +135,8 @@ where
         self.module(b.s()).number_of_gens_in_degree(b.t())
     }
 
-    fn cocycle_string(&self, gen: BidegreeGenerator, compact: bool) -> String {
+    /// Get a string representation of d(gen), where d is the differential of the resolution.
+    fn boundary_string(&self, gen: BidegreeGenerator, compact: bool) -> String {
         let d = self.differential(gen.s());
         let target = d.target();
         let result_vector = d.output(gen.t(), gen.idx());

--- a/web_ext/sseq_gui/interface/display.js
+++ b/web_ext/sseq_gui/interface/display.js
@@ -11,7 +11,7 @@ import { dialog } from './utils.js';
 
 export const STATE_ADD_DIFFERENTIAL = 1;
 export const STATE_QUERY_TABLE = 2;
-export const STATE_QUERY_COCYCLE_STRING = 3;
+export const STATE_QUERY_BOUNDARY_STRING = 3;
 
 export class MainDisplay {
     constructor(container, sseq, isUnit) {
@@ -108,7 +108,7 @@ export class MainDisplay {
                 this.state = STATE_QUERY_TABLE;
                 break;
             case 'x':
-                this.state = STATE_QUERY_COCYCLE_STRING;
+                this.state = STATE_QUERY_BOUNDARY_STRING;
                 break;
             case 'n':
                 if (!this.sseq.selected) break;
@@ -153,8 +153,8 @@ export class MainDisplay {
                 this.sseq.queryTable(...this.sseq.selected);
                 this.state = null;
                 break;
-            case STATE_QUERY_COCYCLE_STRING:
-                this.sseq.queryCocycleString(...this.sseq.selected);
+            case STATE_QUERY_BOUNDARY_STRING:
+                this.sseq.queryBoundaryString(...this.sseq.selected);
                 this.state = null;
                 break;
             case STATE_ADD_DIFFERENTIAL:
@@ -243,7 +243,7 @@ export class UnitDisplay {
                 dialog(
                     `Add differential at (${oldSelected[0]}, ${oldSelected[1]})`,
                     '<section>Invalid target for differential</section>',
-                    () => {},
+                    () => { },
                     'OK',
                 );
             }

--- a/web_ext/sseq_gui/interface/index.js
+++ b/web_ext/sseq_gui/interface/index.js
@@ -62,17 +62,17 @@ if (params.module || params.module_json) {
 
     const action = params.module
         ? {
-              Construct: {
-                  algebra_name: algebra,
-                  module_name: params.module,
-              },
-          }
+            Construct: {
+                algebra_name: algebra,
+                module_name: params.module,
+            },
+        }
         : {
-              ConstructJson: {
-                  algebra_name: 'milnor',
-                  data: params.module_json,
-              },
-          };
+            ConstructJson: {
+                algebra_name: 'milnor',
+                data: params.module_json,
+            },
+        };
 
     // Record this for the save functionality, since the wasm version modifies it
     window.constructCommand = {
@@ -252,7 +252,7 @@ messageHandler.Complete = () => {
     }
 };
 
-messageHandler.QueryCocycleStringResult = m => {
+messageHandler.QueryBoundaryStringResult = m => {
     console.log(
         `Cocyle string for (t - s, s, idx) = (${m.t - m.s}, ${m.s}, ${m.idx}):`,
     );
@@ -269,7 +269,7 @@ messageHandler.Error = m => {
     dialog(
         'Fatal error encountered',
         `<section><pre>${m.message}</pre></section>`,
-        () => {},
+        () => { },
         'OK',
     );
 };

--- a/web_ext/sseq_gui/interface/sseq.js
+++ b/web_ext/sseq_gui/interface/sseq.js
@@ -317,17 +317,15 @@ export class ExtSseq {
                 <input name="source" is="class-input"
                     title="Express source in E${page} page basis"
                     length="${sourceDim}" p=${this.p}
-                    value="${
-                        sourceClass ? '[' + sourceClass.join(', ') + ']' : ''
-                    }"
+                    value="${sourceClass ? '[' + sourceClass.join(', ') + ']' : ''
+            }"
                 ></input>
                 =
                 <input name="target" is="class-input"
                     title="Express target in E${page} page basis"
                     length="${targetDim}" p=${this.p}
-                    value="${
-                        targetClass ? '[' + targetClass.join(', ') + ']' : ''
-                    }"
+                    value="${targetClass ? '[' + targetClass.join(', ') + ']' : ''
+            }"
                 ></input>
             </section>
             <section>
@@ -388,7 +386,7 @@ export class ExtSseq {
             dialog(
                 `Add permanent class at (${x}, ${y})`,
                 '<section>There are no surviving classes</section>',
-                () => {},
+                () => { },
                 'OK',
             );
         } else if (classes[0].length == 1) {
@@ -442,9 +440,8 @@ export class ExtSseq {
             'Resolve further',
             `<section style="input-row">
                 <label>New maximum degree</label>
-                <input style="width: 5em" type="number" value="${
-                    this.maxDegree + 10
-                }">
+                <input style="width: 5em" type="number" value="${this.maxDegree + 10
+            }">
             </section>`,
             dialog => {
                 newmax = parseInt(dialog.querySelector('input').value);
@@ -466,7 +463,7 @@ export class ExtSseq {
         );
     }
 
-    queryCocycleString(x, y) {
+    queryBoundaryString(x, y) {
         const classes = this.classes.get(x, y);
         if (!classes) return;
 
@@ -477,7 +474,7 @@ export class ExtSseq {
                 {
                     recipients: ['Resolver'],
                     action: {
-                        QueryCocycleString: {
+                        QueryBoundaryString: {
                             s: y,
                             t: x + y,
                             idx: i,
@@ -522,8 +519,8 @@ export class ExtSseq {
             'maxy',
             Math.ceil(
                 (this.maxDegree - this.minDegree) * eval(this.vanishingSlope) +
-                    1 +
-                    eval(this.vanishingIntercept),
+                1 +
+                eval(this.vanishingIntercept),
             ),
         ); // We trust our inputs *so* much.
     }

--- a/web_ext/sseq_gui/src/actions.rs
+++ b/web_ext/sseq_gui/src/actions.rs
@@ -73,8 +73,8 @@ pub enum Action {
     // Queries
     QueryTable,
     QueryTableResult,
-    QueryCocycleString,
-    QueryCocycleStringResult,
+    QueryBoundaryString,
+    QueryBoundaryStringResult,
 
     // Error
     Error,
@@ -386,10 +386,10 @@ pub struct QueryTableResult {
 impl ActionT for QueryTableResult {}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct QueryCocycleString {
+pub struct QueryBoundaryString {
     g: BidegreeGenerator,
 }
-impl ActionT for QueryCocycleString {
+impl ActionT for QueryBoundaryString {
     fn act_resolution(&self, resolution: &mut Resolution<CCC>) -> Option<Message> {
         // Ensure bidegree is defined
         let module = resolution.module(self.g.s());
@@ -400,21 +400,21 @@ impl ActionT for QueryCocycleString {
             return None;
         }
 
-        let string = resolution.inner.cocycle_string(self.g, true);
+        let string = resolution.inner.boundary_string(self.g, true);
         Some(Message {
             recipients: vec![],
             sseq: SseqChoice::Main, // This will be overwritten
-            action: Action::from(QueryCocycleStringResult { g: self.g, string }),
+            action: Action::from(QueryBoundaryStringResult { g: self.g, string }),
         })
     }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct QueryCocycleStringResult {
+pub struct QueryBoundaryStringResult {
     g: BidegreeGenerator,
     string: String,
 }
-impl ActionT for QueryCocycleStringResult {}
+impl ActionT for QueryBoundaryStringResult {}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Error {

--- a/web_ext/sseq_gui/src/managers.rs
+++ b/web_ext/sseq_gui/src/managers.rs
@@ -229,7 +229,7 @@ impl SseqManager {
                 | Action::AddProduct(_)
                 | Action::Complete(_)
                 | Action::QueryTableResult(_)
-                | Action::QueryCocycleStringResult(_)
+                | Action::QueryBoundaryStringResult(_)
                 | Action::Resolving(_)
         )
     }
@@ -248,7 +248,7 @@ impl SseqManager {
             Action::Resolving(_) => self.resolving(msg)?,
             Action::Complete(_) => self.relay(msg)?,
             Action::QueryTableResult(_) => self.relay(msg)?,
-            Action::QueryCocycleStringResult(_) => self.relay(msg)?,
+            Action::QueryBoundaryStringResult(_) => self.relay(msg)?,
             Action::Error(_) => self.relay(msg)?,
             _ => {
                 if let Some(sseq) = self.get_sseq(msg.sseq) {


### PR DESCRIPTION
I realized that `QueryCycleString` really queries a boundary, since it prints the value of the differential applied to the generator. The `differentials.rs` example also corroborates that