### PR TITLE
Add iteration and standard impls in `once` crate

### DIFF
--- a/ext/crates/once/Cargo.toml
+++ b/ext/crates/once/Cargo.toml
@@ -15,6 +15,7 @@ maybe-rayon = { path = "../maybe-rayon" }
 
 [dev-dependencies]
 criterion = "0.5"
+expect-test = "1.1.0"
 pprof = { version = "0.14", features = ["criterion", "flamegraph"] }
 proptest = "1.6.0"
 rand = "0.9"

--- a/ext/crates/once/benches/criterion/benchable_impl.rs
+++ b/ext/crates/once/benches/criterion/benchable_impl.rs
@@ -18,6 +18,13 @@ impl<T> Benchable<1, T> for OnceBiVec<T> {
     fn get(&self, coords: [i32; 1]) -> Option<&T> {
         self.get(coords[0])
     }
+
+    fn iter<'a>(&'a self) -> impl Iterator<Item = ([i32; 1], &'a T)>
+    where
+        T: 'a,
+    {
+        self.iter().enumerate().map(|(i, v)| ([i as i32], v))
+    }
 }
 
 impl<T> Benchable<2, T> for OnceBiVec<OnceBiVec<T>> {
@@ -43,6 +50,17 @@ impl<T> Benchable<2, T> for OnceBiVec<OnceBiVec<T>> {
             return None;
         }
         layer1.get(coords[1])
+    }
+
+    fn iter<'a>(&'a self) -> impl Iterator<Item = ([i32; 2], &'a T)>
+    where
+        T: 'a,
+    {
+        self.iter().enumerate().flat_map(|(i, v)| {
+            v.iter()
+                .enumerate()
+                .map(move |(j, w)| ([i as i32, j as i32], w))
+        })
     }
 }
 
@@ -74,6 +92,19 @@ impl<T> Benchable<3, T> for OnceBiVec<OnceBiVec<OnceBiVec<T>>> {
             return None;
         }
         layer2.get(coords[2])
+    }
+
+    fn iter<'a>(&'a self) -> impl Iterator<Item = ([i32; 3], &'a T)>
+    where
+        T: 'a,
+    {
+        self.iter().enumerate().flat_map(|(i, v)| {
+            v.iter().enumerate().flat_map(move |(j, w)| {
+                w.iter()
+                    .enumerate()
+                    .map(move |(k, z)| ([i as i32, j as i32, k as i32], z))
+            })
+        })
     }
 }
 
@@ -110,6 +141,21 @@ impl<T> Benchable<4, T> for OnceBiVec<OnceBiVec<OnceBiVec<OnceBiVec<T>>>> {
             return None;
         }
         layer3.get(coords[3])
+    }
+
+    fn iter<'a>(&'a self) -> impl Iterator<Item = ([i32; 4], &'a T)>
+    where
+        T: 'a,
+    {
+        self.iter().enumerate().flat_map(|(i, v)| {
+            v.iter().enumerate().flat_map(move |(j, w)| {
+                w.iter().enumerate().flat_map(move |(k, z)| {
+                    z.iter()
+                        .enumerate()
+                        .map(move |(l, x)| ([i as i32, j as i32, k as i32, l as i32], x))
+                })
+            })
+        })
     }
 }
 
@@ -151,5 +197,22 @@ impl<T> Benchable<5, T> for OnceBiVec<OnceBiVec<OnceBiVec<OnceBiVec<OnceBiVec<T>
             return None;
         }
         layer4.get(coords[4])
+    }
+
+    fn iter<'a>(&'a self) -> impl Iterator<Item = ([i32; 5], &'a T)>
+    where
+        T: 'a,
+    {
+        self.iter().enumerate().flat_map(|(i, v)| {
+            v.iter().enumerate().flat_map(move |(j, w)| {
+                w.iter().enumerate().flat_map(move |(k, z)| {
+                    z.iter().enumerate().flat_map(move |(l, x)| {
+                        x.iter().enumerate().map(move |(m, y)| {
+                            ([i as i32, j as i32, k as i32, l as i32, m as i32], y)
+                        })
+                    })
+                })
+            })
+        })
     }
 }

