### PR TITLE
New `proptest` feature for `fp`

### DIFF
--- a/ext/crates/fp/Cargo.toml
+++ b/ext/crates/fp/Cargo.toml
@@ -12,12 +12,15 @@ cfg-if = "1.0.0"
 dashmap = "5"
 itertools = { version = "0.13.0" }
 paste = "1.0.15"
+proptest = { version = "1.2", optional = true }
 serde = "1.0.0"
 serde_json = "1.0.0"
 
 maybe-rayon = { path = "../maybe-rayon" }
 
 [dev-dependencies]
+# We use the proptest harness for our own tests
+fp = { path = ".", default-features = false, features = ["proptest"] }
 criterion = { version = "0.5", features = ["html_reports"] }
 expect-test = "1.1.0"
 pprof = { version = "0.13.0", features = ["criterion", "flamegraph"] }

--- a/ext/crates/fp/src/field/field_internal.rs
+++ b/ext/crates/fp/src/field/field_internal.rs
@@ -45,7 +45,8 @@ macro_rules! normal_from_assign {
 /// The fact that each field defines its own element type means that we can define a single struct
 /// that packages both a field and one of its elements, and this struct will be how we expose field
 /// operations to the outside world.
-pub trait FieldInternal: Copy + PartialEq + Eq + Hash + Sized {
+#[allow(private_bounds)]
+pub trait FieldInternal: Copy + PartialEq + Eq + Hash + Sized + crate::MaybeArbitrary<()> {
     /// The internal representation of a field element.
     type ElementContainer: FieldElementContainer;
 

--- a/ext/crates/fp/src/field/mod.rs
+++ b/ext/crates/fp/src/field/mod.rs
@@ -145,14 +145,7 @@ mod tests {
 
     pub(super) fn arb_elements<F: Field, const N: usize>(
     ) -> impl Strategy<Value = (F, [FieldElement<F>; N])> {
-        any::<F>().prop_flat_map(move |f| {
-            let elements: [_; N] = (0..N)
-                .map(|_| f.arb_element())
-                .collect::<Vec<_>>()
-                .try_into()
-                .unwrap();
-            (Just(f), elements)
-        })
+        any::<F>().prop_flat_map(move |f| (Just(f), std::array::from_fn(|_| f.arb_element())))
     }
 
     /// Test the field axioms and good behavior of the Frobenius endomorphism.

--- a/ext/crates/fp/src/field/mod.rs
+++ b/ext/crates/fp/src/field/mod.rs
@@ -24,11 +24,16 @@ pub trait Field: FieldInternal + Sized {
 
     fn zero(self) -> FieldElement<Self>;
     fn one(self) -> FieldElement<Self>;
+
+    #[cfg(feature = "proptest")]
+    fn arb_element(self) -> impl proptest::strategy::Strategy<Value = FieldElement<Self>>;
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{Field, SmallFq};
+    use proptest::prelude::*;
+
+    use super::{element::FieldElement, Field, SmallFq};
     use crate::prime::P2;
 
     #[test]
@@ -138,16 +143,42 @@ mod tests {
         assert_eq!(elements, expansions);
     }
 
-    /// Given a function that generates elements of a field, test the field axioms and good behavior
-    /// of the Frobenius endomorphism. The function should have signature
-    ///
-    /// ```ignore
-    /// fn arb_elements<const N: usize>() -> impl Strategy<Value = (F, [FieldElement<F>; N])>
-    /// ```
-    #[macro_export]
+    pub(super) fn arb_elements<F: Field, const N: usize>(
+    ) -> impl Strategy<Value = (F, [FieldElement<F>; N])> {
+        any::<F>().prop_flat_map(move |f| {
+            let elements: [_; N] = (0..N)
+                .map(|_| f.arb_element())
+                .collect::<Vec<_>>()
+                .try_into()
+                .unwrap();
+            (Just(f), elements)
+        })
+    }
+
+    /// Test the field axioms and good behavior of the Frobenius endomorphism.
     macro_rules! field_tests {
-        () => {
+        ($field:ty) => {
+            use proptest::prelude::*;
+
+            use crate::{
+                field::{element::FieldElement, Field},
+                prime::Prime,
+            };
+
+            // We shadow the `arb_elements` function with one that is specialized to the concrete
+            // field type we're working with
+            fn arb_elements<const N: usize>(
+            ) -> impl Strategy<Value = ($field, [FieldElement<$field>; N])> {
+                crate::field::tests::arb_elements()
+            }
+
             proptest! {
+                #[test]
+                fn test_bit_length((f, []) in arb_elements()) {
+                    use crate::field::field_internal::FieldInternal;
+                    prop_assert!(f.bit_length() <= 63);
+                }
+
                 #[test]
                 fn test_addition_associative((_, [a, b, c]) in arb_elements()) {
                     prop_assert_eq!((a + b) + c, a + (b + c));
@@ -219,6 +250,8 @@ mod tests {
                     prop_assert_eq!((a * b).frobenius(), a.frobenius() * b.frobenius());
                 }
             }
-        }
+        };
     }
+
+    pub(super) use field_tests;
 }

--- a/ext/crates/fp/src/field/smallfq.rs
+++ b/ext/crates/fp/src/field/smallfq.rs
@@ -306,7 +306,7 @@ impl<P: Prime> proptest::arbitrary::Arbitrary for SmallFq<P> {
     fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
         use proptest::prelude::*;
 
-        // Can't be a closure because the return value refenrences this function, and a closure
+        // Can't be a closure because the return value references this function, and a closure
         // would not live long enough
         fn largest_degree(p: impl Prime) -> u32 {
             let mut d = 2;

--- a/ext/crates/fp/src/lib.rs
+++ b/ext/crates/fp/src/lib.rs
@@ -12,6 +12,17 @@ pub mod vector;
 
 pub(crate) mod simd;
 
+// This is useful for traits that want to implement `Arbitrary`. This lets us specify that they
+// should be subtraits of `Arbitrary` iff the `proptest` feature is enabled.
+#[cfg(not(feature = "proptest"))]
+pub(crate) trait MaybeArbitrary<Params> {}
+
+#[cfg(feature = "proptest")]
+pub(crate) trait MaybeArbitrary<Params>:
+    proptest::arbitrary::Arbitrary<Parameters = Params>
+{
+}
+
 #[cfg(feature = "odd-primes")]
 pub const ODD_PRIMES: bool = true;
 #[cfg(not(feature = "odd-primes"))]

--- a/ext/crates/fp/src/prime/mod.rs
+++ b/ext/crates/fp/src/prime/mod.rs
@@ -1,6 +1,7 @@
 use std::{
     fmt::{Debug, Display},
     hash::Hash,
+    num::NonZeroU32,
     ops::{
         Add, AddAssign, Div, DivAssign, Mul, MulAssign, Rem, RemAssign, Shl, ShlAssign, Shr,
         ShrAssign, Sub, SubAssign,
@@ -37,6 +38,7 @@ pub const TWO: ValidPrime = ValidPrime::new(2);
 /// == 2` (or even better, just `p == 2`) will reduce to `true` at compile time, and allow the
 /// compiler to eliminate an entire branch, while also leaving that check in for when the prime is
 /// chosen at runtime.
+#[allow(private_bounds)]
 pub trait Prime:
     Debug
     + Clone
@@ -56,6 +58,8 @@ pub trait Prime:
     + Shr<u32, Output = u32>
     + Serialize
     + for<'de> Deserialize<'de>
+    + crate::MaybeArbitrary<Option<NonZeroU32>>
+    + 'static
 {
     fn as_i32(self) -> i32;
     fn to_dyn(self) -> ValidPrime;
@@ -158,6 +162,20 @@ macro_rules! def_prime_static {
                 $pn::try_from(p).map_err(D::Error::custom)
             }
         }
+
+        #[cfg(feature = "proptest")]
+        impl proptest::arbitrary::Arbitrary for $pn {
+            type Parameters = Option<NonZeroU32>;
+            type Strategy = proptest::strategy::Just<$pn>;
+
+            fn arbitrary_with(_max: Self::Parameters) -> Self::Strategy {
+                // This doesn't honor the max parameter, but that should be fine as long as the
+                // static primes are small enough and/or the max is large enough.
+                proptest::strategy::Just($pn)
+            }
+        }
+
+        impl crate::MaybeArbitrary<Option<NonZeroU32>> for $pn {}
     };
 }
 
@@ -333,41 +351,11 @@ pub fn minus_one_to_the_n<P: Prime>(p: P, i: i32) -> u32 {
 
 #[cfg(test)]
 pub(crate) mod tests {
-    use std::sync::OnceLock;
-
-    use proptest::prelude::*;
-
     use super::{binomial::Binomial, inverse, iter::BinomialIterator, Prime, ValidPrime};
     use crate::{
         constants::PRIMES,
         prime::{is_prime, PrimeError},
     };
-
-    /// An arbitrary `ValidPrime` in the range `2..(1 << 24)`, plus the largest prime that we support.
-    pub(crate) fn arb_prime() -> impl Strategy<Value = ValidPrime> {
-        static TEST_PRIMES: OnceLock<Vec<ValidPrime>> = OnceLock::new();
-        let test_primes = TEST_PRIMES.get_or_init(|| {
-            // Sieve of erathosthenes
-            const MAX: usize = 1 << 24;
-            let mut is_prime = Vec::new();
-            is_prime.resize_with(MAX, || true);
-            is_prime[0] = false;
-            is_prime[1] = false;
-            for i in 2..MAX {
-                if is_prime[i] {
-                    for j in ((2 * i)..MAX).step_by(i) {
-                        is_prime[j] = false;
-                    }
-                }
-            }
-            (0..MAX)
-                .filter(|&i| is_prime[i])
-                .map(|p| ValidPrime::new_unchecked(p as u32))
-                .chain(std::iter::once(ValidPrime::new_unchecked(2147483647)))
-                .collect()
-        });
-        (0..test_primes.len()).prop_map(|i| test_primes[i])
-    }
 
     #[test]
     fn validprime_test() {

--- a/ext/crates/fp/src/prime/mod.rs
+++ b/ext/crates/fp/src/prime/mod.rs
@@ -170,7 +170,9 @@ macro_rules! def_prime_static {
 
             fn arbitrary_with(_max: Self::Parameters) -> Self::Strategy {
                 // This doesn't honor the max parameter, but that should be fine as long as the
-                // static primes are small enough and/or the max is large enough.
+                // static primes are small enough and/or the max is large enough. There's no such
+                // thing as an empty strategy, so the best we could do is return a strategy that
+                // always rejects. This would cause local failures that may make tests fail.
                 proptest::strategy::Just($pn)
             }
         }

--- a/ext/crates/fp/src/prime/primes_generic.rs
+++ b/ext/crates/fp/src/prime/primes_generic.rs
@@ -130,7 +130,7 @@ impl proptest::arbitrary::Arbitrary for ValidPrime {
 
         static TEST_PRIMES: OnceLock<Vec<ValidPrime>> = OnceLock::new();
         let test_primes = TEST_PRIMES.get_or_init(|| {
-            // Sieve of erathosthenes
+            // Sieve of Eratosthenes
             const MAX: usize = 1 << 24;
             let mut is_prime = Vec::new();
             is_prime.resize_with(MAX, || true);

--- a/ext/crates/fp/src/vector/mod.rs
+++ b/ext/crates/fp/src/vector/mod.rs
@@ -19,7 +19,7 @@ mod tests {
     use crate::{
         field::{field_internal::FieldInternal, fp::F2, Fp},
         limb,
-        prime::{tests::arb_prime, Prime, ValidPrime},
+        prime::{Prime, ValidPrime},
     };
 
     pub struct VectorDiffEntry {
@@ -99,7 +99,7 @@ mod tests {
 
     /// An arbitrary (prime, dimension) pair
     fn arb_prime_dim() -> impl Strategy<Value = (ValidPrime, usize)> {
-        arb_prime().prop_flat_map(|p| (Just(p), 0usize..=10_000))
+        any::<ValidPrime>().prop_flat_map(|p| (Just(p), 0usize..=10_000))
     }
 
     /// The start and end positions of an arbitrary slice of a vector of length `dimension`
@@ -160,7 +160,7 @@ mod tests {
     /// the sense of [`FpVector::add_masked`] and [`FpVector::add_unmasked`])
     fn arb_vec_pair_and_mask() -> impl Strategy<Value = (ValidPrime, Vec<u32>, Vec<u32>, Vec<usize>)>
     {
-        arb_prime()
+        any::<ValidPrime>()
             .prop_flat_map(|p| (Just(p), arb_slice(10_000)))
             .prop_flat_map(|(p, (dim_small, dim_large))| {
                 (
@@ -181,13 +181,13 @@ mod tests {
         })]
 
         #[test]
-        fn test_bit_length(p in arb_prime()) {
+        fn test_bit_length(p in any::<ValidPrime>()) {
             prop_assert!(Fp::new(p).bit_length() <= 63);
         }
 
         #[cfg(feature = "odd-primes")]
         #[test]
-        fn test_incompatible_primes((p1, p2) in (arb_prime(), arb_prime())) {
+        fn test_incompatible_primes((p1, p2) in (any::<ValidPrime>(), any::<ValidPrime>())) {
             prop_assume!(p1 != p2);
 
             macro_rules! assert_panic {


### PR DESCRIPTION
The `proptest::arbitrary::Arbitrary` trait lets us create values using a generic `any` free function. It would be really convenient to have an implementation of `Arbitrary` for types implementing `Prime` and `Field`, so that tests can just create values of that type out of thin air and focus on writing the contents of the tests. Let's focus on `Prime` for concreteness. Something like

```rust
#[cfg(test)]
mod tests {
    impl<P: Prime> proptest::arbitrary::Arbitrary for P {
        // stuff...
    }
}
```

isn't allowed because `P` is not constrained enough. One solution would be to use newtypes, but I found that messy and confusing. Another solution would be to add a `Prime: Arbitrary` constraint to the definition of `Prime`, but that exposes the proptest crate in our public API, and it would become a runtime dependency instead of a dev dependency.

As a compromise, I added a new feature that conditionally adds proptest support, using our `MaybeArbitrary` trait. This has the added benefit of exposing a mechanism for producing primes to other crates that depend on `fp` and also want to use proptest. This significantly simplifies the tests for our field types, and streamlines tests for vectors and row reduction.

Using these `Arbitrary` implementations, I was able to write a battery of tests that check the correct behavior of `FqVector` over every field and every prime. I'll submit this as a follow-up PR to keep the diff manageable.