### PR TITLE
2024ify

### DIFF
--- a/ext/crates/algebra/src/algebra/adem_algebra.rs
+++ b/ext/crates/algebra/src/algebra/adem_algebra.rs
@@ -145,14 +145,13 @@ unsafe fn shift_vec<T>(v: &mut Vec<T>, offset: isize) {
     let ptr = v.as_ptr();
     let len = v.len();
     let cap = v.capacity();
-    let w = std::mem::replace(
-        v,
+    let w = std::mem::replace(v, unsafe {
         Vec::from_raw_parts(
             (ptr as *mut T).offset(offset),
             (len as isize - offset) as usize,
             (cap as isize - offset) as usize,
-        ),
-    );
+        )
+    });
     std::mem::forget(w);
 }
 

--- a/ext/crates/algebra/src/algebra/polynomial_algebra.rs
+++ b/ext/crates/algebra/src/algebra/polynomial_algebra.rs
@@ -282,7 +282,7 @@ impl<A: PolynomialAlgebra> Algebra for A {
         }
         let result = exp_map
             .iter()
-            .sorted_by_key(|(_, &(_, gen_deg))| gen_deg)
+            .sorted_by_key(|&(_, &(_, gen_deg))| gen_deg)
             .map(|(var, &(var_exp, gen_deg))| {
                 let pow = if var_exp > 1 {
                     format!("^{{{var_exp}}}")

--- a/ext/crates/algebra/src/lib.rs
+++ b/ext/crates/algebra/src/lib.rs
@@ -60,11 +60,11 @@ pub(crate) fn module_gens_from_json(
         gen_to_idx.insert(name.clone(), (degree, graded_dimension[degree]));
         graded_dimension[degree] += 1;
     }
-    (graded_dimension, gen_names, move |r#gen| {
+    (graded_dimension, gen_names, move |g| {
         gen_to_idx
-            .get(r#gen)
+            .get(g)
             .copied()
-            .ok_or_else(|| anyhow!("Invalid generator: {gen}"))
+            .ok_or_else(|| anyhow!("Invalid generator: {g}"))
     })
 }
 

--- a/ext/crates/algebra/src/lib.rs
+++ b/ext/crates/algebra/src/lib.rs
@@ -4,6 +4,18 @@
 // TODO: Write descriptions of each module therein.
 
 #![deny(clippy::use_self)]
+// Rust 2024 compatibility lints
+#![deny(rust_2024_compatibility)]
+// The `expr` fragment will change in Rust 2024
+#![allow(edition_2024_expr_fragment_specifier)]
+// Drop order will change in Rust 2024
+#![allow(tail_expr_drop_order)]
+// impl Trait will capture more lifetimes in Rust 2024
+#![allow(impl_trait_overcaptures)]
+// `if let` now drops the binding before entering the `else` block in Rust 2024. This lint is
+// currently only supported on nightly.
+#![allow(unknown_lints, if_let_rescope)]
+#![deny(unknown_lints)]
 
 pub mod module;
 pub mod steenrod_evaluator;
@@ -48,9 +60,9 @@ pub(crate) fn module_gens_from_json(
         gen_to_idx.insert(name.clone(), (degree, graded_dimension[degree]));
         graded_dimension[degree] += 1;
     }
-    (graded_dimension, gen_names, move |gen| {
+    (graded_dimension, gen_names, move |r#gen| {
         gen_to_idx
-            .get(gen)
+            .get(r#gen)
             .copied()
             .ok_or_else(|| anyhow!("Invalid generator: {gen}"))
     })

--- a/ext/crates/algebra/src/module/finite_dimensional_module.rs
+++ b/ext/crates/algebra/src/module/finite_dimensional_module.rs
@@ -480,8 +480,8 @@ impl<A: GeneratedAlgebra> FiniteDimensionalModule<A> {
         json["type"] = Value::from("finite dimensional module");
         json["gens"] = json!({});
         for (i, deg_i_gens) in self.gen_names.iter_enum() {
-            for gen in deg_i_gens {
-                json["gens"][gen] = Value::from(i);
+            for g in deg_i_gens {
+                json["gens"][g] = Value::from(i);
             }
         }
 
@@ -500,7 +500,7 @@ impl<A: GeneratedAlgebra> FiniteDimensionalModule<A> {
             .split_once(" = ")
             .ok_or_else(|| anyhow!("Invalid action: {entry}"))?;
 
-        let (action, gen) = lhs
+        let (action, g) = lhs
             .rsplit_once(' ')
             .ok_or_else(|| anyhow!("Invalid action: {entry}"))?;
 
@@ -508,7 +508,7 @@ impl<A: GeneratedAlgebra> FiniteDimensionalModule<A> {
             .basis_element_from_string(action)
             .ok_or_else(|| anyhow!("Invalid algebra element: {action}"))?;
 
-        let (input_deg, input_idx) = gen_to_idx(gen.trim())?;
+        let (input_deg, input_idx) = gen_to_idx(g.trim())?;
 
         let row = self.action_mut(op_deg, op_idx, input_deg, input_idx);
 
@@ -521,18 +521,18 @@ impl<A: GeneratedAlgebra> FiniteDimensionalModule<A> {
         }
 
         for item in rhs.split(" + ") {
-            let (coef, gen) = match item.split_once(' ') {
-                Some((coef, gen)) => (
+            let (coef, g) = match item.split_once(' ') {
+                Some((coef, g)) => (
                     str::parse(coef)
                         .map_err(|_| anyhow!("Invalid item on right-hand side: {item}"))?,
-                    gen,
+                    g,
                 ),
                 None => (1, item),
             };
-            let (deg, idx) = gen_to_idx(gen.trim())?;
+            let (deg, idx) = gen_to_idx(g.trim())?;
             if deg != input_deg + op_deg {
                 return Err(anyhow!(
-                    "Degree of {gen} is {deg} but degree of LHS is {}",
+                    "Degree of {g} is {deg} but degree of LHS is {}",
                     input_deg + op_deg
                 ));
             }

--- a/ext/crates/algebra/src/module/finitely_presented_module.rs
+++ b/ext/crates/algebra/src/module/finitely_presented_module.rs
@@ -130,11 +130,11 @@ impl<A: Algebra> FinitelyPresentedModule<A> {
                     let (term, coef) = opt(digits)(term).unwrap();
                     let coef: u32 = coef.unwrap_or(1);
 
-                    let (op, gen) = term.rsplit_once(' ').unwrap_or(("1", term));
+                    let (op, g) = term.rsplit_once(' ').unwrap_or(("1", term));
                     let (op_deg, op_idx) = algebra
                         .basis_element_from_string(op)
                         .ok_or_else(|| anyhow!("Invalid term in relation: {term}"))?;
-                    let (gen_deg, gen_idx) = gen_to_deg_idx(gen)?;
+                    let (gen_deg, gen_idx) = gen_to_deg_idx(g)?;
 
                     if v.is_empty() {
                         deg = op_deg + gen_deg;

--- a/ext/crates/algebra/src/steenrod_evaluator.rs
+++ b/ext/crates/algebra/src/steenrod_evaluator.rs
@@ -64,13 +64,13 @@ impl SteenrodEvaluator {
         if items.is_empty() {
             return Ok(result);
         }
-        for (op, gen) in parse_module(items)? {
-            if let Some((deg, vec)) = result.get_mut(&gen) {
+        for (op, g) in parse_module(items)? {
+            if let Some((deg, vec)) = result.get_mut(&g) {
                 let (_, adem_v) = self.evaluate_algebra_node(Some(*deg), op)?;
                 vec.add(&adem_v, 1);
             } else {
                 let (deg, adem_v) = self.evaluate_algebra_node(None, op)?;
-                result.insert(gen, (deg, adem_v));
+                result.insert(g, (deg, adem_v));
             }
         }
         Ok(result)

--- a/ext/crates/algebra/src/steenrod_parser.rs
+++ b/ext/crates/algebra/src/steenrod_parser.rs
@@ -207,7 +207,7 @@ fn module_term(i: &str) -> IResult<&str, ModuleNode> {
     .unwrap();
 
     match space(module_generator)(i) {
-        Ok((i, gen)) => return Ok((i, vec![(prefix.unwrap_or(Scalar(1)), gen)])),
+        Ok((i, g)) => return Ok((i, vec![(prefix.unwrap_or(Scalar(1)), g)])),
         Err(nom::Err::Error(_)) => (),
         Err(e) => return Err(e),
     }

--- a/ext/crates/bivec/src/lib.rs
+++ b/ext/crates/bivec/src/lib.rs
@@ -1,4 +1,12 @@
 #![deny(clippy::use_self)]
+// Rust 2024 compatibility lints
+#![deny(rust_2024_compatibility)]
+// The `expr` fragment will change in Rust 2024
+#![allow(edition_2024_expr_fragment_specifier)]
+// Drop order will change in Rust 2024
+#![allow(tail_expr_drop_order)]
+// impl Trait will capture more lifetimes in Rust 2024
+#![allow(impl_trait_overcaptures)]
 
 use core::ops::{Index, IndexMut};
 use std::{

--- a/ext/crates/chart/src/lib.rs
+++ b/ext/crates/chart/src/lib.rs
@@ -1,4 +1,12 @@
 #![deny(clippy::use_self)]
+// Rust 2024 compatibility lints
+#![deny(rust_2024_compatibility)]
+// The `expr` fragment will change in Rust 2024
+#![allow(edition_2024_expr_fragment_specifier)]
+// Drop order will change in Rust 2024
+#![allow(tail_expr_drop_order)]
+// impl Trait will capture more lifetimes in Rust 2024
+#![allow(impl_trait_overcaptures)]
 
 use std::{collections::HashMap, fmt::Display, io::Write};
 

--- a/ext/crates/fp/benches/criterion.rs
+++ b/ext/crates/fp/benches/criterion.rs
@@ -1,5 +1,8 @@
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
-use fp::{matrix::Matrix, prime::ValidPrime};
+use fp::{
+    matrix::Matrix,
+    prime::{Prime, ValidPrime},
+};
 use rand::Rng;
 
 fn random_matrix(p: ValidPrime, dimension: usize) -> Matrix {
@@ -33,7 +36,7 @@ fn row_reductions(c: &mut Criterion) {
 fn random_vector(p: ValidPrime, dimension: usize) -> Vec<u32> {
     let mut result = Vec::with_capacity(dimension);
     let mut rng = rand::thread_rng();
-    result.resize_with(dimension, || rng.gen::<u32>() % p);
+    result.resize_with(dimension, || rng.gen_range(0..p.as_u32()));
     result
 }
 

--- a/ext/crates/fp/src/lib.rs
+++ b/ext/crates/fp/src/lib.rs
@@ -1,4 +1,12 @@
 #![deny(clippy::use_self)]
+// Rust 2024 compatibility lints
+#![deny(rust_2024_compatibility)]
+// The `expr` fragment will change in Rust 2024
+#![allow(edition_2024_expr_fragment_specifier)]
+// Drop order will change in Rust 2024
+#![allow(tail_expr_drop_order)]
+// impl Trait will capture more lifetimes in Rust 2024
+#![allow(impl_trait_overcaptures)]
 
 mod constants;
 mod limb;

--- a/ext/crates/fp/src/matrix/matrix_inner.rs
+++ b/ext/crates/fp/src/matrix/matrix_inner.rs
@@ -419,7 +419,7 @@ impl Matrix {
         if coef == 0 {
             return;
         }
-        let (target, source) = self.split_borrow(target, source);
+        let (target, source) = unsafe { self.split_borrow(target, source) };
         target.add_offset(source, prime - coef, pivot_column);
     }
 
@@ -439,7 +439,7 @@ impl Matrix {
         if coef == 0 {
             return;
         }
-        let (target, source) = self.split_borrow(target, source);
+        let (target, source) = unsafe { self.split_borrow(target, source) };
         target.add(source, prime - coef);
     }
 
@@ -453,7 +453,7 @@ impl Matrix {
         j: usize,
     ) -> (&mut FpVector, &mut FpVector) {
         let ptr = self.vectors.as_mut_ptr();
-        (&mut *ptr.add(i), &mut *ptr.add(j))
+        unsafe { (&mut *ptr.add(i), &mut *ptr.add(j)) }
     }
 
     /// This is very similar to row_reduce, except we only need to get to row echelon form, not

--- a/ext/crates/fp/src/matrix/subquotient.rs
+++ b/ext/crates/fp/src/matrix/subquotient.rs
@@ -133,10 +133,10 @@ impl Subquotient {
         self.dimension = 0;
     }
 
-    pub fn add_gen(&mut self, gen: FpSlice) {
+    pub fn add_gen(&mut self, g: FpSlice) {
         self.gens.update_then_row_reduce(|gens_matrix| {
             let mut new_row = gens_matrix.row_mut(self.dimension);
-            new_row.assign(gen);
+            new_row.assign(g);
             self.quotient.reduce(new_row);
         });
         self.dimension = self.gens.dimension();

--- a/ext/crates/fp/src/prime/binomial.rs
+++ b/ext/crates/fp/src/prime/binomial.rs
@@ -11,10 +11,12 @@ use crate::{
 /// apriori because k and n are obtained by reducing mod p, so it is better to expose an unsafe
 /// interface that avoids these checks.
 unsafe fn direct_binomial(p: ValidPrime, n: usize, k: usize) -> u32 {
-    *BINOMIAL_TABLE
-        .get_unchecked(PRIME_TO_INDEX_MAP[p.as_usize()])
-        .get_unchecked(n)
-        .get_unchecked(k)
+    unsafe {
+        *BINOMIAL_TABLE
+            .get_unchecked(PRIME_TO_INDEX_MAP[p.as_usize()])
+            .get_unchecked(n)
+            .get_unchecked(k)
+    }
 }
 
 /// A number satisfying the Binomial trait supports computing various binomial coefficients. This

--- a/ext/crates/fp/src/simd/generic.rs
+++ b/ext/crates/fp/src/simd/generic.rs
@@ -3,11 +3,11 @@ use crate::limb::Limb;
 pub(crate) type SimdLimb = Limb;
 
 pub(crate) unsafe fn load(limb: *const Limb) -> SimdLimb {
-    *limb
+    unsafe { *limb }
 }
 
 pub(crate) unsafe fn store(limb: *mut Limb, val: SimdLimb) {
-    *limb = val;
+    unsafe { *limb = val };
 }
 
 pub(crate) unsafe fn xor(left: SimdLimb, right: SimdLimb) -> SimdLimb {

--- a/ext/crates/fp/src/simd/x86_64.rs
+++ b/ext/crates/fp/src/simd/x86_64.rs
@@ -18,11 +18,11 @@ cfg_if::cfg_if! {
 pub(crate) unsafe fn load(limb: *const Limb) -> SimdLimb {
     cfg_if::cfg_if! {
         if #[cfg(target_feature="avx2")] {
-            x86_64::_mm256_loadu_si256(limb as *const SimdLimb)
+            unsafe { x86_64::_mm256_loadu_si256(limb as *const SimdLimb) }
         } else if #[cfg(target_feature="avx")] {
-            x86_64::_mm256_loadu_ps(limb as *const f32)
+            unsafe { x86_64::_mm256_loadu_ps(limb as *const f32) }
         } else if #[cfg(target_feature="sse2")] {
-            x86_64::_mm_loadu_si128(limb as *const SimdLimb)
+            unsafe { x86_64::_mm_loadu_si128(limb as *const SimdLimb) }
         } else {
             *limb
         }
@@ -32,11 +32,11 @@ pub(crate) unsafe fn load(limb: *const Limb) -> SimdLimb {
 pub(crate) unsafe fn store(limb: *mut Limb, val: SimdLimb) {
     cfg_if::cfg_if! {
         if #[cfg(target_feature="avx2")] {
-            x86_64::_mm256_storeu_si256(limb as *mut SimdLimb, val);
+            unsafe { x86_64::_mm256_storeu_si256(limb as *mut SimdLimb, val) };
         } else if #[cfg(target_feature="avx")] {
-            x86_64::_mm256_storeu_ps(limb as *mut f32, val);
+            unsafe { x86_64::_mm256_storeu_ps(limb as *mut f32, val) };
         } else if #[cfg(target_feature="sse2")] {
-            x86_64::_mm_storeu_si128(limb as *mut SimdLimb, val)
+            unsafe { x86_64::_mm_storeu_si128(limb as *mut SimdLimb, val) };
         } else {
             *limb = val;
         }
@@ -46,11 +46,11 @@ pub(crate) unsafe fn store(limb: *mut Limb, val: SimdLimb) {
 pub(crate) unsafe fn xor(left: SimdLimb, right: SimdLimb) -> SimdLimb {
     cfg_if::cfg_if! {
         if #[cfg(target_feature="avx2")] {
-            x86_64::_mm256_xor_si256(left, right)
+            unsafe { x86_64::_mm256_xor_si256(left, right) }
         } else if #[cfg(target_feature="avx")] {
-            x86_64::_mm256_xor_ps(left, right)
+            unsafe { x86_64::_mm256_xor_ps(left, right) }
         } else if #[cfg(target_feature="sse2")] {
-            x86_64::_mm_xor_si128(left, right)
+            unsafe { x86_64::_mm_xor_si128(left, right) }
         } else {
             left ^ right
         }

--- a/ext/crates/maybe-rayon/src/lib.rs
+++ b/ext/crates/maybe-rayon/src/lib.rs
@@ -1,4 +1,12 @@
 #![deny(clippy::use_self)]
+// Rust 2024 compatibility lints
+#![deny(rust_2024_compatibility)]
+// The `expr` fragment will change in Rust 2024
+#![allow(edition_2024_expr_fragment_specifier)]
+// Drop order will change in Rust 2024
+#![allow(tail_expr_drop_order)]
+// impl Trait will capture more lifetimes in Rust 2024
+#![allow(impl_trait_overcaptures)]
 
 #[cfg(feature = "concurrent")]
 pub mod concurrent;

--- a/ext/crates/once/src/lib.rs
+++ b/ext/crates/once/src/lib.rs
@@ -1,4 +1,12 @@
 #![deny(clippy::use_self)]
+// Rust 2024 compatibility lints
+#![deny(rust_2024_compatibility)]
+// The `expr` fragment will change in Rust 2024
+#![allow(edition_2024_expr_fragment_specifier)]
+// Drop order will change in Rust 2024
+#![allow(tail_expr_drop_order)]
+// impl Trait will capture more lifetimes in Rust 2024
+#![allow(impl_trait_overcaptures)]
 
 extern crate alloc;
 
@@ -80,10 +88,10 @@ impl<T> Page<T> {
                     1 << page_index
                 };
                 for idx in 0..end {
-                    std::ptr::drop_in_place(ptr.as_ptr().add(idx));
+                    unsafe { std::ptr::drop_in_place(ptr.as_ptr().add(idx)) };
                 }
             }
-            alloc::alloc::dealloc(ptr.as_ptr() as *mut u8, Self::layout(page_index));
+            unsafe { alloc::alloc::dealloc(ptr.as_ptr() as *mut u8, Self::layout(page_index)) };
         }
     }
 
@@ -104,7 +112,7 @@ impl<T> Page<T> {
             } else {
                 1 << page_index
             };
-            std::slice::from_raw_parts(self.0.unwrap().as_ptr() as *const T, len)
+            unsafe { std::slice::from_raw_parts(self.0.unwrap().as_ptr() as *const T, len) }
         }
     }
 }
@@ -335,7 +343,7 @@ impl<T> OnceVec<T> {
     /// page references should exist.
     unsafe fn entry_ptr(&self, index: usize) -> *mut T {
         let (page, idx) = inner_index(index);
-        (*self.page_raw(page)).ptr().add(idx)
+        unsafe { (*self.page_raw(page)).ptr().add(idx) }
     }
 
     /// # Returns
@@ -495,9 +503,9 @@ impl<T> OnceVec<T> {
         for i in 0..=max_page {
             let page_ptr = self.page_raw(i);
             // Safety assumption is propagated up call chain
-            if !(*page_ptr).allocated() {
+            if unsafe { !(*page_ptr).allocated() } {
                 // Only make mutable reference if the page is not allocated
-                (*page_ptr).allocate(i);
+                unsafe { (*page_ptr).allocate(i) };
             }
         }
     }

--- a/ext/crates/query/src/lib.rs
+++ b/ext/crates/query/src/lib.rs
@@ -11,6 +11,14 @@
 //! functionality. However, the first is useful for testing and batch processing.
 
 #![deny(clippy::use_self)]
+// Rust 2024 compatibility lints
+#![deny(rust_2024_compatibility)]
+// The `expr` fragment will change in Rust 2024
+#![allow(edition_2024_expr_fragment_specifier)]
+// Drop order will change in Rust 2024
+#![allow(tail_expr_drop_order)]
+// impl Trait will capture more lifetimes in Rust 2024
+#![allow(impl_trait_overcaptures)]
 
 use std::{
     cell::RefCell,

--- a/ext/crates/sseq/src/coordinates/element.rs
+++ b/ext/crates/sseq/src/coordinates/element.rs
@@ -55,13 +55,13 @@ impl BidegreeElement {
         self.vec
             .iter_nonzero()
             .map(|(i, v)| {
-                let gen = BidegreeGenerator::new(self.degree(), i);
+                let g = BidegreeGenerator::new(self.degree(), i);
                 let coeff_str = if v != 1 {
                     format!("{v} ")
                 } else {
                     String::new()
                 };
-                format!("{coeff_str}x_{gen}")
+                format!("{coeff_str}x_{g}")
             })
             .collect::<Vec<_>>()
             .join(" + ")
@@ -91,15 +91,15 @@ impl BidegreeElement {
                 } else {
                     String::new()
                 };
-                let gen = BidegreeGenerator::s_t(
+                let g = BidegreeGenerator::s_t(
                     self.s() - 1,
                     opgen.generator_degree,
                     opgen.generator_index,
                 );
                 let gen_str = if compact {
-                    format!("x_{gen:#}")
+                    format!("x_{g:#}")
                 } else {
-                    format!("x_{gen}")
+                    format!("x_{g}")
                 };
                 format!("{coeff_str}{op_str}{gen_str}")
             })

--- a/ext/crates/sseq/src/lib.rs
+++ b/ext/crates/sseq/src/lib.rs
@@ -1,4 +1,12 @@
 #![deny(clippy::use_self)]
+// Rust 2024 compatibility lints
+#![deny(rust_2024_compatibility)]
+// The `expr` fragment will change in Rust 2024
+#![allow(edition_2024_expr_fragment_specifier)]
+// Drop order will change in Rust 2024
+#![allow(tail_expr_drop_order)]
+// impl Trait will capture more lifetimes in Rust 2024
+#![allow(impl_trait_overcaptures)]
 
 mod bigraded;
 pub mod coordinates;

--- a/ext/crates/sseq/src/sseq.rs
+++ b/ext/crates/sseq/src/sseq.rs
@@ -280,8 +280,8 @@ impl<P: SseqProfile> Sseq<P> {
 
             if r > self.differentials[x][y].len() || self.page_data[tx][ty][r - 1].is_empty() {
                 let (prev, cur) = self.page_data[x][y].split_borrow_mut(r - 1, r);
-                for gen in prev.gens() {
-                    cur.add_gen(gen);
+                for g in prev.gens() {
+                    cur.add_gen(g);
                 }
                 if r - 1 < self.differentials[x][y].len() {
                     differentials.push(vec![Vec::new(); self.page_data[x][y][r].dimension()]);
@@ -302,13 +302,12 @@ impl<P: SseqProfile> Sseq<P> {
                     source_dim + target_dim,
                 );
 
-                for (row, gen) in
+                for (row, g) in
                     std::iter::zip(matrix.iter_mut(), self.page_data[x][y][r - 1].gens())
                 {
-                    row.slice_mut(target_dim, target_dim + source_dim)
-                        .assign(gen);
+                    row.slice_mut(target_dim, target_dim + source_dim).assign(g);
 
-                    d.evaluate(gen, dvec.as_slice_mut());
+                    d.evaluate(g, dvec.as_slice_mut());
                     row.slice_mut(0, target_dim).assign(dvec.as_slice());
 
                     drawn_differentials

--- a/ext/examples/bruner.rs
+++ b/ext/examples/bruner.rs
@@ -198,9 +198,9 @@ fn read_bruner_resolution(data_dir: &Path, max_n: i32) -> Result<(u32, FiniteCha
         let mut entries: Vec<FpVector> = Vec::new();
         let mut cur_degree: i32 = 0;
 
-        while let Some((t, gen)) = get_element(algebra, cc.module(s - 1).as_ref(), &mut f)? {
+        while let Some((t, g)) = get_element(algebra, cc.module(s - 1).as_ref(), &mut f)? {
             if t == cur_degree {
-                entries.push(gen);
+                entries.push(g);
             } else {
                 m.add_generators(cur_degree, entries.len(), None);
                 d.add_generators_from_rows(cur_degree, entries);
@@ -208,7 +208,7 @@ fn read_bruner_resolution(data_dir: &Path, max_n: i32) -> Result<(u32, FiniteCha
                 m.extend_by_zero(t - 1);
                 d.extend_by_zero(t - 1);
 
-                entries = vec![gen];
+                entries = vec![g];
                 cur_degree = t;
             }
         }
@@ -262,8 +262,8 @@ fn main() {
         let matrix = hom.get_map(b.s()).hom_k(b.t());
 
         for (i, row) in matrix.into_iter().enumerate() {
-            let gen = BidegreeGenerator::new(b, i);
-            println!("x_{gen:#} = {row:?}");
+            let g = BidegreeGenerator::new(b, i);
+            println!("x_{g:#} = {row:?}");
         }
     }
 }

--- a/ext/examples/define_module.rs
+++ b/ext/examples/define_module.rs
@@ -28,8 +28,8 @@ pub fn get_gens() -> anyhow::Result<BiVec<Vec<String>>> {
         if gen_deg.is_none() {
             eprintln!("This is the list of generators and degrees:");
             for (i, deg_i_gens) in gens.iter_enum() {
-                for gen in deg_i_gens.iter() {
-                    eprint!("({i}, {gen}) ");
+                for g in deg_i_gens.iter() {
+                    eprint!("({i}, {g}) ");
                 }
             }
             eprintln!();
@@ -78,8 +78,8 @@ pub fn get_gens() -> anyhow::Result<BiVec<Vec<String>>> {
 pub fn gens_to_json(gens: &BiVec<Vec<String>>) -> serde_json::Value {
     let mut gens_json = json!({});
     for (i, deg_i_gens) in gens.iter_enum() {
-        for gen in deg_i_gens {
-            gens_json[gen] = json!(i);
+        for g in deg_i_gens {
+            gens_json[g] = json!(i);
         }
     }
     gens_json
@@ -106,8 +106,8 @@ pub fn interactive_module_define_fdmodule(
     let mut module = FDModule::new(Arc::clone(&algebra), String::new(), graded_dim);
 
     for (i, deg_i_gens) in gens.iter_enum() {
-        for (j, gen) in deg_i_gens.iter().enumerate() {
-            module.set_basis_element_name(i, j, gen.to_string());
+        for (j, g) in deg_i_gens.iter().enumerate() {
+            module.set_basis_element_name(i, j, g.to_string());
         }
     }
 
@@ -139,19 +139,16 @@ pub fn interactive_module_define_fdmodule(
                             }
                             for term in expr.split('+') {
                                 let term = term.trim();
-                                let (coef, gen) = match term.split_once(' ') {
-                                    Some((coef, gen)) => (str::parse::<u32>(coef)?, gen),
+                                let (coef, g) = match term.split_once(' ') {
+                                    Some((coef, g)) => (str::parse::<u32>(coef)?, g),
                                     None => (1, term),
                                 };
 
-                                if let Some(gen_idx) =
-                                    gens[output_deg].iter().position(|d| d == gen)
+                                if let Some(gen_idx) = gens[output_deg].iter().position(|d| d == g)
                                 {
                                     result[gen_idx] += coef;
                                 } else {
-                                    return Err(anyhow!(
-                                        "No generator {gen} in degree {output_deg}"
-                                    ));
+                                    return Err(anyhow!("No generator {g} in degree {output_deg}"));
                                 }
                             }
 
@@ -173,8 +170,8 @@ pub fn interactive_module_define_fdmodule(
 
 /// Given a string representation of an element in an algebra together with a generator, multiply
 /// each term on the right with the generator.
-fn replace(algebra_elt: &str, gen: &str) -> String {
-    algebra_elt.replace('+', &format!("{gen} +")) + " " + gen
+fn replace(algebra_elt: &str, g: &str) -> String {
+    algebra_elt.replace('+', &format!("{g} +")) + " " + g
 }
 
 pub fn interactive_module_define_fpmodule(
@@ -203,8 +200,8 @@ pub fn interactive_module_define_fpmodule(
 
     let mut degree_lookup = HashMap::default();
     for (i, deg_i_gens) in gens.iter_enum() {
-        for gen in deg_i_gens.iter() {
-            degree_lookup.insert(gen.clone(), i);
+        for g in deg_i_gens.iter() {
+            degree_lookup.insert(g.clone(), i);
         }
     }
 
@@ -221,11 +218,11 @@ pub fn interactive_module_define_fpmodule(
 
             // Check that the generators exist and the terms all have the same degree
             let mut deg = None;
-            for (gen, (op_deg, _)) in result.iter() {
+            for (g, (op_deg, _)) in result.iter() {
                 let cur_deg = op_deg
                     + degree_lookup
-                        .get(gen)
-                        .ok_or_else(|| anyhow!("Unknown generator: {gen}"))?;
+                        .get(g)
+                        .ok_or_else(|| anyhow!("Unknown generator: {g}"))?;
                 if deg.is_none() {
                     deg = Some(cur_deg);
                 } else if deg != Some(cur_deg) {
@@ -247,7 +244,7 @@ pub fn interactive_module_define_fpmodule(
         let mut milnor_relation = String::new();
 
         let mut milnor_op = FpVector::new(p, 0);
-        for (gen, (op_deg, adem_op)) in relation.iter() {
+        for (g, (op_deg, adem_op)) in relation.iter() {
             if adem_op.is_zero() {
                 continue;
             }
@@ -258,10 +255,10 @@ pub fn interactive_module_define_fpmodule(
             milnor_op.set_scratch_vector_size(adem_op.len());
             ev.adem_to_milnor(&mut milnor_op, 1, *op_deg, adem_op);
 
-            adem_relation += &replace(&ev.adem.element_to_string(*op_deg, adem_op.as_slice()), gen);
+            adem_relation += &replace(&ev.adem.element_to_string(*op_deg, adem_op.as_slice()), g);
             milnor_relation += &replace(
                 &ev.milnor.element_to_string(*op_deg, milnor_op.as_slice()),
-                gen,
+                g,
             );
         }
         if !adem_relation.is_empty() {
@@ -273,8 +270,8 @@ pub fn interactive_module_define_fpmodule(
     output_json["p"] = Value::from(p.as_u32());
     output_json["type"] = Value::String("finitely presented module".to_owned());
     for (i, deg_i_gens) in gens.iter_enum() {
-        for gen in deg_i_gens {
-            output_json["gens"][gen] = Value::from(i);
+        for g in deg_i_gens {
+            output_json["gens"][g] = Value::from(i);
         }
     }
     output_json["adem_relations"] = Value::Array(adem_relations);

--- a/ext/examples/differentials.rs
+++ b/ext/examples/differentials.rs
@@ -13,9 +13,9 @@ fn main() -> anyhow::Result<()> {
 
     for b in resolution.iter_stem() {
         for i in 0..resolution.number_of_gens_in_bidegree(b) {
-            let gen = BidegreeGenerator::new(b, i);
-            let boundary = resolution.boundary_string(gen, true);
-            println!("d x_{gen:#} = {boundary}");
+            let g = BidegreeGenerator::new(b, i);
+            let boundary = resolution.boundary_string(g, true);
+            println!("d x_{g:#} = {boundary}");
         }
     }
     Ok(())

--- a/ext/examples/filtration_one.rs
+++ b/ext/examples/filtration_one.rs
@@ -21,9 +21,9 @@ fn main() -> anyhow::Result<()> {
             // TODO: This doesn't work with the reordered Adams basis
             let products = resolution.filtration_one_product(1 << i, 0, b).unwrap();
             for (idx, row) in products.into_iter().enumerate() {
-                let gen = BidegreeGenerator::new(b, idx);
+                let g = BidegreeGenerator::new(b, idx);
                 if !row.is_empty() {
-                    println!("h_{i} x_{gen} = {row:?}");
+                    println!("h_{i} x_{g} = {row:?}");
                 }
             }
             i += 1;

--- a/ext/examples/lift_hom.rs
+++ b/ext/examples/lift_hom.rs
@@ -119,8 +119,8 @@ fn main() -> anyhow::Result<()> {
             hom.extend_step(input, None);
         } else {
             for (idx, row) in matrix.iter_mut().enumerate() {
-                let gen = BidegreeGenerator::new(input, idx);
-                let v: Vec<u32> = query::vector(&format!("f(x_{gen}"), row.len());
+                let g = BidegreeGenerator::new(input, idx);
+                let v: Vec<u32> = query::vector(&format!("f(x_{g}"), row.len());
                 for (i, &x) in v.iter().enumerate() {
                     row.set_entry(i, x);
                 }
@@ -140,8 +140,8 @@ fn main() -> anyhow::Result<()> {
         }
         let matrix = hom.get_map(shifted_b2.s()).hom_k(b2.t());
         for (i, r) in matrix.iter().enumerate() {
-            let gen = BidegreeGenerator::new(b2, i);
-            println!("{name} x_{gen} = {r:?}");
+            let g = BidegreeGenerator::new(b2, i);
+            println!("{name} x_{g} = {r:?}");
         }
     }
     Ok(())

--- a/ext/examples/mahowald_invariant.rs
+++ b/ext/examples/mahowald_invariant.rs
@@ -100,7 +100,7 @@ struct PKData {
 }
 
 struct MahowaldInvariant {
-    gen: BidegreeGenerator,
+    g: BidegreeGenerator,
     output_t: i32,
     invariant: FpVector,
     indeterminacy_basis: Vec<FpVector>,
@@ -217,13 +217,13 @@ impl PKData {
 
                     let it = (0..minus_one_s_2_gens).filter_map(move |i| {
                         let mut image = FpVector::new(TWO, p_k_gens);
-                        let gen = BidegreeGenerator::new(b, i);
-                        self.minus_one_cell.act(image.as_slice_mut(), 1, gen);
+                        let g = BidegreeGenerator::new(b, i);
+                        self.minus_one_cell.act(image.as_slice_mut(), 1, g);
                         if !image.is_zero() && image_subspace.contains(image.as_slice()) {
                             let mut invariant = FpVector::new(TWO, bottom_s_2_gens);
                             quasi_inverse.apply(invariant.as_slice_mut(), 1, image.as_slice());
                             Some(MahowaldInvariant {
-                                gen,
+                                g,
                                 output_t: b_bottom.t(),
                                 invariant,
                                 indeterminacy_basis: indeterminacy_basis.clone(),
@@ -245,7 +245,7 @@ impl fmt::Display for MahowaldInvariant {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> fmt::Result {
         let output_t = self.output_t;
         let f2_vec_to_sum = |v: &FpVector| {
-            let elt = BidegreeElement::new(Bidegree::s_t(self.gen.s(), output_t), v.clone());
+            let elt = BidegreeElement::new(Bidegree::s_t(self.g.s(), output_t), v.clone());
             elt.to_basis_string()
         };
         let indeterminacy_info = if self.indeterminacy_basis.is_empty() {
@@ -262,11 +262,7 @@ impl fmt::Display for MahowaldInvariant {
             )
         };
         let invariant = f2_vec_to_sum(&self.invariant);
-        write!(
-            f,
-            "M(x_{gen}) = {invariant}{indeterminacy_info}",
-            gen = self.gen
-        )
+        write!(f, "M(x_{g}) = {invariant}{indeterminacy_info}", g = self.g)
     }
 }
 
@@ -290,11 +286,11 @@ mod tests {
         #[case] invariant: Vec<u32>,
         #[case] indeterminacy_dim: usize,
     ) {
-        let gen = BidegreeGenerator::new(Bidegree::s_t(s, input_t), input_i);
+        let g = BidegreeGenerator::new(Bidegree::s_t(s, input_t), input_i);
         let s_2_resolution = resolve_s_2(None, k).unwrap();
         let p_k = PKData::try_new(k, &None, &s_2_resolution).unwrap();
-        for mi in p_k.mahowald_invariants_for_bidegree(gen.degree()) {
-            if mi.gen.idx() == gen.idx() {
+        for mi in p_k.mahowald_invariants_for_bidegree(g.degree()) {
+            if mi.g.idx() == g.idx() {
                 assert_eq!(mi.output_t, output_t);
                 assert_eq!(Vec::from(&mi.invariant), invariant);
                 assert_eq!(mi.indeterminacy_basis.len(), indeterminacy_dim);

--- a/ext/examples/massey.rs
+++ b/ext/examples/massey.rs
@@ -115,8 +115,8 @@ fn main() -> anyhow::Result<()> {
 
             for (k, &v) in b_class.iter().enumerate() {
                 if v != 0 {
-                    let gen = BidegreeGenerator::new(b, k);
-                    hom.act(product[idx].slice_mut(0, product_num_gens), v, gen);
+                    let g = BidegreeGenerator::new(b, k);
+                    hom.act(product[idx].slice_mut(0, product_num_gens), v, g);
                 }
             }
         }

--- a/ext/examples/secondary_massey.rs
+++ b/ext/examples/secondary_massey.rs
@@ -297,13 +297,13 @@ fn main() -> anyhow::Result<()> {
                         .get_map(c.s() + b.underlying().shift.s())
                         .hom_k(c.t()),
                 );
-                for (gen, out) in target_page_data
+                for (g, out) in target_page_data
                     .subspace_gens()
                     .zip_eq(product_matrix.iter_mut())
                 {
                     out.slice_mut(prod_num_gens, prod_num_gens + target_num_gens)
-                        .add(gen, 1);
-                    for (i, v) in gen.iter_nonzero() {
+                        .add(g, 1);
+                    for (i, v) in g.iter_nonzero() {
                         out.slice_mut(0, prod_num_gens).add(m0[i].as_slice(), v);
                     }
                 }
@@ -386,12 +386,12 @@ fn main() -> anyhow::Result<()> {
             .hom_k(c.t() + b_shift.t());
         let mb = b.underlying().get_map(c.s() + b_shift.s()).hom_k(c.t());
 
-        for gen in e3_kernel.iter() {
+        for g in e3_kernel.iter() {
             // Print name
             {
                 print!("<{a_name}, {b_name}, ");
                 let has_ext = {
-                    let ext_part = gen.slice(0, target_num_gens);
+                    let ext_part = g.slice(0, target_num_gens);
                     if ext_part.iter_nonzero().count() > 0 {
                         print!(
                             "[{basis_string}]",
@@ -404,7 +404,7 @@ fn main() -> anyhow::Result<()> {
                     }
                 };
 
-                let tau_part = gen.slice(target_num_gens, target_all_gens);
+                let tau_part = g.slice(target_num_gens, target_all_gens);
                 let num_entries = tau_part.iter_nonzero().count();
                 if num_entries > 0 {
                     if has_ext {
@@ -414,7 +414,7 @@ fn main() -> anyhow::Result<()> {
 
                     let basis_string = BidegreeElement::new(
                         c + TAU_BIDEGREE,
-                        gen.slice(target_num_gens, target_all_gens).to_owned(),
+                        g.slice(target_num_gens, target_all_gens).to_owned(),
                     )
                     .to_basis_string();
                     if num_entries == 1 {
@@ -431,20 +431,20 @@ fn main() -> anyhow::Result<()> {
             scratch1.set_scratch_vector_size(source_tau_num_gens);
 
             // First deal with the null-homotopy of ab
-            for (i, v) in gen.slice(0, target_num_gens).iter_nonzero() {
+            for (i, v) in g.slice(0, target_num_gens).iter_nonzero() {
                 scratch0
                     .iter_mut()
                     .zip_eq(&m0[i])
                     .for_each(|(a, b)| *a += v * b);
                 scratch1.add(&m1[i], v);
             }
-            for (i, v) in gen.slice(target_num_gens, target_all_gens).iter_nonzero() {
+            for (i, v) in g.slice(target_num_gens, target_all_gens).iter_nonzero() {
                 scratch1.add(&mt[i], v);
             }
             // Now do the -1 part of the null-homotopy of bc.
             {
                 let sign = p * p - 1;
-                let out = b.product_nullhomotopy(b_tau.as_deref(), &unit_sseq, c, gen);
+                let out = b.product_nullhomotopy(b_tau.as_deref(), &unit_sseq, c, g);
                 for (i, v) in out.iter_nonzero() {
                     scratch0
                         .iter_mut()
@@ -465,7 +465,7 @@ fn main() -> anyhow::Result<()> {
             scratch0.clear();
             scratch0.resize(prod_num_gens, 0);
 
-            for (i, v) in gen.slice(0, target_num_gens).iter_nonzero() {
+            for (i, v) in g.slice(0, target_num_gens).iter_nonzero() {
                 scratch0
                     .iter_mut()
                     .zip_eq(&mb[i])

--- a/ext/examples/secondary_product.rs
+++ b/ext/examples/secondary_product.rs
@@ -150,8 +150,8 @@ fn main() -> anyhow::Result<()> {
         if target_num_gens > 0 {
             let hom_k = hom.get_map((b + shift).s()).hom_k(b.t());
             for i in page_data.complement_pivots() {
-                let gen = BidegreeGenerator::new(b, i);
-                println!("{name} τ x_{gen} = τ {:?}", &hom_k[i]);
+                let g = BidegreeGenerator::new(b, i);
+                println!("{name} τ x_{g} = τ {:?}", &hom_k[i]);
             }
         }
 
@@ -169,12 +169,12 @@ fn main() -> anyhow::Result<()> {
             page_data.subspace_gens(),
             outputs.iter_mut().map(FpVector::as_slice_mut),
         );
-        for (gen, output) in page_data.subspace_gens().zip_eq(outputs) {
+        for (g, output) in page_data.subspace_gens().zip_eq(outputs) {
             println!(
                 "{name} [{basis_string}] = {} + τ {}",
                 output.slice(0, target_num_gens),
                 output.slice(target_num_gens, target_num_gens + tau_num_gens),
-                basis_string = BidegreeElement::new(b, gen.to_owned()).to_basis_string(),
+                basis_string = BidegreeElement::new(b, g.to_owned()).to_basis_string(),
             );
         }
     }

--- a/ext/examples/sq0.rs
+++ b/ext/examples/sq0.rs
@@ -48,9 +48,9 @@ fn main() -> anyhow::Result<()> {
         let map = hom.get_map(b.s());
 
         for i in 0..res.number_of_gens_in_bidegree(b) {
-            let gen = BidegreeGenerator::new(b, i);
+            let g = BidegreeGenerator::new(b, i);
             println!(
-                "Sq^0 x_{gen} = [{}]",
+                "Sq^0 x_{g} = [{}]",
                 (0..source_num_gens)
                     .map(|j| map.output(doubled_b.t(), j).entry(offset + i))
                     .format(", ")

--- a/ext/src/chain_complex/mod.rs
+++ b/ext/src/chain_complex/mod.rs
@@ -142,13 +142,12 @@ where
     }
 
     /// Get a string representation of d(gen), where d is the differential of the resolution.
-    fn boundary_string(&self, gen: BidegreeGenerator, compact: bool) -> String {
-        let d = self.differential(gen.s());
+    fn boundary_string(&self, g: BidegreeGenerator, compact: bool) -> String {
+        let d = self.differential(g.s());
         let target = d.target();
-        let result_vector = d.output(gen.t(), gen.idx());
+        let result_vector = d.output(g.t(), g.idx());
 
-        BidegreeElement::new(gen.degree(), result_vector.clone())
-            .to_string_module(&*target, compact)
+        BidegreeElement::new(g.degree(), result_vector.clone()).to_string_module(&*target, compact)
     }
 }
 

--- a/ext/src/lib.rs
+++ b/ext/src/lib.rs
@@ -169,6 +169,18 @@
 
 #![allow(clippy::upper_case_acronyms)]
 #![deny(clippy::use_self)]
+// Rust 2024 compatibility lints
+#![deny(rust_2024_compatibility)]
+// The `expr` fragment will change in Rust 2024
+#![allow(edition_2024_expr_fragment_specifier)]
+// Drop order will change in Rust 2024
+#![allow(tail_expr_drop_order)]
+// impl Trait will capture more lifetimes in Rust 2024
+#![allow(impl_trait_overcaptures)]
+// `if let` now drops the binding before entering the `else` block in Rust 2024. This lint is
+// currently only supported on nightly.
+#![allow(unknown_lints, if_let_rescope)]
+#![deny(unknown_lints)]
 
 pub mod chain_complex;
 pub mod resolution;

--- a/ext/src/resolution_homomorphism.rs
+++ b/ext/src/resolution_homomorphism.rs
@@ -471,8 +471,8 @@ where
     /// Given a chain map $f: C \to C'$ between free chain complexes, apply
     /// $$ \Hom(f, k): \Hom(C', k) \to \Hom(C, k) $$
     /// to the specified generator of $\Hom(C', k)$.
-    pub fn act(&self, mut result: FpSliceMut, coef: u32, gen: BidegreeGenerator) {
-        let source = gen.degree() + self.shift;
+    pub fn act(&self, mut result: FpSliceMut, coef: u32, g: BidegreeGenerator) {
+        let source = g.degree() + self.shift;
 
         assert_eq!(
             result.as_slice().len(),
@@ -481,10 +481,10 @@ where
                 .number_of_gens_in_degree(source.t())
         );
 
-        let target_module = self.target.module(gen.s());
+        let target_module = self.target.module(g.s());
 
         let map = self.get_map(source.s());
-        let j = target_module.operation_generator_to_index(0, 0, gen.t(), gen.idx());
+        let j = target_module.operation_generator_to_index(0, 0, g.t(), g.idx());
         for i in 0..result.as_slice().len() {
             result.add_basis_element(i, coef * map.output(source.t(), i).entry(j));
         }

--- a/ext/src/secondary.rs
+++ b/ext/src/secondary.rs
@@ -246,18 +246,18 @@ impl<A: PairAlgebra + Send + Sync> SecondaryHomotopy<A> {
         let tracing_span = tracing::Span::current();
         let f = |t, idx| {
             let _tracing_guard = tracing_span.enter();
-            let gen = BidegreeGenerator::s_t(s, t, idx);
+            let g = BidegreeGenerator::s_t(s, t, idx);
             let save_file = SaveFile {
                 algebra: self.target.algebra(),
                 kind: SaveKind::SecondaryComposite,
-                b: gen.degree(),
-                idx: Some(gen.idx()),
+                b: g.degree(),
+                idx: Some(g.idx()),
             };
             if let Some(dir) = dir.read() {
                 if let Some(mut f) = save_file.open_file(dir.to_owned()) {
                     return SecondaryComposite::from_bytes(
                         Arc::clone(&self.target),
-                        gen.t() - self.shift_t,
+                        g.t() - self.shift_t,
                         self.hit_generator,
                         &mut f,
                     )
@@ -267,13 +267,13 @@ impl<A: PairAlgebra + Send + Sync> SecondaryHomotopy<A> {
 
             let mut composite = SecondaryComposite::new(
                 Arc::clone(&self.target),
-                gen.t() - self.shift_t,
+                g.t() - self.shift_t,
                 self.hit_generator,
             );
 
-            tracing::info_span!("Computing composite", gen = %gen).in_scope(|| {
+            tracing::info_span!("Computing composite", g = %g).in_scope(|| {
                 for (coef, d1, d0) in &maps {
-                    composite.add_composite(*coef, gen.t(), gen.idx(), d1, d0);
+                    composite.add_composite(*coef, g.t(), g.idx(), d1, d0);
                 }
                 composite.finalize();
             });
@@ -381,7 +381,7 @@ pub trait SecondaryLift: Sync + Sized {
 
     fn save_dir(&self) -> &SaveDirectory;
 
-    fn compute_intermediate(&self, gen: BidegreeGenerator) -> FpVector;
+    fn compute_intermediate(&self, g: BidegreeGenerator) -> FpVector;
     fn composite(&self, s: u32) -> CompositeData<Self::Algebra>;
 
     #[tracing::instrument(skip(self))]
@@ -417,17 +417,17 @@ pub trait SecondaryLift: Sync + Sized {
         self.homotopies().range().into_maybe_par_iter().for_each(f);
     }
 
-    #[tracing::instrument(skip(self), ret(Display, level = Level::DEBUG), fields(gen = %gen))]
-    fn get_intermediate(&self, gen: BidegreeGenerator) -> FpVector {
-        if let Some((_, v)) = self.intermediates().remove(&gen) {
+    #[tracing::instrument(skip(self), ret(Display, level = Level::DEBUG), fields(g = %g))]
+    fn get_intermediate(&self, g: BidegreeGenerator) -> FpVector {
+        if let Some((_, v)) = self.intermediates().remove(&g) {
             return v;
         }
 
         let save_file = SaveFile {
             algebra: self.algebra(),
             kind: SaveKind::SecondaryIntermediate,
-            b: gen.degree(),
-            idx: Some(gen.idx()),
+            b: g.degree(),
+            idx: Some(g.idx()),
         };
 
         if let Some(dir) = self.save_dir().read() {
@@ -438,7 +438,7 @@ pub trait SecondaryLift: Sync + Sized {
             }
         }
 
-        let result = self.compute_intermediate(gen);
+        let result = self.compute_intermediate(g);
 
         if let Some(dir) = self.save_dir().write() {
             let mut f = save_file.create_file(dir.to_owned(), false);
@@ -485,11 +485,11 @@ pub trait SecondaryLift: Sync + Sized {
     #[tracing::instrument(skip(self))]
     fn compute_intermediates(&self) {
         let tracing_span = tracing::Span::current();
-        let f = |gen: BidegreeGenerator| {
+        let f = |g: BidegreeGenerator| {
             let _tracing_guard = tracing_span.enter();
 
             // If we already have homotopies, we don't need to compute intermediate
-            if self.homotopies()[gen.s() as i32].homotopies.next_degree() >= gen.t() {
+            if self.homotopies()[g.s() as i32].homotopies.next_degree() >= g.t() {
                 return;
             }
             // Check if we have a saved homotopy
@@ -497,7 +497,7 @@ pub trait SecondaryLift: Sync + Sized {
                 let save_file = SaveFile {
                     algebra: self.algebra(),
                     kind: SaveKind::SecondaryHomotopy,
-                    b: gen.degree(),
+                    b: g.degree(),
                     idx: None,
                 };
 
@@ -505,7 +505,7 @@ pub trait SecondaryLift: Sync + Sized {
                     return;
                 }
             }
-            self.intermediates().insert(gen, self.get_intermediate(gen));
+            self.intermediates().insert(g, self.get_intermediate(g));
         };
 
         self.homotopies()
@@ -565,14 +565,14 @@ pub trait SecondaryLift: Sync + Sized {
         let get_intermediate = |i| {
             let _tracing_guard = tracing_span.enter();
 
-            let gen = BidegreeGenerator::new(b, i);
-            let mut v = self.get_intermediate(gen);
-            if gen.s() > shift.s() + 1 {
-                self.homotopies()[gen.s() as i32 - 1].homotopies.apply(
+            let g = BidegreeGenerator::new(b, i);
+            let mut v = self.get_intermediate(g);
+            if g.s() > shift.s() + 1 {
+                self.homotopies()[g.s() as i32 - 1].homotopies.apply(
                     v.as_slice_mut(),
                     1,
-                    gen.t(),
-                    d.output(gen.t(), gen.idx()).as_slice(),
+                    g.t(),
+                    d.output(g.t(), g.idx()).as_slice(),
                 );
             }
             v
@@ -727,16 +727,16 @@ where
         vec![(1, d1, d0)]
     }
 
-    fn compute_intermediate(&self, gen: BidegreeGenerator) -> FpVector {
+    fn compute_intermediate(&self, g: BidegreeGenerator) -> FpVector {
         let p = self.prime();
-        let target = self.underlying.module(gen.s() - 3);
-        let mut result = FpVector::new(p, target.dimension(gen.t() - 1));
-        let d = self.underlying.differential(gen.s());
-        self.homotopies[gen.s() as i32 - 1].act(
+        let target = self.underlying.module(g.s() - 3);
+        let mut result = FpVector::new(p, target.dimension(g.t() - 1));
+        let d = self.underlying.differential(g.s());
+        self.homotopies[g.s() as i32 - 1].act(
             result.as_slice_mut(),
             1,
-            gen.t(),
-            d.output(gen.t(), gen.idx()).as_slice(),
+            g.t(),
+            d.output(g.t(), g.idx()).as_slice(),
             false,
         );
         result
@@ -912,20 +912,20 @@ where
         vec![(neg_1, d_source, c0), (1, c1, d_target)]
     }
 
-    fn compute_intermediate(&self, gen: BidegreeGenerator) -> FpVector {
+    fn compute_intermediate(&self, g: BidegreeGenerator) -> FpVector {
         let p = self.prime();
         let neg_1 = p - 1;
-        let shifted_b = gen.degree() - self.shift();
+        let shifted_b = g.degree() - self.shift();
         let target = self.target().module(shifted_b.s() - 1);
 
         let mut result = FpVector::new(p, target.dimension(shifted_b.t() - 1));
-        let d = self.source().differential(gen.s());
+        let d = self.source().differential(g.s());
 
-        self.homotopies[gen.s() as i32 - 1].act(
+        self.homotopies[g.s() as i32 - 1].act(
             result.as_slice_mut(),
             neg_1,
-            gen.t(),
-            d.output(gen.t(), gen.idx()).as_slice(),
+            g.t(),
+            d.output(g.t(), g.idx()).as_slice(),
             false,
         );
         self.target.homotopy(shifted_b.s() + 1).act(
@@ -933,19 +933,19 @@ where
             neg_1,
             shifted_b.t(),
             self.underlying
-                .get_map(gen.s())
-                .output(gen.t(), gen.idx())
+                .get_map(g.s())
+                .output(g.t(), g.idx())
                 .as_slice(),
             true,
         );
-        self.underlying.get_map(gen.s() - 2).apply(
+        self.underlying.get_map(g.s() - 2).apply(
             result.as_slice_mut(),
             1,
-            gen.t() - 1,
+            g.t() - 1,
             self.source
-                .homotopy(gen.s())
+                .homotopy(g.s())
                 .homotopies
-                .output(gen.t(), gen.idx())
+                .output(g.t(), g.idx())
                 .as_slice(),
         );
 
@@ -1240,22 +1240,22 @@ where
         self.underlying.save_dir()
     }
 
-    fn compute_intermediate(&self, gen: BidegreeGenerator) -> FpVector {
+    fn compute_intermediate(&self, g: BidegreeGenerator) -> FpVector {
         let p = self.prime();
         let neg_1 = p - 1;
-        let shifted_b = gen.degree() - self.shift();
+        let shifted_b = g.degree() - self.shift();
 
         let target = self.target().module(shifted_b.s() - 1);
 
         let mut result = FpVector::new(p, target.dimension(shifted_b.t() - 1));
 
-        self.homotopies[gen.s() as i32 - 1].act(
+        self.homotopies[g.s() as i32 - 1].act(
             result.as_slice_mut(),
             1,
-            gen.t(),
+            g.t(),
             self.source()
-                .differential(gen.s())
-                .output(gen.t(), gen.idx())
+                .differential(g.s())
+                .output(g.t(), g.idx())
                 .as_slice(),
             false,
         );
@@ -1265,31 +1265,31 @@ where
             1,
             shifted_b.t(),
             self.underlying
-                .homotopy(gen.s())
-                .output(gen.t(), gen.idx())
+                .homotopy(g.s())
+                .output(g.t(), g.idx())
                 .as_slice(),
             true,
         );
 
-        self.underlying.homotopy(gen.s() - 2).apply(
+        self.underlying.homotopy(g.s() - 2).apply(
             result.as_slice_mut(),
             neg_1,
-            gen.t() - 1,
-            self.left.source.homotopies()[gen.s() as i32]
+            g.t() - 1,
+            self.left.source.homotopies()[g.s() as i32]
                 .homotopies
-                .output(gen.t(), gen.idx())
+                .output(g.t(), g.idx())
                 .as_slice(),
         );
 
-        let left_shifted_b = gen.degree() - self.left.underlying.shift;
+        let left_shifted_b = g.degree() - self.left.underlying.shift;
         self.right.homotopies()[left_shifted_b.s() as i32].act(
             result.as_slice_mut(),
             neg_1,
             left_shifted_b.t(),
             self.left
                 .underlying
-                .get_map(gen.s())
-                .output(gen.t(), gen.idx())
+                .get_map(g.s())
+                .output(g.t(), g.idx())
                 .as_slice(),
             true,
         );
@@ -1303,8 +1303,8 @@ where
                 left_shifted_b.t(),
                 self.left
                     .underlying
-                    .get_map(gen.s())
-                    .output(gen.t(), gen.idx())
+                    .get_map(g.s())
+                    .output(g.t(), g.idx())
                     .as_slice(),
             );
         }
@@ -1313,9 +1313,9 @@ where
             result.as_slice_mut(),
             neg_1,
             left_shifted_b.t() - 1,
-            self.left.homotopies()[gen.s() as i32]
+            self.left.homotopies()[g.s() as i32]
                 .homotopies
-                .output(gen.t(), gen.idx())
+                .output(g.t(), g.idx())
                 .as_slice(),
         );
 
@@ -1324,10 +1324,7 @@ where
                 result.as_slice_mut(),
                 neg_1,
                 left_shifted_b.t() - 1,
-                left_tau
-                    .get_map(gen.s())
-                    .output(gen.t(), gen.idx())
-                    .as_slice(),
+                left_tau.get_map(g.s()).output(g.t(), g.idx()).as_slice(),
             );
         }
         result

--- a/web_ext/sseq_gui/src/lib.rs
+++ b/web_ext/sseq_gui/src/lib.rs
@@ -1,4 +1,16 @@
 #![deny(clippy::use_self)]
+// Rust 2024 compatibility lints
+#![deny(rust_2024_compatibility)]
+// The `expr` fragment will change in Rust 2024
+#![allow(edition_2024_expr_fragment_specifier)]
+// Drop order will change in Rust 2024
+#![allow(tail_expr_drop_order)]
+// impl Trait will capture more lifetimes in Rust 2024
+#![allow(impl_trait_overcaptures)]
+// `if let` now drops the binding before entering the `else` block in Rust 2024. This lint is
+// currently only supported on nightly.
+#![allow(unknown_lints, if_let_rescope)]
+#![deny(unknown_lints)]
 
 pub mod sseq;
 

--- a/web_ext/sseq_gui/src/resolution_wrapper.rs
+++ b/web_ext/sseq_gui/src/resolution_wrapper.rs
@@ -263,7 +263,7 @@ impl<CC: ChainComplex> Resolution<CC> {
             match &mut self.unit_resolution {
                 UnitResolution::None => panic!("No unit resolution set"),
                 UnitResolution::Own => unreachable!(),
-                UnitResolution::Some(ref mut r) => r,
+                UnitResolution::Some(r) => r,
             }
         }
     }


### PR DESCRIPTION
This ensures that the code is ready to be updated to the 2024 edition of Rust when it comes out in a few months. For us, the main pain point was the fact that `gen` is now a reserved keyword, so we can't use it to name generators. The way `cargo fix --edition` fixes this is by using the raw identifier `r#gen`, but I would rather not use raw identifiers. I renamed them all `g` instead, but I'm open to other names