### PR TITLE
Disable Selenium test for now

### DIFF
--- a/.github/workflows/ext.yaml
+++ b/.github/workflows/ext.yaml
@@ -179,7 +179,9 @@ jobs:
           path: web_ext/sseq_gui/dist/
 
   selenium:
-    if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository }}
+    # TODO Someone please figure out how to make the selenium tests work on Ubuntu 24.04
+    if: false
+    # if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: [webserver]


### PR DESCRIPTION
The switch from Ubuntu 20.04 which reached EOL to Ubuntu 24.04 broke our selenium tests. I don't have the bandwidth to deal with that right now, but at least the webserver jobs still work. Since `deploy` depends on `selenium`, that also means that we won't be deploying new versions until this gets fixed. I feel it's ok since the webserver hasn't changed in years.