### PR TITLE
Update chart CI

### DIFF
--- a/.github/workflows/chart.yaml
+++ b/.github/workflows/chart.yaml
@@ -21,7 +21,6 @@ jobs:
       uses: actions/cache@v2
       with:
           path: |
-              ~/.rustup
               ~/.cargo
               ~/.local/lib/python*/
               **/node_modules

--- a/.github/workflows/chart.yaml
+++ b/.github/workflows/chart.yaml
@@ -37,10 +37,10 @@ jobs:
       run: python3 -m pip install setuptools wheel
 
     - name: Install rustup
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@v1
       with:
           toolchain: stable
-          target: wasm32-unknown-unknown
+          targets: wasm32-unknown-unknown
 
     - name: Install wasm-pack
       run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh

--- a/.github/workflows/ext.yaml
+++ b/.github/workflows/ext.yaml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Install rustup
         id: rustup
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: ${{ matrix.toolchain }}
 
@@ -68,7 +68,7 @@ jobs:
 
       - name: Install rustup
         id: rustup
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: nightly
           components: miri
@@ -98,7 +98,7 @@ jobs:
 
       - name: Install rustup
         id: rustup
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: nightly
           components: clippy, rustfmt
@@ -142,11 +142,11 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install rustup
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@v1
         id: rustup
         with:
           toolchain: ${{ matrix.toolchain }}
-          target: wasm32-unknown-unknown
+          targets: wasm32-unknown-unknown
           components: clippy, rustfmt
 
       - name: Cache files
@@ -209,7 +209,7 @@ jobs:
           path: web_ext/sseq_gui/dist/
 
       - name: Install rustup
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@v1
         id: rustup
         with:
           toolchain: ${{ matrix.toolchain }}
@@ -268,10 +268,10 @@ jobs:
 
       - name: Install rustup
         id: rustup
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: ${{ matrix.toolchain }}
-          target: wasm32-unknown-unknown
+          targets: wasm32-unknown-unknown
           components: clippy, rustfmt
 
       - name: Cache files
@@ -322,7 +322,7 @@ jobs:
 
       - name: Install rustup
         id: rustup
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: ${{ matrix.toolchain }}
 


### PR DESCRIPTION
I noticed the `chart` CI stopped working, and I found that `actions-rs/toolchain` is unmaintained. Thankfully, dtolnay has an (arguably better) action that does the same thing. This didn't end up fixing things, but after a bit more investigation, it turns out that removing `.rustup` from the cache does the trick