### PR TITLE
Rename saved files

### DIFF
--- a/ext/pytests/test_secondary_job.py
+++ b/ext/pytests/test_secondary_job.py
@@ -2,9 +2,9 @@ import subprocess
 
 
 def folder_pairs(folder):
+    filename_parts = (f.stem.split("_") for f in folder.glob("*"))
     return (
-        (int(split[0]), int(split[1]))
-        for split in (f.stem.split("_") for f in folder.glob("*"))
+        (int(split[0].replace("m", "-")), int(split[1])) for split in filename_parts
     )
 
 
@@ -34,11 +34,11 @@ def test_secondary_job(tmp_path, monkeypatch):
         "secondary_composites",
         "secondary_intermediates",
     ]:
-        for s, t in folder_pairs(tmp_path / folder):
-            assert t - s <= max_stems
+        for n, _ in folder_pairs(tmp_path / folder):
+            assert n <= max_stems
 
-    for s, _ in folder_pairs(tmp_path / "secondary_composites"):
+    for _, s in folder_pairs(tmp_path / "secondary_composites"):
         assert s == goal_stem
 
-    for s, _ in folder_pairs(tmp_path / "secondary_intermediates"):
+    for _, s in folder_pairs(tmp_path / "secondary_intermediates"):
         assert s == goal_stem + 1

--- a/ext/src/save.rs
+++ b/ext/src/save.rs
@@ -397,19 +397,22 @@ impl<A: Algebra> SaveFile<A> {
 
     /// This panics if there is no save dir
     fn get_save_path(&self, mut dir: PathBuf) -> PathBuf {
+        let n = if self.b.n() < 0 {
+            format!("m{}", -self.b.n())
+        } else {
+            self.b.n().to_string()
+        };
         if let Some(idx) = self.idx {
             dir.push(format!(
-                "{name}s/{s}_{t}_{idx}_{name}",
+                "{name}s/{n}_{s}_{idx}_{name}",
                 name = self.kind.name(),
                 s = self.b.s(),
-                t = self.b.t()
             ));
         } else {
             dir.push(format!(
-                "{name}s/{s}_{t}_{name}",
+                "{name}s/{n}_{s}_{name}",
                 name = self.kind.name(),
                 s = self.b.s(),
-                t = self.b.t()
             ));
         }
         dir

--- a/ext/tests/save_load_resolution.rs
+++ b/ext/tests/save_load_resolution.rs
@@ -289,7 +289,7 @@ fn test_checksum() {
         .compute_through_bidegree(Bidegree::s_t(2, 2));
 
     let mut path = tempdir.path().to_owned();
-    path.push("differentials/2_2_differential");
+    path.push("differentials/0_2_differential");
 
     let mut file = OpenOptions::new()
         .read(true)


### PR DESCRIPTION
We now use (stem, homological degree) notation instead of (homological degree, internal degree) in the names of files, which makes them easier to inspect. To avoid dashes in filenames, we replace minuses by the character `m`.

This is the change that I mentioned in https://github.com/SpectralSequences/sseq/pull/127#issuecomment-2613829194.