--- a/ext/crates/once/benches/criterion/main.rs
+++ b/ext/crates/once/benches/criterion/main.rs
@@ -13,10 +13,12 @@ criterion_group! {
 criterion_main!(benches);
 
 fn run_benchmarks(c: &mut Criterion) {
-    run_insert_benchmarks(c, &|i| i as i32);
-    run_insert_benchmarks(c, &|i| [i; 1000]);
-    run_lookup_benchmarks(c, &|i| i as i32);
-    run_lookup_benchmarks(c, &|i| [i; 1000]);
+    // run_insert_benchmarks(c, &|i| i as i32);
+    // run_insert_benchmarks(c, &|i| [i; 1000]);
+    // run_lookup_benchmarks(c, &|i| i as i32);
+    // run_lookup_benchmarks(c, &|i| [i; 1000]);
+    run_iter_benchmarks(c, &|i| i as i32);
+    run_iter_benchmarks(c, &|i| [i; 1000]);
 }
 
 /// A trait that matches OnceBiVec's semantics for benchmarking
@@ -32,6 +34,11 @@ trait Benchable<const K: usize, T> {
 
     /// Get a value at the given coordinates if it exists and is within bounds
     fn get(&self, coords: [i32; K]) -> Option<&T>;
+
+    /// Iterate over all items in the container
+    fn iter<'a>(&'a self) -> impl Iterator<Item = ([i32; K], &T)>
+    where
+        T: 'a;
 }
 
 impl<T, const K: usize> Benchable<K, T> for MultiIndexed<K, T> {
@@ -50,6 +57,13 @@ impl<T, const K: usize> Benchable<K, T> for MultiIndexed<K, T> {
     fn get(&self, coords: [i32; K]) -> Option<&T> {
         self.get(coords)
     }
+
+    fn iter<'a>(&'a self) -> impl Iterator<Item = ([i32; K], &'a T)>
+    where
+        T: 'a,
+    {
+        self.iter()
+    }
 }
 
 impl<T> Benchable<1, T> for TwoEndedGrove<T> {
@@ -67,6 +81,13 @@ impl<T> Benchable<1, T> for TwoEndedGrove<T> {
 
     fn get(&self, coords: [i32; 1]) -> Option<&T> {
         self.get(coords[0])
+    }
+
+    fn iter<'a>(&'a self) -> impl Iterator<Item = ([i32; 1], &'a T)>
+    where
+        T: 'a,
+    {
+        self.enumerate().map(|(k, v)| ([k], v))
     }
 }
 
@@ -259,6 +280,76 @@ fn bench_lookup_k<const K: usize, T, B: Benchable<K, T>>(
             b.iter(|| {
                 for coord in coords.iter() {
                     black_box(vec.get(*coord));
+                }
+            })
+        },
+    );
+}
+
+// Iteration benchmarks
+
+fn run_iter_benchmarks<T>(c: &mut Criterion, make_value: &dyn Fn(usize) -> T) {
+    // Dim 1
+    let mut g = c.benchmark_group(format!("iter_dim1_{}", std::any::type_name::<T>()));
+    bench_iter_k::<1, _, OnceBiVec<_>>(&mut g, [0], make_value);
+    bench_iter_k::<1, _, TwoEndedGrove<_>>(&mut g, [0], make_value);
+    bench_iter_k::<1, _, MultiIndexed<1, _>>(&mut g, [0], make_value);
+    g.finish();
+
+    run_iter_benchmark::<2, _, OnceBiVec<OnceBiVec<_>>, MultiIndexed<2, _>>(c, [0, 0], make_value);
+    run_iter_benchmark::<3, _, OnceBiVec<OnceBiVec<OnceBiVec<_>>>, MultiIndexed<3, _>>(
+        c,
+        [0, 0, 0],
+        make_value,
+    );
+    run_iter_benchmark::<4, _, OnceBiVec<OnceBiVec<OnceBiVec<OnceBiVec<_>>>>, MultiIndexed<4, _>>(
+        c,
+        [0, 0, 0, 0],
+        make_value,
+    );
+    run_iter_benchmark::<
+        5,
+        _,
+        OnceBiVec<OnceBiVec<OnceBiVec<OnceBiVec<OnceBiVec<_>>>>>,
+        MultiIndexed<5, _>,
+    >(c, [0, 0, 0, 0, 0], make_value);
+
+    let mut g = c.benchmark_group(format!("iter_dim6_{}", std::any::type_name::<T>()));
+    bench_iter_k::<6, _, MultiIndexed<6, _>>(&mut g, [0, 0, 0, 0, 0, 0], make_value);
+    g.finish();
+}
+
+fn run_iter_benchmark<const K: usize, T, B1: Benchable<K, T>, B2: Benchable<K, T>>(
+    c: &mut Criterion,
+    min: [i32; K],
+    make_value: &dyn Fn(usize) -> T,
+) {
+    let mut g = c.benchmark_group(format!("iter_dim{K}_{}", std::any::type_name::<T>()));
+    bench_iter_k::<K, _, B1>(&mut g, min, make_value);
+    bench_iter_k::<K, _, B2>(&mut g, min, make_value);
+    g.finish();
+}
+
+// Benchmark iters for different dimensions
+fn bench_iter_k<const K: usize, T, B: Benchable<K, T>>(
+    c: &mut BenchmarkGroup<'_, WallTime>,
+    min: [i32; K],
+    make_value: &dyn Fn(usize) -> T,
+) {
+    let vec = B::new(min);
+    let coords = get_n_coords(NUM_ELEMENTS, min);
+
+    // Insert data
+    for (i, coord) in coords.iter().enumerate() {
+        vec.push_checked(*coord, make_value(i));
+    }
+
+    c.bench_function(
+        format!("{}_iter_k{}_{}", B::name(), K, std::any::type_name::<T>()),
+        |b| {
+            b.iter(|| {
+                for x in vec.iter() {
+                    black_box(x);
                 }
             })
         },

--- a/ext/crates/once/benches/criterion/main.rs
+++ b/ext/crates/once/benches/criterion/main.rs
@@ -1,7 +1,7 @@
 use criterion::{
     black_box, criterion_group, criterion_main, measurement::WallTime, BenchmarkGroup, Criterion,
 };
-use once::{MultiIndexed, OnceBiVec, TwoEndedGrove};
+use once::{multiindexed::kdtrie::KdTrie, MultiIndexed, OnceBiVec, TwoEndedGrove};
 use pprof::criterion::{Output, PProfProfiler};
 use rand::{rng, seq::SliceRandom};
 
@@ -13,10 +13,10 @@ criterion_group! {
 criterion_main!(benches);
 
 fn run_benchmarks(c: &mut Criterion) {
-    // run_insert_benchmarks(c, &|i| i as i32);
-    // run_insert_benchmarks(c, &|i| [i; 1000]);
-    // run_lookup_benchmarks(c, &|i| i as i32);
-    // run_lookup_benchmarks(c, &|i| [i; 1000]);
+    run_insert_benchmarks(c, &|i| i as i32);
+    run_insert_benchmarks(c, &|i| [i; 1000]);
+    run_lookup_benchmarks(c, &|i| i as i32);
+    run_lookup_benchmarks(c, &|i| [i; 1000]);
     run_iter_benchmarks(c, &|i| i as i32);
     run_iter_benchmarks(c, &|i| [i; 1000]);
 }
@@ -36,7 +36,7 @@ trait Benchable<const K: usize, T> {
     fn get(&self, coords: [i32; K]) -> Option<&T>;
 
     /// Iterate over all items in the container
-    fn iter<'a>(&'a self) -> impl Iterator<Item = ([i32; K], &T)>
+    fn iter<'a>(&'a self) -> impl Iterator<Item = ([i32; K], &'a T)>
     where
         T: 'a;
 }
@@ -88,6 +88,32 @@ impl<T> Benchable<1, T> for TwoEndedGrove<T> {
         T: 'a,
     {
         self.enumerate().map(|(k, v)| ([k], v))
+    }
+}
+
+impl<const K: usize, T> Benchable<K, T> for KdTrie<T> {
+    fn name() -> &'static str {
+        "kd_trie"
+    }
+
+    fn new(_min: [i32; K]) -> Self {
+        Self::new(K)
+    }
+
+    fn push_checked(&self, coords: [i32; K], value: T) {
+        self.insert(&coords, value);
+    }
+
+    fn get(&self, coords: [i32; K]) -> Option<&T> {
+        self.get(&coords)
+    }
+
+    fn iter<'a>(&'a self) -> impl Iterator<Item = ([i32; K], &'a T)>
+    where
+        T: 'a,
+    {
+        self.iter()
+            .map(|(coords, value)| (coords.try_into().unwrap(), value))
     }
 }
 
@@ -146,36 +172,47 @@ fn run_insert_benchmarks<T>(c: &mut Criterion, make_value: &dyn Fn(usize) -> T) 
     bench_insert_k::<1, _, OnceBiVec<_>>(&mut g, [0], make_value);
     bench_insert_k::<1, _, TwoEndedGrove<_>>(&mut g, [0], make_value);
     bench_insert_k::<1, _, MultiIndexed<1, _>>(&mut g, [0], make_value);
+    bench_insert_k::<1, _, KdTrie<_>>(&mut g, [0], make_value);
     g.finish();
 
-    run_insert_benchmark::<2, _, OnceBiVec<OnceBiVec<_>>, MultiIndexed<2, _>>(
+    run_insert_benchmark::<2, _, OnceBiVec<OnceBiVec<_>>, MultiIndexed<2, _>, KdTrie<_>>(
         c,
         [0, 0],
         make_value,
     );
-    run_insert_benchmark::<3, _, OnceBiVec<OnceBiVec<OnceBiVec<_>>>, MultiIndexed<3, _>>(
+    run_insert_benchmark::<3, _, OnceBiVec<OnceBiVec<OnceBiVec<_>>>, MultiIndexed<3, _>, KdTrie<_>>(
         c,
         [0, 0, 0],
         make_value,
     );
-    run_insert_benchmark::<4, _, OnceBiVec<OnceBiVec<OnceBiVec<OnceBiVec<_>>>>, MultiIndexed<4, _>>(
-        c,
-        [0, 0, 0, 0],
-        make_value,
-    );
+    run_insert_benchmark::<
+        4,
+        _,
+        OnceBiVec<OnceBiVec<OnceBiVec<OnceBiVec<_>>>>,
+        MultiIndexed<4, _>,
+        KdTrie<_>,
+    >(c, [0, 0, 0, 0], make_value);
     run_insert_benchmark::<
         5,
         _,
         OnceBiVec<OnceBiVec<OnceBiVec<OnceBiVec<OnceBiVec<_>>>>>,
         MultiIndexed<5, _>,
+        KdTrie<_>,
     >(c, [0, 0, 0, 0, 0], make_value);
 
     let mut g = c.benchmark_group(format!("insert_dim6_{}", std::any::type_name::<T>()));
     bench_insert_k::<6, _, MultiIndexed<6, _>>(&mut g, [0, 0, 0, 0, 0, 0], make_value);
+    bench_insert_k::<6, _, KdTrie<_>>(&mut g, [0, 0, 0, 0, 0, 0], make_value);
     g.finish();
 }
 
-fn run_insert_benchmark<const K: usize, T, B1: Benchable<K, T>, B2: Benchable<K, T>>(
+fn run_insert_benchmark<
+    const K: usize,
+    T,
+    B1: Benchable<K, T>,
+    B2: Benchable<K, T>,
+    B3: Benchable<K, T>,
+>(
     c: &mut Criterion,
     min: [i32; K],
     make_value: &dyn Fn(usize) -> T,
@@ -183,6 +220,7 @@ fn run_insert_benchmark<const K: usize, T, B1: Benchable<K, T>, B2: Benchable<K,
     let mut g = c.benchmark_group(format!("insert_dim{K}_{}", std::any::type_name::<T>()));
     bench_insert_k::<K, _, B1>(&mut g, min, make_value);
     bench_insert_k::<K, _, B2>(&mut g, min, make_value);
+    bench_insert_k::<K, _, B3>(&mut g, min, make_value);
     g.finish();
 }
 
@@ -218,36 +256,47 @@ fn run_lookup_benchmarks<T>(c: &mut Criterion, make_value: &dyn Fn(usize) -> T) 
     bench_lookup_k::<1, _, OnceBiVec<_>>(&mut g, [0], make_value);
     bench_lookup_k::<1, _, TwoEndedGrove<_>>(&mut g, [0], make_value);
     bench_lookup_k::<1, _, MultiIndexed<1, _>>(&mut g, [0], make_value);
+    bench_lookup_k::<1, _, KdTrie<_>>(&mut g, [0], make_value);
     g.finish();
 
-    run_lookup_benchmark::<2, _, OnceBiVec<OnceBiVec<_>>, MultiIndexed<2, _>>(
+    run_lookup_benchmark::<2, _, OnceBiVec<OnceBiVec<_>>, MultiIndexed<2, _>, KdTrie<_>>(
         c,
         [0, 0],
         make_value,
     );
-    run_lookup_benchmark::<3, _, OnceBiVec<OnceBiVec<OnceBiVec<_>>>, MultiIndexed<3, _>>(
+    run_lookup_benchmark::<3, _, OnceBiVec<OnceBiVec<OnceBiVec<_>>>, MultiIndexed<3, _>, KdTrie<_>>(
         c,
         [0, 0, 0],
         make_value,
     );
-    run_lookup_benchmark::<4, _, OnceBiVec<OnceBiVec<OnceBiVec<OnceBiVec<_>>>>, MultiIndexed<4, _>>(
-        c,
-        [0, 0, 0, 0],
-        make_value,
-    );
+    run_lookup_benchmark::<
+        4,
+        _,
+        OnceBiVec<OnceBiVec<OnceBiVec<OnceBiVec<_>>>>,
+        MultiIndexed<4, _>,
+        KdTrie<_>,
+    >(c, [0, 0, 0, 0], make_value);
     run_lookup_benchmark::<
         5,
         _,
         OnceBiVec<OnceBiVec<OnceBiVec<OnceBiVec<OnceBiVec<_>>>>>,
         MultiIndexed<5, _>,
+        KdTrie<_>,
     >(c, [0, 0, 0, 0, 0], make_value);
 
     let mut g = c.benchmark_group(format!("lookup_dim6_{}", std::any::type_name::<T>()));
     bench_lookup_k::<6, _, MultiIndexed<6, _>>(&mut g, [0, 0, 0, 0, 0, 0], make_value);
+    bench_lookup_k::<6, _, KdTrie<_>>(&mut g, [0, 0, 0, 0, 0, 0], make_value);
     g.finish();
 }
 
-fn run_lookup_benchmark<const K: usize, T, B1: Benchable<K, T>, B2: Benchable<K, T>>(
+fn run_lookup_benchmark<
+    const K: usize,
+    T,
+    B1: Benchable<K, T>,
+    B2: Benchable<K, T>,
+    B3: Benchable<K, T>,
+>(
     c: &mut Criterion,
     min: [i32; K],
     make_value: &dyn Fn(usize) -> T,
@@ -255,6 +304,7 @@ fn run_lookup_benchmark<const K: usize, T, B1: Benchable<K, T>, B2: Benchable<K,
     let mut g = c.benchmark_group(format!("lookup_dim{K}_{}", std::any::type_name::<T>()));
     bench_lookup_k::<K, _, B1>(&mut g, min, make_value);
     bench_lookup_k::<K, _, B2>(&mut g, min, make_value);
+    bench_lookup_k::<K, _, B3>(&mut g, min, make_value);
     g.finish();
 }
 
@@ -294,32 +344,47 @@ fn run_iter_benchmarks<T>(c: &mut Criterion, make_value: &dyn Fn(usize) -> T) {
     bench_iter_k::<1, _, OnceBiVec<_>>(&mut g, [0], make_value);
     bench_iter_k::<1, _, TwoEndedGrove<_>>(&mut g, [0], make_value);
     bench_iter_k::<1, _, MultiIndexed<1, _>>(&mut g, [0], make_value);
+    bench_iter_k::<1, _, KdTrie<_>>(&mut g, [0], make_value);
     g.finish();
 
-    run_iter_benchmark::<2, _, OnceBiVec<OnceBiVec<_>>, MultiIndexed<2, _>>(c, [0, 0], make_value);
-    run_iter_benchmark::<3, _, OnceBiVec<OnceBiVec<OnceBiVec<_>>>, MultiIndexed<3, _>>(
+    run_iter_benchmark::<2, _, OnceBiVec<OnceBiVec<_>>, MultiIndexed<2, _>, KdTrie<_>>(
+        c,
+        [0, 0],
+        make_value,
+    );
+    run_iter_benchmark::<3, _, OnceBiVec<OnceBiVec<OnceBiVec<_>>>, MultiIndexed<3, _>, KdTrie<_>>(
         c,
         [0, 0, 0],
         make_value,
     );
-    run_iter_benchmark::<4, _, OnceBiVec<OnceBiVec<OnceBiVec<OnceBiVec<_>>>>, MultiIndexed<4, _>>(
-        c,
-        [0, 0, 0, 0],
-        make_value,
-    );
+    run_iter_benchmark::<
+        4,
+        _,
+        OnceBiVec<OnceBiVec<OnceBiVec<OnceBiVec<_>>>>,
+        MultiIndexed<4, _>,
+        KdTrie<_>,
+    >(c, [0, 0, 0, 0], make_value);
     run_iter_benchmark::<
         5,
         _,
         OnceBiVec<OnceBiVec<OnceBiVec<OnceBiVec<OnceBiVec<_>>>>>,
         MultiIndexed<5, _>,
+        KdTrie<_>,
     >(c, [0, 0, 0, 0, 0], make_value);
 
     let mut g = c.benchmark_group(format!("iter_dim6_{}", std::any::type_name::<T>()));
     bench_iter_k::<6, _, MultiIndexed<6, _>>(&mut g, [0, 0, 0, 0, 0, 0], make_value);
+    bench_iter_k::<6, _, KdTrie<_>>(&mut g, [0, 0, 0, 0, 0, 0], make_value);
     g.finish();
 }
 
-fn run_iter_benchmark<const K: usize, T, B1: Benchable<K, T>, B2: Benchable<K, T>>(
+fn run_iter_benchmark<
+    const K: usize,
+    T,
+    B1: Benchable<K, T>,
+    B2: Benchable<K, T>,
+    B3: Benchable<K, T>,
+>(
     c: &mut Criterion,
     min: [i32; K],
     make_value: &dyn Fn(usize) -> T,
@@ -327,6 +392,7 @@ fn run_iter_benchmark<const K: usize, T, B1: Benchable<K, T>, B2: Benchable<K, T
     let mut g = c.benchmark_group(format!("iter_dim{K}_{}", std::any::type_name::<T>()));
     bench_iter_k::<K, _, B1>(&mut g, min, make_value);
     bench_iter_k::<K, _, B2>(&mut g, min, make_value);
+    bench_iter_k::<K, _, B3>(&mut g, min, make_value);
     g.finish();
 }
 

--- a/ext/crates/once/src/grove/mod.rs
+++ b/ext/crates/once/src/grove/mod.rs
@@ -375,6 +375,43 @@ impl<T> Default for Grove<T> {
     }
 }
 
+impl<T: std::fmt::Debug> std::fmt::Debug for Grove<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut debug_map = f.debug_map();
+        for (i, val) in self.enumerate() {
+            debug_map.entry(&i, val);
+        }
+        debug_map.finish()
+    }
+}
+
+impl<T: Clone> Clone for Grove<T> {
+    fn clone(&self) -> Self {
+        let new_grove = Self::new();
+        for (i, value) in self.enumerate() {
+            new_grove.insert(i, value.clone());
+        }
+        new_grove
+    }
+}
+
+impl<T: PartialEq> PartialEq for Grove<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.enumerate().eq(other.enumerate())
+    }
+}
+
+impl<T: Eq> Eq for Grove<T> {}
+
+impl<T: std::hash::Hash> std::hash::Hash for Grove<T> {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        for (i, value) in self.enumerate() {
+            i.hash(state);
+            value.hash(state);
+        }
+    }
+}
+
 /// A bidirectional sparse vector that supports both positive and negative indices.
 ///
 /// `TwoEndedGrove` extends the functionality of [`Grove`] by allowing elements to be indexed using
@@ -693,6 +730,43 @@ impl<T> Default for TwoEndedGrove<T> {
     }
 }
 
