### PR TITLE
Add Quickstart section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ allows us to work compute in the derived category of said algebra. The primary
 purpose is to compute the classical Adams E2 page by computing Ext over the
 Steenrod algebra.
 
+** To get started computing Ext over the Steenrod algebra, read the Quickstart [here](ext/README.md).**
+
 2. `web_ext`
 Web interfaces to `ext`. There are two subprojects at the moment:
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ allows us to work compute in the derived category of said algebra. The primary
 purpose is to compute the classical Adams E2 page by computing Ext over the
 Steenrod algebra.
 
-** To get started computing Ext over the Steenrod algebra, read the Quickstart [here](ext/README.md).**
+**To get started computing Ext over the Steenrod algebra, read the Quickstart [here](ext/README.md).**
 
 2. `web_ext`
 Web interfaces to `ext`. There are two subprojects at the moment:

--- a/ext/README.md
+++ b/ext/README.md
@@ -14,6 +14,65 @@ computations, or act as actual examples for how to use the library.
 Since `ext-rs` is based on [Rust](https://www.rust-lang.org/), one must install
 Rust before using this library.
 
+## Quickstart
+### Installing `sseq`
+
+1. **Install Git**  (if not already installed)
+   - On Windows: Install [Git for Windows](https://git-scm.com/downloads/win)
+   - On macOS: git will be installed automatically when you type a git command in the terminal
+   - On Linux: use your package manager
+
+2. **Install Rust** (if not already installed)
+   Install Rust via rustup: [download the installer here](https://www.rust-lang.org/tools/install).
+   Run the installer and accept the defaults.
+
+3. **Clone the repository**  
+   - Open a new terminal. (On windows: hit `Windows + r`, type `cmd`, and hit
+   enter to get a command prompt.)
+   - Type `git clone https://github.com/SpectralSequences/sseq`
+   and hit enter.
+
+4. **Navigate to the project folder**  
+   In your terminal type `cd sseq/ext` and hit enter.
+
+5. Now you're ready to run the example in the "First usage" section.
+
+   **Troubleshooting:**
+   - If you get a command not found error when running a `cargo` command, make
+     sure you're using a new terminal window (not the one you used to install rust).
+   - If it says that `Cargo.toml` is not found, then you may have skipped Step 4.
+
+### First usage: how to compute the Adams E2 term
+
+To produce an svg chart of the stable Adams spectral sequence E2 term for a
+given module, run:
+
+```shell
+cargo run --example chart
+```
+
+On your first run, you can just accept the defaults (the 2-primary sphere in a
+modest range of degrees) by pressing enter. Other preset Steenrod modules can
+be found in the `ext/steenrod_modules/` directory; enter their name (e.g. `C2`)
+in the first prompt. If the module you want is not in this list, read the file
+`ext/MODULE-SPEC.md` in this repository which explains how to construct your own.
+
+More essential end-user documentation, such as command-line options that will
+speed up runtimes, can be found at
+[https://spectralsequences.github.io/sseq/docs/ext/](https://spectralsequences.github.io/sseq/docs/ext/).
+
+### Notable functionality
+In addition to the standard Ext, more runnable code can be found in
+`ext/examples`. All of the "examples" can be run in a similar way as `chart`.
+In particular, we highlight the following notable functionality:
+
+* Ext over the odd-primary Steenrod algebra (start by using the module `S_3`
+  for the 3-primary sphere in the `chart` example above)
+* Adams d2's via the secondary Steenrod algebra (see the `secondary` example)
+* Massey products (see the `massey` example)
+* Unstable Adams E2 term for spheres (see the `unstable_chart` example)
+
+
 ## Library documentation
 
 Documentation for both the examples and the library itself is hosted at


### PR DESCRIPTION
I wrote this section for the README after having conversations with several people who asked whether sseq had a certain feature or how to get started on a basic level. The goal is to make this more accessible to homotopy theorists who mostly want to make an Ext chart for their favorite module.

I talked to Joey about this, and also had someone successfully install sseq on windows using a version of these instructions, but who ran into the "gotchas" I listed below step 5 in the installation section.