### PR TITLE
Use `i32` for homological degree

### DIFF
--- a/ext/benches/iai.rs
+++ b/ext/benches/iai.rs
@@ -2,15 +2,11 @@ use ext::{chain_complex::ChainComplex, utils::construct};
 use sseq::coordinates::Bidegree;
 
 fn benchmark(module_name: &str, max_degree: i32, algebra: &str, n_times: u128) {
-    let max = Bidegree::s_t(max_degree as u32, max_degree);
+    let max = Bidegree::s_t(max_degree, max_degree);
     for _ in 0..n_times {
         let res = construct((module_name, algebra), None).unwrap();
         res.compute_through_bidegree(max);
-        assert!(
-            res.module(max_degree as u32)
-                .number_of_gens_in_degree(max_degree)
-                < 1000
-        );
+        assert!(res.module(max_degree).number_of_gens_in_degree(max_degree) < 1000);
     }
 }
 

--- a/ext/benches/resolve.rs
+++ b/ext/benches/resolve.rs
@@ -7,16 +7,12 @@ fn benchmark(module_name: &str, max_degree: i32, algebra: &str, n_times: u128) {
     print!("benchmark  {algebra:6}  {module_name}  {max_degree}:    ");
     std::io::stdout().flush().unwrap();
 
-    let max = Bidegree::s_t(max_degree as u32, max_degree);
+    let max = Bidegree::s_t(max_degree, max_degree);
     let start = Instant::now();
     for _ in 0..n_times {
         let res = construct((module_name, algebra), None).unwrap();
         res.compute_through_bidegree(max);
-        assert!(
-            res.module(max_degree as u32)
-                .number_of_gens_in_degree(max_degree)
-                < 1000
-        );
+        assert!(res.module(max_degree).number_of_gens_in_degree(max_degree) < 1000);
     }
     let dur = start.elapsed();
 

--- a/ext/crates/sseq/src/coordinates/bidegree.rs
+++ b/ext/crates/sseq/src/coordinates/bidegree.rs
@@ -9,29 +9,29 @@ use serde::{Deserialize, Serialize};
 #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct Bidegree {
     /// Homological degree
-    s: u32,
+    s: i32,
     /// Internal degree
     t: i32,
 }
 
 impl Bidegree {
-    pub const fn s_t(s: u32, t: i32) -> Self {
+    pub const fn s_t(s: i32, t: i32) -> Self {
         Self { s, t }
     }
 
-    pub const fn t_s(t: i32, s: u32) -> Self {
+    pub const fn t_s(t: i32, s: i32) -> Self {
         Self::s_t(s, t)
     }
 
-    pub const fn n_s(n: i32, s: u32) -> Self {
-        Self::s_t(s, n + s as i32)
+    pub const fn n_s(n: i32, s: i32) -> Self {
+        Self::s_t(s, n + s)
     }
 
     pub const fn zero() -> Self {
         Self { s: 0, t: 0 }
     }
 
-    pub fn s(&self) -> u32 {
+    pub fn s(&self) -> i32 {
         self.s
     }
 
@@ -40,7 +40,7 @@ impl Bidegree {
     }
 
     pub fn n(&self) -> i32 {
-        self.t - self.s as i32
+        self.t - self.s
     }
 
     /// Returns difference as a bidegree if the difference in homological degrees is nonnegative,

--- a/ext/crates/sseq/src/coordinates/element.rs
+++ b/ext/crates/sseq/src/coordinates/element.rs
@@ -24,7 +24,7 @@ impl BidegreeElement {
         Self { degree, vec }
     }
 
-    pub fn s(&self) -> u32 {
+    pub fn s(&self) -> i32 {
         self.degree.s()
     }
 

--- a/ext/crates/sseq/src/coordinates/generator.rs
+++ b/ext/crates/sseq/src/coordinates/generator.rs
@@ -23,15 +23,15 @@ impl BidegreeGenerator {
         }
     }
 
-    pub fn s_t(s: u32, t: i32, idx: usize) -> Self {
+    pub fn s_t(s: i32, t: i32, idx: usize) -> Self {
         Self::new(Bidegree::s_t(s, t), idx)
     }
 
-    pub fn n_s(n: i32, s: u32, idx: usize) -> Self {
+    pub fn n_s(n: i32, s: i32, idx: usize) -> Self {
         Self::new(Bidegree::n_s(n, s), idx)
     }
 
-    pub fn s(&self) -> u32 {
+    pub fn s(&self) -> i32 {
         self.degree.s()
     }
 

--- a/ext/crates/sseq/src/coordinates/range.rs
+++ b/ext/crates/sseq/src/coordinates/range.rs
@@ -2,27 +2,27 @@
 /// maximum `t`.
 pub struct BidegreeRange<'a, T> {
     /// The maximal value of `s` in the range.
-    s: u32,
+    s: i32,
     /// The function that gives, for a given value of `s`, the maximum value for `t`.
-    t: &'a (dyn Fn(&T, u32) -> i32 + Sync),
+    t: &'a (dyn Fn(&T, i32) -> i32 + Sync),
     /// Auxillary data that `t` may depend on.
     aux: &'a T,
 }
 
 impl<'a, T> BidegreeRange<'a, T> {
-    pub fn new(aux: &'a T, s: u32, t: &'a (dyn Fn(&T, u32) -> i32 + Sync)) -> Self {
+    pub fn new(aux: &'a T, s: i32, t: &'a (dyn Fn(&T, i32) -> i32 + Sync)) -> Self {
         Self { s, t, aux }
     }
 
-    pub fn s(&self) -> u32 {
+    pub fn s(&self) -> i32 {
         self.s
     }
 
-    pub fn t(&self, s: u32) -> i32 {
+    pub fn t(&self, s: i32) -> i32 {
         (self.t)(self.aux, s)
     }
 
-    pub fn restrict(self, s: u32) -> Self {
+    pub fn restrict(self, s: i32) -> Self {
         assert!(s <= self.s);
         Self {
             s,

--- a/ext/examples/bruner.rs
+++ b/ext/examples/bruner.rs
@@ -164,18 +164,18 @@ fn create_chain_complex(num_s: usize) -> FiniteChainComplex {
 }
 
 /// Read the Diff.$N files in `data_dir` and produce the corresponding chain complex object.
-fn read_bruner_resolution(data_dir: &Path, max_n: i32) -> Result<(u32, FiniteChainComplex)> {
-    let num_s: usize = data_dir.read_dir()?.count();
+fn read_bruner_resolution(data_dir: &Path, max_n: i32) -> Result<(i32, FiniteChainComplex)> {
+    let num_s = data_dir.read_dir()?.count() as i32;
 
-    let cc = create_chain_complex(num_s);
+    let cc = create_chain_complex(num_s as usize);
     let algebra = cc.algebra();
 
     let algebra: &MilnorAlgebra = algebra.as_ref().try_into()?;
 
     let mut buf = String::new();
-    let s = num_s as u32 - 1;
+    let s = num_s - 1;
 
-    algebra.compute_basis(max_n + s as i32 + 1);
+    algebra.compute_basis(max_n + s + 1);
     // Handle s = 0
     {
         // TODO: actually parse file
@@ -184,7 +184,7 @@ fn read_bruner_resolution(data_dir: &Path, max_n: i32) -> Result<(u32, FiniteCha
         m.extend_by_zero(max_n + 1);
     }
 
-    for s in 1..num_s as u32 {
+    for s in 1..num_s {
         let m = cc.module(s);
         let d = cc.differential(s);
 
@@ -215,8 +215,8 @@ fn read_bruner_resolution(data_dir: &Path, max_n: i32) -> Result<(u32, FiniteCha
         m.add_generators(cur_degree, entries.len(), None);
         d.add_generators_from_rows(cur_degree, entries);
 
-        m.extend_by_zero(max_n + s as i32 + 1);
-        d.extend_by_zero(max_n + s as i32);
+        m.extend_by_zero(max_n + s + 1);
+        d.extend_by_zero(max_n + s);
     }
 
     Ok((s, cc))

--- a/ext/examples/ext_m_n.rs
+++ b/ext/examples/ext_m_n.rs
@@ -57,14 +57,14 @@ mod hom_cochain_complex {
     };
     use ext::chain_complex::FreeChainComplex;
     use fp::matrix::Subquotient;
-    use once::OnceVec;
+    use once::OnceBiVec;
     use sseq::coordinates::Bidegree;
 
     pub struct HomCochainComplex<CC: FreeChainComplex, M: Module<Algebra = CC::Algebra>> {
         source: Arc<CC>,
         target: Arc<M>,
-        modules: OnceVec<Arc<HomModule<M>>>,
-        differentials: OnceVec<Arc<HomPullback<M>>>,
+        modules: OnceBiVec<Arc<HomModule<M>>>,
+        differentials: OnceBiVec<Arc<HomPullback<M>>>,
     }
 
     impl<CC: FreeChainComplex, M: Module<Algebra = CC::Algebra>> HomCochainComplex<CC, M> {
@@ -72,27 +72,27 @@ mod hom_cochain_complex {
             Self {
                 source,
                 target,
-                modules: OnceVec::new(),
-                differentials: OnceVec::new(),
+                modules: OnceBiVec::new(0),
+                differentials: OnceBiVec::new(0),
             }
         }
 
         pub fn min_degree(&self) -> i32 {
-            self.modules[0usize].min_degree()
+            self.modules[0].min_degree()
         }
 
         pub fn compute_through_stem(&self, max: Bidegree) {
-            self.modules.extend(max.s() as usize + 1, |s| {
+            self.modules.extend(max.s() + 1, |s| {
                 Arc::new(HomModule::new(
-                    self.source.module(s as u32),
+                    self.source.module(s),
                     Arc::clone(&self.target),
                 ))
             });
-            self.differentials.extend(max.s() as usize, |s| {
+            self.differentials.extend(max.s(), |s| {
                 Arc::new(HomPullback::new(
                     Arc::clone(&self.modules[s]),
                     Arc::clone(&self.modules[s + 1]),
-                    self.source.differential(s as u32 + 1),
+                    self.source.differential(s + 1),
                 ))
             });
             for (s, module) in self.modules.iter().enumerate() {

--- a/ext/examples/massey.rs
+++ b/ext/examples/massey.rs
@@ -25,7 +25,7 @@ fn main() -> anyhow::Result<()> {
 
     let a = Bidegree::n_s(
         query::raw("n of Ext class a", str::parse),
-        query::raw("s of Ext class a", str::parse::<std::num::NonZeroU32>).get(),
+        query::raw("s of Ext class a", str::parse::<std::num::NonZeroI32>).get(),
     );
 
     unit.compute_through_stem(a);
@@ -36,7 +36,7 @@ fn main() -> anyhow::Result<()> {
 
     let b = Bidegree::n_s(
         query::raw("n of Ext class b", str::parse),
-        query::raw("s of Ext class b", str::parse::<std::num::NonZeroU32>).get(),
+        query::raw("s of Ext class b", str::parse::<std::num::NonZeroI32>).get(),
     );
 
     unit.compute_through_stem(b);

--- a/ext/examples/resolution_size.rs
+++ b/ext/examples/resolution_size.rs
@@ -8,7 +8,7 @@ fn main() -> anyhow::Result<()> {
 
     for s in (0..res.next_homological_degree()).rev() {
         let module = res.module(s);
-        for t in res.min_degree() + s as i32..=module.max_computed_degree() {
+        for t in res.min_degree() + s..=module.max_computed_degree() {
             print!("{}, ", module.dimension(t));
         }
         println!();

--- a/ext/examples/secondary_massey.rs
+++ b/ext/examples/secondary_massey.rs
@@ -241,7 +241,7 @@ fn main() -> anyhow::Result<()> {
     ch_lift.extend_all();
 
     fn get_page_data(sseq: &sseq::Sseq, b: Bidegree) -> &fp::matrix::Subquotient {
-        let d = sseq.page_data(b.n(), b.s() as i32);
+        let d = sseq.page_data(b.n(), b.s());
         &d[std::cmp::min(3, d.len() - 1)]
     }
 
@@ -372,9 +372,7 @@ fn main() -> anyhow::Result<()> {
         let mt = Matrix::from_vec(p, &chain_homotopy.homotopy(source.s() + 1).hom_k(c.t() + 1));
         let m1 = Matrix::from_vec(
             p,
-            &ch_lift.homotopies()[source.s() as i32 + 1]
-                .homotopies
-                .hom_k(c.t()),
+            &ch_lift.homotopies()[source.s() + 1].homotopies.hom_k(c.t()),
         );
         let mp = Matrix::from_vec(
             p,

--- a/ext/examples/secondary_product.rs
+++ b/ext/examples/secondary_product.rs
@@ -121,7 +121,7 @@ fn main() -> anyhow::Result<()> {
     };
 
     fn get_page_data(sseq: &sseq::Sseq<sseq::Adams>, b: Bidegree) -> &fp::matrix::Subquotient {
-        let d = sseq.page_data(b.n(), b.s() as i32);
+        let d = sseq.page_data(b.n(), b.s());
         &d[std::cmp::min(3, d.len() - 1)]
     }
 

--- a/ext/src/chain_complex/finite_chain_complex.rs
+++ b/ext/src/chain_complex/finite_chain_complex.rs
@@ -141,7 +141,7 @@ where
         Arc::clone(&self.zero_module)
     }
 
-    fn module(&self, s: u32) -> Arc<Self::Module> {
+    fn module(&self, s: i32) -> Arc<Self::Module> {
         let s = s as usize;
         if s >= self.modules.len() {
             self.zero_module()
@@ -150,7 +150,7 @@ where
         }
     }
 
-    fn differential(&self, s: u32) -> Arc<Self::Homomorphism> {
+    fn differential(&self, s: i32) -> Arc<Self::Homomorphism> {
         let s = s as usize;
         let s = std::cmp::min(s, self.differentials.len() - 1); // The last entry is the zero homomorphism
         Arc::clone(&self.differentials[s])
@@ -163,11 +163,11 @@ where
     }
 
     fn has_computed_bidegree(&self, b: Bidegree) -> bool {
-        b.s() > self.modules.len() as u32 || b.t() < self.module(b.s()).max_computed_degree()
+        b.s() > self.modules.len() as i32 || b.t() < self.module(b.s()).max_computed_degree()
     }
 
-    fn next_homological_degree(&self) -> u32 {
-        u32::MAX
+    fn next_homological_degree(&self) -> i32 {
+        i32::MAX
     }
 }
 
@@ -176,8 +176,8 @@ where
     M: Module,
     F: ModuleHomomorphism<Source = M, Target = M>,
 {
-    fn max_s(&self) -> u32 {
-        self.modules.len() as u32
+    fn max_s(&self) -> i32 {
+        self.modules.len() as i32
     }
 }
 
@@ -220,11 +220,11 @@ where
         self.cc.zero_module()
     }
 
-    fn module(&self, s: u32) -> Arc<Self::Module> {
+    fn module(&self, s: i32) -> Arc<Self::Module> {
         self.cc.module(s)
     }
 
-    fn differential(&self, s: u32) -> Arc<Self::Homomorphism> {
+    fn differential(&self, s: i32) -> Arc<Self::Homomorphism> {
         self.cc.differential(s)
     }
 
@@ -232,7 +232,7 @@ where
         self.cc.compute_through_bidegree(b)
     }
 
-    fn next_homological_degree(&self) -> u32 {
+    fn next_homological_degree(&self) -> i32 {
         self.cc.next_homological_degree()
     }
 }
@@ -284,7 +284,7 @@ where
     }
 
     /// This currently crashes if `s` is greater than the s degree of the class this came from.
-    fn chain_map(&self, s: u32) -> Arc<Self::ChainMap> {
+    fn chain_map(&self, s: i32) -> Arc<Self::ChainMap> {
         Arc::clone(&self.chain_maps[s as usize])
     }
 }
@@ -308,7 +308,7 @@ where
     F1: ModuleHomomorphism<Source = M, Target = M>,
     F2: ModuleHomomorphism<Source = M, Target = CC::Module>,
 {
-    fn max_s(&self) -> u32 {
+    fn max_s(&self) -> i32 {
         self.cc.max_s()
     }
 }

--- a/ext/src/chain_complex/mod.rs
+++ b/ext/src/chain_complex/mod.rs
@@ -43,7 +43,7 @@ where
         for s in (0..self.next_homological_degree()).rev() {
             let module = self.module(s);
 
-            for t in min_degree + s as i32..=module.max_computed_degree() {
+            for t in min_degree + s..=module.max_computed_degree() {
                 result.push(unicode_num(module.number_of_gens_in_degree(t)));
                 result.push(' ');
             }
@@ -60,7 +60,7 @@ where
         let p = self.prime();
         let mut sseq = sseq::Sseq::new(p, self.min_degree(), 0);
         for b in self.iter_stem() {
-            sseq.set_dimension(b.n(), b.s() as i32, self.number_of_gens_in_bidegree(b));
+            sseq.set_dimension(b.n(), b.s(), self.number_of_gens_in_bidegree(b));
         }
         sseq
     }
@@ -68,7 +68,7 @@ where
     fn filtration_one_products(&self, op_deg: i32, op_idx: usize) -> sseq::Product {
         let p = self.prime();
         let mut matrices = BiVec::new(self.min_degree());
-        let max_y = self.next_homological_degree() as i32 - 1;
+        let max_y = self.next_homological_degree() - 1;
         matrices.extend_with(self.module(0).max_computed_degree() - op_deg + 2, |x| {
             let mut entries = BiVec::with_capacity(0, max_y);
             let mut b = Bidegree::n_s(x, 0);
@@ -176,10 +176,10 @@ pub trait ChainComplex: Send + Sync {
     fn algebra(&self) -> Arc<Self::Algebra>;
     fn min_degree(&self) -> i32;
     fn zero_module(&self) -> Arc<Self::Module>;
-    fn module(&self, homological_degree: u32) -> Arc<Self::Module>;
+    fn module(&self, homological_degree: i32) -> Arc<Self::Module>;
 
     /// This returns the differential starting from the sth module.
-    fn differential(&self, s: u32) -> Arc<Self::Homomorphism>;
+    fn differential(&self, s: i32) -> Arc<Self::Homomorphism>;
 
     /// If the complex has been computed at bidegree (s, t). This means the module has been
     /// computed at (s, t), and so has the differential at (s, t). In the case of a free module,
@@ -191,7 +191,7 @@ pub trait ChainComplex: Send + Sync {
     fn compute_through_bidegree(&self, b: Bidegree);
 
     /// The first s such that `self.module(s)` is not defined.
-    fn next_homological_degree(&self) -> u32;
+    fn next_homological_degree(&self) -> i32;
 
     /// Iterate through all defined bidegrees in increasing order of stem.
     fn iter_stem(&self) -> StemIterator<'_, Self> {
@@ -255,7 +255,7 @@ pub trait ChainComplex: Send + Sync {
 pub struct StemIterator<'a, CC: ?Sized> {
     cc: &'a CC,
     current: Bidegree,
-    max_s: u32,
+    max_s: i32,
 }
 
 impl<CC: ChainComplex + ?Sized> Iterator for StemIterator<'_, CC> {
@@ -294,12 +294,12 @@ pub trait AugmentedChainComplex: ChainComplex {
     >;
 
     fn target(&self) -> Arc<Self::TargetComplex>;
-    fn chain_map(&self, s: u32) -> Arc<Self::ChainMap>;
+    fn chain_map(&self, s: i32) -> Arc<Self::ChainMap>;
 }
 
 /// A bounded chain complex is a chain complex C for which C_s = 0 for all s >= max_s
 pub trait BoundedChainComplex: ChainComplex {
-    fn max_s(&self) -> u32;
+    fn max_s(&self) -> i32;
 
     fn euler_characteristic(&self, t: i32) -> isize {
         (0..self.max_s())
@@ -310,6 +310,6 @@ pub trait BoundedChainComplex: ChainComplex {
 
 /// `chain_maps` is required to be non-empty
 pub struct ChainMap<F: ModuleHomomorphism> {
-    pub s_shift: u32,
+    pub s_shift: i32,
     pub chain_maps: Vec<F>,
 }

--- a/ext/src/resolution_homomorphism.rs
+++ b/ext/src/resolution_homomorphism.rs
@@ -64,7 +64,7 @@ where
             name,
             source,
             target,
-            maps: OnceBiVec::new(shift.s() as i32),
+            maps: OnceBiVec::new(shift.s()),
             shift,
             save_dir,
         }
@@ -82,21 +82,21 @@ where
         self.maps.len()
     }
 
-    fn get_map_ensure_length(&self, input_s: u32) -> &MuFreeModuleHomomorphism<U, CC2::Module> {
-        self.maps.extend(input_s as i32, |input_s| {
-            let output_s = input_s as u32 - self.shift.s();
+    fn get_map_ensure_length(&self, input_s: i32) -> &MuFreeModuleHomomorphism<U, CC2::Module> {
+        self.maps.extend(input_s, |input_s| {
+            let output_s = input_s - self.shift.s();
             Arc::new(MuFreeModuleHomomorphism::new(
-                self.source.module(input_s as u32),
+                self.source.module(input_s),
                 self.target.module(output_s),
                 self.shift.t(),
             ))
         });
-        &self.maps[input_s as i32]
+        &self.maps[input_s]
     }
 
     /// Returns the chain map on the `s`th source module.
-    pub fn get_map(&self, input_s: u32) -> Arc<MuFreeModuleHomomorphism<U, CC2::Module>> {
-        Arc::clone(&self.maps[input_s as i32])
+    pub fn get_map(&self, input_s: i32) -> Arc<MuFreeModuleHomomorphism<U, CC2::Module>> {
+        Arc::clone(&self.maps[input_s])
     }
 
     pub fn save_dir(&self) -> &SaveDirectory {
@@ -130,7 +130,7 @@ where
     #[tracing::instrument(fields(self = self.name, max = %max))]
     pub fn extend_through_stem(&self, max: Bidegree) {
         self.extend_profile(BidegreeRange::new(&(), max.s() + 1, &|_, s| {
-            max.n() + s as i32 + 1
+            max.n() + s + 1
         }))
     }
 
@@ -188,7 +188,7 @@ where
         for s in self.shift.s()..max.s() {
             assert_eq!(
                 Vec::<i32>::new(),
-                self.maps[s as i32].ooo_outputs(),
+                self.maps[s].ooo_outputs(),
                 "Map {s} has out of order elements"
             );
         }

--- a/ext/src/save.rs
+++ b/ext/src/save.rs
@@ -357,7 +357,7 @@ impl<A: Algebra> SaveFile<A> {
     fn write_header(&self, buffer: &mut impl io::Write) -> io::Result<()> {
         buffer.write_u32::<LittleEndian>(self.kind.magic())?;
         buffer.write_u32::<LittleEndian>(self.algebra.magic())?;
-        buffer.write_u32::<LittleEndian>(self.b.s())?;
+        buffer.write_i32::<LittleEndian>(self.b.s())?;
         buffer.write_i32::<LittleEndian>(if let Some(i) = self.idx {
             self.b.t() + ((i as i32) << 16)
         } else {
@@ -385,7 +385,7 @@ impl<A: Algebra> SaveFile<A> {
 
         check_header!("magic", self.kind.magic(), "{:#010x}");
         check_header!("algebra", self.algebra.magic(), "{:#06x}");
-        check_header!("s", self.b.s(), "{}");
+        check_header!("s", self.b.s() as u32, "{}");
         check_header!(
             "t",
             if let Some(i) = self.idx {

--- a/ext/src/utils.rs
+++ b/ext/src/utils.rs
@@ -223,7 +223,7 @@ where
         let shift = json["shift"].as_i64().unwrap_or(0) as i32;
 
         let cofiber = BidegreeGenerator::s_t(
-            cofiber["s"].as_u64().unwrap() as u32,
+            cofiber["s"].as_i64().unwrap() as i32,
             cofiber["t"].as_i64().unwrap() as i32 + shift,
             cofiber["idx"].as_u64().unwrap() as usize,
         );
@@ -554,9 +554,9 @@ pub use logging::{ext_tracing_subscriber, init_logging, LogWriter};
 /// be computed. The minimum value of `s` is the `shift_s` of the
 /// [`SecondaryLift`](crate::secondary::SecondaryLift) and the maximum value (inclusive) is the
 /// maximum `s` of the resolution.
-pub fn secondary_job() -> Option<u32> {
+pub fn secondary_job() -> Option<i32> {
     let val = std::env::var("SECONDARY_JOB").ok()?;
-    let parsed: Option<u32> = str::parse(&val).ok();
+    let parsed: Option<i32> = str::parse(&val).ok();
     if parsed.is_none() {
         eprintln!(
             "Invalid argument for `SECONDARY_JOB`. Expected non-negative integer but found {val}"

--- a/ext/src/yoneda.rs
+++ b/ext/src/yoneda.rs
@@ -190,9 +190,9 @@ where
     let algebra = cc.algebra();
 
     let t_shift: i32 = map.chain_maps[0].degree_shift();
-    let s_shift: u32 = map.s_shift;
+    let s_shift: i32 = map.s_shift;
 
-    let s_max = std::cmp::max(target_cc.max_s(), map.s_shift + map.chain_maps.len() as u32) - 1;
+    let s_max = std::cmp::max(target_cc.max_s(), map.s_shift + map.chain_maps.len() as i32) - 1;
 
     let t_max = {
         // The maximum t required by the augmentation maps
@@ -398,7 +398,7 @@ where
 
         // Now we clean up the module degree by degree from above.
         for t in (t_min..=t_max).rev() {
-            if t - (s as i32) < cc.min_degree() {
+            if t - s < cc.min_degree() {
                 continue;
             }
             if source.dimension(t) == 0 {

--- a/ext/tests/extend_identity.rs
+++ b/ext/tests/extend_identity.rs
@@ -44,7 +44,7 @@ use sseq::coordinates::Bidegree;
 fn extend_identity<T: TryInto<Config>>(#[case] config: T, #[case] max_degree: i32) {
     let config: Config = config.try_into().ok().unwrap();
     let resolution = Arc::new(construct(config, None).unwrap());
-    let max = Bidegree::s_t(max_degree as u32, max_degree);
+    let max = Bidegree::s_t(max_degree, max_degree);
     resolution.compute_through_bidegree(max);
 
     let module = resolution.target().module(0);
@@ -60,7 +60,7 @@ fn extend_identity<T: TryInto<Config>>(#[case] config: T, #[case] max_degree: i3
     );
     hom.extend(max);
 
-    for s in 0..=max_degree as u32 {
+    for s in 0..=max_degree {
         let source = resolution.module(s);
         let map = hom.get_map(s);
         for t in 0..=max_degree {

--- a/ext/tests/milnor_vs_adem.rs
+++ b/ext/tests/milnor_vs_adem.rs
@@ -20,7 +20,7 @@ use sseq::coordinates::Bidegree;
 #[case("j_mod_2", 30)]
 #[case("ksp", 30)]
 fn compare(#[case] module_name: &str, #[case] max_degree: i32) {
-    let max = Bidegree::s_t(max_degree as u32, max_degree);
+    let max = Bidegree::s_t(max_degree, max_degree);
     let a = construct((module_name, "adem"), None).unwrap();
     let b = construct((module_name, "milnor"), None).unwrap();
 
@@ -40,7 +40,7 @@ fn compare(#[case] module_name: &str, #[case] max_degree: i32) {
 #[case("S_3[10]", 50)]
 #[case("Calpha[15]", 50)]
 fn compare_unstable(#[case] module_name: &str, #[case] max_degree: i32) {
-    let max = Bidegree::s_t(max_degree as u32, max_degree);
+    let max = Bidegree::s_t(max_degree, max_degree);
     let a = construct_standard::<true, _, _>((module_name, "adem"), None).unwrap();
     let b = construct_standard::<true, _, _>((module_name, "milnor"), None).unwrap();
 

--- a/ext/tests/milnor_vs_nassau.rs
+++ b/ext/tests/milnor_vs_nassau.rs
@@ -12,7 +12,7 @@ use sseq::coordinates::Bidegree;
 #[case("Joker", 30)]
 #[case("Csigma", 30)]
 fn compare(#[case] module_name: &str, #[case] max_degree: i32) {
-    let max = Bidegree::s_t(max_degree as u32, max_degree);
+    let max = Bidegree::s_t(max_degree, max_degree);
     let a = construct_standard::<false, _, _>(module_name, None).unwrap();
     let b = construct_nassau(module_name, None).unwrap();
 

--- a/web_ext/sseq_gui/src/actions.rs
+++ b/web_ext/sseq_gui/src/actions.rs
@@ -143,7 +143,7 @@ impl ActionT for AddProductType {
     }
 
     fn act_resolution(&self, resolution: &mut Resolution<CCC>) -> Option<Message> {
-        let b = Bidegree::s_t(self.y as u32, self.x + self.y);
+        let b = Bidegree::s_t(self.y, self.x + self.y);
 
         resolution.add_product(b, self.class.clone(), &self.name);
         None

--- a/web_ext/sseq_gui/src/managers.rs
+++ b/web_ext/sseq_gui/src/managers.rs
@@ -180,10 +180,8 @@ impl ResolutionManager {
         };
         self.sender.send(msg)?;
 
-        resolution.compute_through_stem(Bidegree::n_s(
-            action.max_degree,
-            action.max_degree as u32 / 2 + 5,
-        ));
+        resolution
+            .compute_through_stem(Bidegree::n_s(action.max_degree, action.max_degree / 2 + 5));
 
         Ok(())
     }


### PR DESCRIPTION
This enables a few things.
- We can now reason about duals, which are negatively graded, even though this is completely untested and probably broken as-is.
- We can also use `Bidegree`s to index full-page spectral sequences, like in the `sseq` subcrate or the webserver.
- We can now store bidegrees as `[i32; 2]`, to allow for generalizing to `[i32; N]` for multi-graded objects in the future.