+impl<T: std::fmt::Debug> std::fmt::Debug for TwoEndedGrove<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut debug_map = f.debug_map();
+        for (i, val) in self.enumerate() {
+            debug_map.entry(&i, val);
+        }
+        debug_map.finish()
+    }
+}
+
+impl<T: Clone> Clone for TwoEndedGrove<T> {
+    fn clone(&self) -> Self {
+        let new_grove = Self::new();
+        for (i, value) in self.enumerate() {
+            new_grove.insert(i, value.clone());
+        }
+        new_grove
+    }
+}
+
+impl<T: PartialEq> PartialEq for TwoEndedGrove<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.enumerate().eq(other.enumerate())
+    }
+}
+
+impl<T: Eq> Eq for TwoEndedGrove<T> {}
+
+impl<T: std::hash::Hash> std::hash::Hash for TwoEndedGrove<T> {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        for (i, value) in self.enumerate() {
+            i.hash(state);
+            value.hash(state);
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::{
@@ -732,6 +806,36 @@ mod tests {
         assert!(v.get(42).is_none());
         v.insert(42, 42);
         assert_eq!(v.get(42), Some(&42));
+    }
+
+    #[test]
+    fn test_grove_debug() {
+        let v = Grove::<i32>::new();
+        v.insert(0, 1);
+        v.insert(100, 2);
+        v.insert(1000, 3);
+
+        expect_test::expect![[r#"
+            {
+                0: 1,
+                100: 2,
+                1000: 3,
+            }
+        "#]]
+        .assert_debug_eq(&v);
+    }
+
+    #[test]
+    fn test_grove_clone() {
+        let v = Grove::<i32>::new();
+        v.insert(0, 1);
+        v.insert(100, 2);
+        v.insert(1000, 3);
+
+        let v2 = v.clone();
+
+        assert_ne!(&raw const v, &raw const v2);
+        assert_eq!(v, v2);
     }
 
     #[test]

--- a/ext/crates/once/src/multiindexed/iter.rs
+++ b/ext/crates/once/src/multiindexed/iter.rs
@@ -1,0 +1,70 @@
+use super::{kdtrie::KdTrie, node::Node};
+
+pub struct KdTrieIterator<'a, V> {
+    trie: &'a KdTrie<V>,
+    stack: Vec<(Vec<i32>, &'a Node<V>, std::ops::Range<i32>)>,
+}
+impl<'a, V> KdTrieIterator<'a, V> {
+    pub(crate) fn new(trie: &'a KdTrie<V>) -> Self {
+        let root_range = if trie.dimensions() == 1 {
+            unsafe { trie.root().leaf() }.range()
+        } else {
+            unsafe { trie.root().inner() }.range()
+        };
+        Self {
+            trie,
+            stack: vec![(vec![], trie.root(), root_range)],
+        }
+    }
+}
+
+impl<'a, V> Iterator for KdTrieIterator<'a, V> {
+    type Item = (Vec<i32>, &'a V);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        while let Some((mut current_coords, current_node, mut range)) = self.stack.pop() {
+            // Find the next index in the current range that has a value
+            while let Some(idx) = range.next() {
+                if current_coords.len() == self.trie.dimensions() - 1 {
+                    // This is a leaf node, check if there's a value at this index
+                    let current_leaf = unsafe { current_node.leaf() };
+                    if let Some(value) = current_leaf.get(idx) {
+                        // Push back the remaining range for this node
+                        if !range.is_empty() {
+                            self.stack
+                                .push((current_coords.clone(), current_node, range));
+                        }
+
+                        // Return the value with full coordinates
+                        current_coords.push(idx);
+                        return Some((current_coords, value));
+                    }
+                } else {
+                    // This is an inner node, check if there's a child at this index
+                    let current_inner = unsafe { current_node.inner() };
+                    if let Some(child_node) = current_inner.get(idx) {
+                        // Push back the remaining range for this node
+                        if !range.is_empty() {
+                            self.stack
+                                .push((current_coords.clone(), current_node, range));
+                        }
+
+                        // Add the current index to coordinates and push the child
+                        current_coords.push(idx);
+                        let child_range = if current_coords.len() == self.trie.dimensions() - 1 {
+                            unsafe { child_node.leaf() }.range()
+                        } else {
+                            unsafe { child_node.inner() }.range()
+                        };
+                        self.stack.push((current_coords, child_node, child_range));
+
+                        // Go to the next iteration of the outer loop, which will process the child
+                        break;
+                    }
+                }
+            }
+        }
+
+        None
+    }
+}

--- a/ext/crates/once/src/multiindexed/iter.rs
+++ b/ext/crates/once/src/multiindexed/iter.rs
@@ -1,43 +1,95 @@
-use super::{kdtrie::KdTrie, node::Node};
+use std::ops::Range;
 
-pub struct KdTrieIterator<'a, V> {
-    trie: &'a KdTrie<V>,
-    stack: Vec<(Vec<i32>, &'a Node<V>, std::ops::Range<i32>)>,
+use super::node::Node;
+
+/// A single frame in the iteration stack, representing the current state of traversal.
+struct IterFrame<'a, V> {
+    /// The current depth in the multi-indexed structure
+    /// (0 for the root, 1 for the first level, etc.)
+    depth: usize,
+
+    /// The current node being processed
+    current_node: &'a Node<V>,
+
+    /// The range of indices left to iterate over in the current node
+    range: Range<i32>,
 }
-impl<'a, V> KdTrieIterator<'a, V> {
-    pub(crate) fn new(trie: &'a KdTrie<V>) -> Self {
-        let root_range = if trie.dimensions() == 1 {
-            unsafe { trie.root().leaf() }.range()
+
+impl<'a, V> IterFrame<'a, V> {
+    /// Creates the initial iteration frame.
+    fn new(dimensions: usize, root: &'a Node<V>) -> Self {
+        let root_range = if dimensions == 1 {
+            unsafe { root.leaf() }.range()
         } else {
-            unsafe { trie.root().inner() }.range()
+            unsafe { root.inner() }.range()
         };
+
         Self {
-            trie,
-            stack: vec![(vec![], trie.root(), root_range)],
+            depth: 0,
+            current_node: root,
+            range: root_range,
         }
     }
 }
 
-impl<'a, V> Iterator for KdTrieIterator<'a, V> {
-    type Item = (Vec<i32>, &'a V);
+/// Trait for managing coordinates during iteration
+pub(super) trait Coordinates {
+    fn set_coord(&mut self, depth: usize, value: i32);
+    fn truncate_to(&mut self, depth: usize);
+    fn get(&self) -> Self;
+}
+
+/// Iterator implementation for multi-dimensional structures
+///
+/// This abstracts over both dynamic and fixed-size coordinates, which allows us to iterate over
+/// `KdTrie`s with vector coordinates and `MultiIndexed`s with fixed-size arrays. It's important to
+/// allow fixed-size arrays to be used as coordinates, as they are `Copy` and can avoid the
+/// expensive `clone`s. Empirically, this gives a 3x speedup.
+pub(super) struct KdIterator<'a, V, C> {
+    dimensions: usize,
+    stack: Vec<IterFrame<'a, V>>,
+    coordinates: C,
+}
+
+impl<'a, V, C: Coordinates> KdIterator<'a, V, C> {
+    pub(super) fn new(dimensions: usize, root: &'a Node<V>, coordinates: C) -> Self {
+        Self {
+            dimensions,
+            stack: vec![IterFrame::new(dimensions, root)],
+            coordinates,
+        }
+    }
+}
+
+impl<'a, V, C: Coordinates> Iterator for KdIterator<'a, V, C> {
+    type Item = (C, &'a V);
 
     fn next(&mut self) -> Option<Self::Item> {
-        while let Some((mut current_coords, current_node, mut range)) = self.stack.pop() {
+        while let Some(IterFrame {
+            depth,
+            current_node,
+            mut range,
+        }) = self.stack.pop()
+        {
+            self.coordinates.truncate_to(depth);
+
             // Find the next index in the current range that has a value
             while let Some(idx) = range.next() {
-                if current_coords.len() == self.trie.dimensions() - 1 {
+                if depth == self.dimensions - 1 {
                     // This is a leaf node, check if there's a value at this index
                     let current_leaf = unsafe { current_node.leaf() };
                     if let Some(value) = current_leaf.get(idx) {
                         // Push back the remaining range for this node
                         if !range.is_empty() {
-                            self.stack
-                                .push((current_coords.clone(), current_node, range));
+                            self.stack.push(IterFrame {
+                                depth,
+                                current_node,
+                                range,
+                            });
                         }
 
-                        // Return the value with full coordinates
-                        current_coords.push(idx);
-                        return Some((current_coords, value));
+                        self.coordinates.set_coord(depth, idx);
+                        return Some((self.coordinates.get(), value));
                     }
                 } else {
                     // This is an inner node, check if there's a child at this index
@@ -45,18 +97,25 @@ impl<'a, V> Iterator for KdTrieIterator<'a, V> {
                     if let Some(child_node) = current_inner.get(idx) {
                         // Push back the remaining range for this node
                         if !range.is_empty() {
-                            self.stack
-                                .push((current_coords.clone(), current_node, range));
+                            self.stack.push(IterFrame {
+                                depth,
+                                current_node,
+                                range,
+                            });
                         }
 
                         // Add the current index to coordinates and push the child
-                        current_coords.push(idx);
-                        let child_range = if current_coords.len() == self.trie.dimensions() - 1 {
+                        self.coordinates.set_coord(depth, idx);
+                        let child_range = if depth + 1 == self.dimensions - 1 {
                             unsafe { child_node.leaf() }.range()
                         } else {
                             unsafe { child_node.inner() }.range()
                         };
-                        self.stack.push((current_coords, child_node, child_range));
+                        self.stack.push(IterFrame {
+                            depth: depth + 1,
+                            current_node: child_node,
+                            range: child_range,
+                        });
 
                         // Go to the next iteration of the outer loop, which will process the child
                         break;
@@ -66,5 +125,34 @@ impl<'a, V> Iterator for KdTrieIterator<'a, V> {
         }
 
         None
+    }
+}
+
+impl<const K: usize> Coordinates for [i32; K] {
+    fn set_coord(&mut self, depth: usize, value: i32) {
+        self[depth] = value;
+    }
+
+    fn truncate_to(&mut self, _depth: usize) {
+        // Array doesn't need truncation
+    }
+
+    fn get(&self) -> Self {
+        *self
+    }
+}
+
+impl Coordinates for Vec<i32> {
+    fn set_coord(&mut self, depth: usize, value: i32) {
+        assert_eq!(self.len(), depth);
+        self.push(value);
+    }
+
+    fn truncate_to(&mut self, depth: usize) {
+        self.truncate(depth);
+    }
+
+    fn get(&self) -> Self {
+        self.clone()
     }
 }

--- a/ext/crates/once/src/multiindexed/kdtrie.rs
+++ b/ext/crates/once/src/multiindexed/kdtrie.rs
@@ -161,8 +161,12 @@ impl<V> KdTrie<V> {
         self.dimensions
     }
 
-    pub fn iter(&self) -> KdTrieIterator<'_, V> {
-        KdTrieIterator::new(self)
+    pub fn iter(&self) -> impl Iterator<Item = (Vec<i32>, &V)> + '_ {
+        KdIterator::new(
+            self.dimensions,
+            &self.root,
+            Vec::with_capacity(self.dimensions),
+        )
     }
 
     pub(super) fn root(&self) -> &Node<V> {

--- a/ext/crates/once/src/multiindexed/kdtrie.rs
+++ b/ext/crates/once/src/multiindexed/kdtrie.rs
@@ -1,4 +1,4 @@
-use super::{iter::KdTrieIterator, node::Node};
+use super::{iter::KdIterator, node::Node};
 
 /// A K-dimensional trie data structure that efficiently stores values indexed by multi-dimensional
 /// coordinates.
@@ -183,5 +183,35 @@ impl<V> Drop for KdTrie<V> {
 impl<V: std::fmt::Debug> std::fmt::Debug for KdTrie<V> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_map().entries(self.iter()).finish()
+    }
+}
+
+impl<V: Clone> Clone for KdTrie<V> {
+    fn clone(&self) -> Self {
+        let new_trie = Self::new(self.dimensions);
+        for (coords, value) in self.iter() {
+            new_trie.insert(&coords, value.clone());
+        }
+        new_trie
+    }
+}
+
+impl<V: PartialEq> PartialEq for KdTrie<V> {
+    fn eq(&self, other: &Self) -> bool {
+        if self.dimensions != other.dimensions {
+            return false;
+        }
+        self.iter().eq(other.iter())
+    }
+}
+
+impl<V: Eq> Eq for KdTrie<V> {}
+
+impl<V: std::hash::Hash> std::hash::Hash for KdTrie<V> {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        for (coords, value) in self.iter() {
+            coords.hash(state);
+            value.hash(state);
+        }
     }
 }

--- a/ext/crates/once/src/multiindexed/kdtrie.rs
+++ b/ext/crates/once/src/multiindexed/kdtrie.rs
@@ -1,4 +1,4 @@
-use super::node::Node;
+use super::{iter::KdTrieIterator, node::Node};
 
 /// A K-dimensional trie data structure that efficiently stores values indexed by multi-dimensional
 /// coordinates.
@@ -156,10 +156,28 @@ impl<V> KdTrie<V> {
 
         unsafe { node.try_set_value(coords[self.dimensions - 1], value) }
     }
+
+    pub fn dimensions(&self) -> usize {
+        self.dimensions
+    }
+
+    pub fn iter(&self) -> KdTrieIterator<'_, V> {
+        KdTrieIterator::new(self)
+    }
+
+    pub(super) fn root(&self) -> &Node<V> {
+        &self.root
+    }
 }
 
 impl<V> Drop for KdTrie<V> {
     fn drop(&mut self) {
         self.root.drop_level(self.dimensions, 0);
+    }
+}
+
+impl<V: std::fmt::Debug> std::fmt::Debug for KdTrie<V> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_map().entries(self.iter()).finish()
     }
 }

--- a/ext/crates/once/src/multiindexed/mod.rs
+++ b/ext/crates/once/src/multiindexed/mod.rs
@@ -1,3 +1,4 @@
+use self::iter::KdIterator;
 pub use self::kdtrie::KdTrie;
 
 mod iter;
@@ -206,8 +207,8 @@ impl<const K: usize, V> MultiIndexed<K, V> {
 
     /// Returns an iterator over all coordinate-value pairs in the array.
     ///
-    /// The iterator yields tuples of `(Vec<i32>, &V)` where the first element
-    /// is the coordinate vector and the second is a reference to the value.
+    /// The iterator yields tuples of `([i32; K], &V)` where the first element is the coordinate
+    /// array and the second is a reference to the value.
     ///
     /// # Examples
     ///
@@ -220,12 +221,10 @@ impl<const K: usize, V> MultiIndexed<K, V> {
     ///
     /// let mut items: Vec<_> = array.iter().collect();
     ///
-    /// assert_eq!(items, vec![(vec![1, 2], &20), (vec![3, 4], &10)]);
+    /// assert_eq!(items, vec![([1, 2], &20), ([3, 4], &10)]);
     /// ```
     pub fn iter(&self) -> impl Iterator<Item = ([i32; K], &V)> {
-        self.0
-            .iter()
-            .map(|(coords, value)| (coords.try_into().unwrap(), value))
+        KdIterator::new(K, self.0.root(), [0; K])
     }
 }
 

--- a/ext/crates/once/src/multiindexed/node.rs
+++ b/ext/crates/once/src/multiindexed/node.rs
@@ -160,6 +160,24 @@ impl<V> Node<V> {
         unsafe { self.leaf.try_insert(idx, value) }
     }
 
+    /// Returns a reference to the inner grove.
+    ///
+    /// # Safety
+    ///
+    /// Can only be called on an inner node.
+    pub(super) unsafe fn inner(&self) -> &TwoEndedGrove<Self> {
+        &self.inner
+    }
+
+    /// Returns a reference to the leaf grove.
+    ///
+    /// # Safety
+    ///
+    /// Can only be called on a leaf node.
+    pub(super) unsafe fn leaf(&self) -> &TwoEndedGrove<V> {
+        &self.leaf
+    }
+
     /// Recursively drops the node and all its children.
     ///
     /// This method is called by the `Drop` implementation of `KdTrie` to ensure


### PR DESCRIPTION
It was getting annoying that `MultiIndexed` didn't implement Debug, Clone, PartialEq, Eq, Hash, since any structs that contain one would not be able to derive them. The main bottleneck was being able to iterate over the entire tree.

I implemented iterators and updated the criterion bench to make sure the performance is close to optimal. I also implemented all the standard traits for `MultiIndexed`, `KdTrie`, `Grove` and `TwoSidedGrove`. I added proptests to check for correctness too.