### PR TITLE
Allow reading and writing in separate directories

### DIFF
--- a/ext/src/chain_complex/chain_homotopy.rs
+++ b/ext/src/chain_complex/chain_homotopy.rs
@@ -55,7 +55,7 @@ impl<
                 .create_dir(save_dir.write().unwrap())
                 .unwrap();
 
-            left.source.save_dir().clone()
+            save_dir
         } else {
             SaveDirectory::None
         };

--- a/ext/src/chain_complex/chain_homotopy.rs
+++ b/ext/src/chain_complex/chain_homotopy.rs
@@ -1,7 +1,4 @@
-use std::{
-    path::{Path, PathBuf},
-    sync::{Arc, Mutex},
-};
+use std::sync::{Arc, Mutex};
 
 use algebra::module::{
     homomorphism::{FreeModuleHomomorphism, ModuleHomomorphism},
@@ -15,7 +12,7 @@ use sseq::coordinates::{Bidegree, BidegreeRange};
 use crate::{
     chain_complex::{ChainComplex, FreeChainComplex},
     resolution_homomorphism::ResolutionHomomorphism,
-    save::SaveKind,
+    save::{SaveDirectory, SaveKind},
 };
 
 // Another instance of https://github.com/rust-lang/rust/issues/91380
@@ -34,7 +31,7 @@ pub struct ChainHomotopy<
     lock: Mutex<()>,
     /// Homotopies, indexed by the filtration of the target of f - g.
     homotopies: OnceBiVec<Arc<FreeModuleHomomorphism<U::Module>>>,
-    save_dir: Option<PathBuf>,
+    save_dir: SaveDirectory,
 }
 
 impl<
@@ -51,14 +48,16 @@ impl<
             && !left.name().is_empty()
             && !right.name().is_empty()
         {
-            let mut path = left.source.save_dir().unwrap().to_owned();
-            path.push(format!("massey/{},{}/", left.name(), right.name(),));
+            let mut save_dir = left.source.save_dir().clone();
+            save_dir.push(format!("massey/{},{}/", left.name(), right.name()));
 
-            SaveKind::ChainHomotopy.create_dir(&path).unwrap();
+            SaveKind::ChainHomotopy
+                .create_dir(save_dir.write().unwrap())
+                .unwrap();
 
-            Some(path)
+            left.source.save_dir().clone()
         } else {
-            None
+            SaveDirectory::None
         };
 
         assert!(Arc::ptr_eq(&left.target, &right.source));
@@ -181,7 +180,7 @@ impl<
                 .add_generators_from_rows_ooo(source.t(), outputs);
         }
 
-        if let Some(dir) = &self.save_dir {
+        if let Some(dir) = self.save_dir.read() {
             if let Some(mut f) = self
                 .left
                 .source
@@ -268,7 +267,7 @@ impl<
             &scratches,
         ));
 
-        if let Some(dir) = &self.save_dir {
+        if let Some(dir) = self.save_dir.write() {
             let mut f = self
                 .left
                 .source
@@ -285,7 +284,7 @@ impl<
         Arc::clone(&self.homotopies[source_s as i32])
     }
 
-    pub fn save_dir(&self) -> Option<&Path> {
-        self.save_dir.as_deref()
+    pub fn save_dir(&self) -> &SaveDirectory {
+        &self.save_dir
     }
 }

--- a/ext/src/chain_complex/mod.rs
+++ b/ext/src/chain_complex/mod.rs
@@ -22,7 +22,7 @@ use fp::{
 use itertools::Itertools;
 use sseq::coordinates::{Bidegree, BidegreeElement, BidegreeGenerator};
 
-use crate::utils::unicode_num;
+use crate::{save::SaveDirectory, utils::unicode_num};
 
 pub enum ChainComplexGrading {
     Homological,
@@ -227,8 +227,8 @@ pub trait ChainComplex: Send + Sync {
     }
 
     /// A directory used to save information about the chain complex.
-    fn save_dir(&self) -> Option<&std::path::Path> {
-        None
+    fn save_dir(&self) -> &SaveDirectory {
+        &SaveDirectory::None
     }
 
     /// Get the save file of a bidegree

--- a/ext/src/utils.rs
+++ b/ext/src/utils.rs
@@ -12,6 +12,7 @@ use sseq::coordinates::{Bidegree, BidegreeGenerator};
 use crate::{
     chain_complex::{AugmentedChainComplex, BoundedChainComplex, ChainComplex, FiniteChainComplex},
     resolution::{Resolution, UnstableResolution},
+    save::SaveDirectory,
     CCC,
 };
 
@@ -136,7 +137,7 @@ impl<T: TryInto<AlgebraType>> TryFrom<(Value, T)> for Config {
 /// the `nassau` feature is enabled.
 pub fn construct<T, E>(
     module_spec: T,
-    save_dir: Option<PathBuf>,
+    save_dir: impl Into<SaveDirectory>,
 ) -> anyhow::Result<QueryModuleResolution>
 where
     anyhow::Error: From<E>,
@@ -156,7 +157,7 @@ where
 /// See [`construct`]
 pub fn construct_nassau<T, E>(
     module_spec: T,
-    save_dir: Option<PathBuf>,
+    save_dir: impl Into<SaveDirectory>,
 ) -> anyhow::Result<crate::nassau::Resolution<FDModule<MilnorAlgebra>>>
 where
     anyhow::Error: From<E>,
@@ -196,7 +197,7 @@ where
 /// See [`construct`]
 pub fn construct_standard<const U: bool, T, E>(
     module_spec: T,
-    save_dir: Option<PathBuf>,
+    save_dir: impl Into<SaveDirectory>,
 ) -> anyhow::Result<crate::resolution::MuResolution<U, CCC>>
 where
     anyhow::Error: From<E>,


### PR DESCRIPTION
This is handy if we are working on a big resolution and computing chain maps or homotopies. Computing maps and homotopies usually generates a ton of very small files, so it might be convenient to write them to some fast storage like an SSD or a ramdisk. Note that the way it is implemented means that it's impossible for a struct to read what it has previously written. This should not be a problem in practice.

Open problem: what should be the syntax to specify a split save directory in the examples? If we have a specific syntax we can just `impl FromStr for SaveDirectory` and make this feature available to examples without even changing our tests.