### PR TITLE
Add `Arbitrary` implementation for other types in `fp`

### DIFF
--- a/ext/crates/fp/src/field/field_internal.rs
+++ b/ext/crates/fp/src/field/field_internal.rs
@@ -47,7 +47,7 @@ macro_rules! normal_from_assign {
 /// operations to the outside world.
 #[allow(private_bounds)]
 pub trait FieldInternal:
-    std::fmt::Debug + Copy + PartialEq + Eq + Hash + Sized + crate::MaybeArbitrary<()>
+    std::fmt::Debug + Copy + PartialEq + Eq + Hash + Sized + crate::MaybeArbitrary<()> + 'static
 {
     /// The internal representation of a field element.
     type ElementContainer: FieldElementContainer;

--- a/ext/crates/fp/src/matrix/mod.rs
+++ b/ext/crates/fp/src/matrix/mod.rs
@@ -13,3 +13,5 @@ pub use matrix_inner::{AugmentedMatrix, Matrix, MatrixSliceMut};
 pub use quasi_inverse::QuasiInverse;
 pub use subquotient::Subquotient;
 pub use subspace::Subspace;
+#[cfg(feature = "proptest")]
+pub use {matrix_inner::arbitrary::*, subquotient::arbitrary::*, subspace::arbitrary::*};

--- a/ext/crates/fp/src/matrix/subquotient.rs
+++ b/ext/crates/fp/src/matrix/subquotient.rs
@@ -96,10 +96,8 @@ impl Subquotient {
 
     /// The pivot columns of the complement to the subspace
     pub fn complement_pivots(&self) -> impl Iterator<Item = usize> + '_ {
-        (0..self.ambient_dimension()).filter(|&i| {
-            !self.quotient.pivots().contains(&(i as isize))
-                && !self.gens.pivots().contains(&(i as isize))
-        })
+        (0..self.ambient_dimension())
+            .filter(|&i| self.quotient.pivots()[i] < 0 && self.gens.pivots()[i] < 0)
     }
 
     pub fn quotient(&mut self, elt: FpSlice) {

--- a/ext/crates/fp/src/matrix/subquotient.rs
+++ b/ext/crates/fp/src/matrix/subquotient.rs
@@ -239,6 +239,7 @@ pub mod arbitrary {
 #[cfg(test)]
 mod tests {
     use expect_test::expect;
+    use proptest::prelude::*;
 
     use super::*;
 
@@ -271,5 +272,15 @@ mod tests {
         .assert_debug_eq(&sq.reduce(FpVector::from_slice(p, &[2, 0, 0, 0, 0]).as_slice_mut()));
 
         assert_eq!(sq.gens().count(), 1);
+    }
+
+    proptest! {
+        #[test]
+        fn test_sum_quotient_gens_complement_is_ambient(sq: Subquotient) {
+            let quotient_dim = sq.zeros().dimension();
+            let gens_dim = sq.gens().count();
+            let complement_dim = sq.complement_pivots().count();
+            assert_eq!(quotient_dim + gens_dim + complement_dim, sq.ambient_dimension());
+        }
     }
 }

--- a/ext/crates/fp/src/matrix/subspace.rs
+++ b/ext/crates/fp/src/matrix/subspace.rs
@@ -334,7 +334,7 @@ pub mod arbitrary {
 
             (p, args.dim)
                 .prop_flat_map(move |(p, dim)| {
-                    Matrix::arbitrary_with(MatrixArbParams {
+                    Matrix::arbitrary_rref_with(MatrixArbParams {
                         p: Some(p),
                         rows: (0..=dim + 1).boxed(),
                         columns: Just(dim).boxed(),

--- a/ext/crates/fp/src/vector/mod.rs
+++ b/ext/crates/fp/src/vector/mod.rs
@@ -7,6 +7,8 @@ mod impl_fqvector;
 mod iter;
 
 pub use fp_wrapper::*;
+#[cfg(feature = "proptest")]
+pub use impl_fqvector::arbitrary;
 pub use inner::*;
 
 #[cfg(test)]
@@ -14,13 +16,11 @@ pub(super) mod tests {
     use itertools::Itertools;
     use proptest::prelude::*;
 
-    use super::inner::FqVector;
+    use super::{arbitrary::MAX_LEN as MAX_TEST_VEC_LEN, inner::FqVector};
     use crate::{
         field::{element::FieldElement, fp::F2, Field},
         limb,
     };
-
-    pub const MAX_TEST_VEC_LEN: usize = 10_000;
 
     pub struct VectorDiffEntry<F: Field> {
         pub index: usize,


### PR DESCRIPTION
I noticed a bug in `Subquotient::complement_pivots`, so I wanted to add a test to cover that. That led me to implement proptest's `Arbitrary` for several types. This PR also fixes the bug