### PR TITLE
Update `upload-artifact` and `download-artifact` to v4

### DIFF
--- a/.github/workflows/ext.yaml
+++ b/.github/workflows/ext.yaml
@@ -174,7 +174,7 @@ jobs:
         run: ls -l web_ext/sseq_gui/dist/sseq_gui_wasm_bg.wasm
 
       - name: Upload webserver
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: webserver-${{ matrix.toolchain }}
           path: web_ext/sseq_gui/dist/
@@ -203,7 +203,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Download webserver
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: webserver-beta
           path: web_ext/sseq_gui/dist/
@@ -245,7 +245,7 @@ jobs:
 
       - name: Upload Artifact
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: svg-changes-${{ matrix.toolchain }}
           path: web_ext/sseq_gui/tests/benchmarks/*-new.svg
@@ -299,7 +299,7 @@ jobs:
         run: ls -l web_ext/steenrod_calculator/dist/steenrod_calculator_wasm_bg.wasm
 
       - name: Upload calculator
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: calculator-${{ matrix.toolchain }}
           path: web_ext/steenrod_calculator/dist/
@@ -339,7 +339,7 @@ jobs:
         run: make -C ext docs
 
       - name: Upload docs
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: docs-${{ matrix.toolchain }}
           path: ext/target/doc/
@@ -351,18 +351,18 @@ jobs:
 
     steps:
       - name: Download webserver
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: webserver-stable
 
       - name: Download calculator
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: calculator-stable
           path: calculator
 
       - name: Download docs
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: docs-stable
           path: docs


### PR DESCRIPTION
These have been fully deprecated and are making CI fail