### PR TITLE
Update dependencies

### DIFF
--- a/ext/Cargo.toml
+++ b/ext/Cargo.toml
@@ -25,23 +25,23 @@ sseq = { path = "crates/sseq", default-features = false }
 adler = "1"
 anyhow = "1.0.98"
 byteorder = "1.5.0"
-dashmap = "4.0.2"
-itertools = { version = "0.10.5", default-features = false, features = [
+dashmap = "6.1.0"
+itertools = { version = "0.14.0", default-features = false, features = [
     "use_alloc",
 ] }
-rustc-hash = "1.1.0"
+rustc-hash = "2.1.1"
 serde_json = { version = "1.0.141", features = ["preserve_order"] }
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 
-zstd = { version = "0.9.2", optional = true }
+zstd = { version = "0.13.3", optional = true }
 
 [target.'cfg(unix)'.dependencies]
 ctrlc = { version = "3", features = ["termination"] }
 
 [dev-dependencies]
 expect-test = "1.5.1"
-rstest = "0.17.0"
+rstest = "0.25.0"
 tempfile = "3.20.0"
 
 [lib]

--- a/ext/Cargo.toml
+++ b/ext/Cargo.toml
@@ -23,26 +23,26 @@ query = { path = "crates/query" }
 sseq = { path = "crates/sseq", default-features = false }
 
 adler = "1"
-anyhow = "1.0.0"
-byteorder = "1.4.3"
-dashmap = "4.0.0"
-itertools = { version = "0.10.0", default-features = false, features = [
+anyhow = "1.0.98"
+byteorder = "1.5.0"
+dashmap = "4.0.2"
+itertools = { version = "0.10.5", default-features = false, features = [
     "use_alloc",
 ] }
 rustc-hash = "1.1.0"
-serde_json = { version = "1.0.0", features = ["preserve_order"] }
-tracing = "0.1.40"
-tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
+serde_json = { version = "1.0.141", features = ["preserve_order"] }
+tracing = "0.1.41"
+tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 
-zstd = { version = "0.9.0", optional = true }
+zstd = { version = "0.9.2", optional = true }
 
 [target.'cfg(unix)'.dependencies]
 ctrlc = { version = "3", features = ["termination"] }
 
 [dev-dependencies]
-expect-test = "1.1.0"
+expect-test = "1.5.1"
 rstest = "0.17.0"
-tempfile = "3.0.0"
+tempfile = "3.20.0"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/ext/crates/algebra/Cargo.toml
+++ b/ext/crates/algebra/Cargo.toml
@@ -18,19 +18,19 @@ once = { path = "../once" }
 
 anyhow = "1.0.98"
 auto_impl = "1.3.0"
-hashbrown = "0.14.5"
-itertools = { version = "0.10.5", default-features = false, features = [
+hashbrown = "0.15.4"
+itertools = { version = "0.14.0", default-features = false, features = [
     "use_alloc",
 ] }
-nom = { version = "7.1.3", default-features = false, features = ["alloc"] }
-rustc-hash = "1.1.0"
+nom = { version = "8.0.0", default-features = false, features = ["alloc"] }
+rustc-hash = "2.1.1"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.141"
 
 [dev-dependencies]
 bencher = "0.1.5"
 expect-test = "1.5.1"
-rstest = "0.17.0"
+rstest = "0.25.0"
 
 [features]
 default = ["odd-primes"]

--- a/ext/crates/algebra/Cargo.toml
+++ b/ext/crates/algebra/Cargo.toml
@@ -16,20 +16,20 @@ fp = { path = "../fp", default-features = false }
 maybe-rayon = { path = "../maybe-rayon" }
 once = { path = "../once" }
 
-anyhow = "1.0.0"
-auto_impl = "1.0.0"
-hashbrown = "0.14.0"
-itertools = { version = "0.10.0", default-features = false, features = [
+anyhow = "1.0.98"
+auto_impl = "1.3.0"
+hashbrown = "0.14.5"
+itertools = { version = "0.10.5", default-features = false, features = [
     "use_alloc",
 ] }
-nom = { version = "7.0.0", default-features = false, features = ["alloc"] }
+nom = { version = "7.1.3", default-features = false, features = ["alloc"] }
 rustc-hash = "1.1.0"
-serde = { version = "1.0.0", features = ["derive"] }
-serde_json = "1.0.0"
+serde = { version = "1.0.219", features = ["derive"] }
+serde_json = "1.0.141"
 
 [dev-dependencies]
 bencher = "0.1.5"
-expect-test = "1.1.0"
+expect-test = "1.5.1"
 rstest = "0.17.0"
 
 [features]

--- a/ext/crates/algebra/src/algebra/adem_algebra.rs
+++ b/ext/crates/algebra/src/algebra/adem_algebra.rs
@@ -290,7 +290,7 @@ impl Algebra for AdemAlgebra {
     }
 
     fn basis_element_from_string(&self, mut elt: &str) -> Option<(i32, usize)> {
-        use nom::sequence::preceded;
+        use nom::{sequence::preceded, Parser};
 
         use crate::steenrod_parser::{digits, p_or_sq};
 
@@ -310,7 +310,7 @@ impl Algebra for AdemAlgebra {
             if elt.is_empty() {
                 break;
             }
-            let (rem, sqn) = preceded(p_or_sq, digits)(elt).ok()?;
+            let (rem, sqn) = preceded(p_or_sq, digits).parse(elt).ok()?;
             elt = rem;
 
             ps.push(sqn);

--- a/ext/crates/algebra/src/module/finitely_presented_module.rs
+++ b/ext/crates/algebra/src/module/finitely_presented_module.rs
@@ -102,7 +102,7 @@ impl<A: Algebra> FinitelyPresentedModule<A> {
 impl<A: Algebra> FinitelyPresentedModule<A> {
     pub fn from_json(algebra: Arc<A>, json: &Value) -> anyhow::Result<Self> {
         use anyhow::anyhow;
-        use nom::combinator::opt;
+        use nom::{combinator::opt, Parser};
 
         use crate::steenrod_parser::digits;
 
@@ -127,7 +127,7 @@ impl<A: Algebra> FinitelyPresentedModule<A> {
                 let mut v = FpVector::new(p, 0);
 
                 for term in reln.as_str().unwrap().split(" + ") {
-                    let (term, coef) = opt(digits)(term).unwrap();
+                    let (term, coef) = opt(digits).parse(term).unwrap();
                     let coef: u32 = coef.unwrap_or(1);
 
                     let (op, gen) = term.rsplit_once(' ').unwrap_or(("1", term));
@@ -160,7 +160,7 @@ impl<A: Algebra> FinitelyPresentedModule<A> {
             .collect::<anyhow::Result<Vec<_>>>()?;
 
         relations.sort_unstable_by_key(|x| x.0);
-        for (degree, rels) in &relations.into_iter().group_by(|x| x.0) {
+        for (degree, rels) in &relations.into_iter().chunk_by(|x| x.0) {
             for deg in result.relations.max_computed_degree() + 1..degree {
                 result.add_relations(deg, vec![]);
             }

--- a/ext/crates/bivec/Cargo.toml
+++ b/ext/crates/bivec/Cargo.toml
@@ -8,6 +8,6 @@ authors = [
 edition = "2021"
 
 [dependencies]
-serde = "1.0.0"
+serde = "1.0.219"
 
 [features]

--- a/ext/crates/chart/Cargo.toml
+++ b/ext/crates/chart/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dev-dependencies]
-expect-test = "1.1.0"
+expect-test = "1.5.1"

--- a/ext/crates/fp/Cargo.toml
+++ b/ext/crates/fp/Cargo.toml
@@ -7,14 +7,14 @@ edition = "2021"
 
 [dependencies]
 build_const = "0.2.2"
-byteorder = "1.4.3"
-cfg-if = "1.0.0"
+byteorder = "1.5.0"
+cfg-if = "1.0.1"
 dashmap = "5"
 itertools = { version = "0.13.0" }
 paste = "1.0.15"
-proptest = { version = "1.2", optional = true }
-serde = "1.0.0"
-serde_json = "1.0.0"
+proptest = { version = "1.7", optional = true }
+serde = "1.0.219"
+serde_json = "1.0.141"
 
 maybe-rayon = { path = "../maybe-rayon" }
 
@@ -22,10 +22,10 @@ maybe-rayon = { path = "../maybe-rayon" }
 # We use the proptest harness for our own tests
 fp = { path = ".", default-features = false, features = ["proptest"] }
 criterion = { version = "0.5", features = ["html_reports"] }
-expect-test = "1.1.0"
+expect-test = "1.5.1"
 pprof = { version = "0.13.0", features = ["criterion", "flamegraph"] }
-proptest = "1.2"
-rand = "0.8.4"
+proptest = "1.7"
+rand = "0.8.5"
 rstest = "0.17.0"
 
 [build-dependencies]

--- a/ext/crates/fp/Cargo.toml
+++ b/ext/crates/fp/Cargo.toml
@@ -9,8 +9,8 @@ edition = "2021"
 build_const = "0.2.2"
 byteorder = "1.5.0"
 cfg-if = "1.0.1"
-dashmap = "5"
-itertools = { version = "0.13.0" }
+dashmap = "6"
+itertools = { version = "0.14.0" }
 paste = "1.0.15"
 proptest = { version = "1.7", optional = true }
 serde = "1.0.219"
@@ -23,10 +23,10 @@ maybe-rayon = { path = "../maybe-rayon" }
 fp = { path = ".", default-features = false, features = ["proptest"] }
 criterion = { version = "0.5", features = ["html_reports"] }
 expect-test = "1.5.1"
-pprof = { version = "0.13.0", features = ["criterion", "flamegraph"] }
+pprof = { version = "0.15.0", features = ["criterion", "flamegraph"] }
 proptest = "1.7"
-rand = "0.8.5"
-rstest = "0.17.0"
+rand = "0.9.2"
+rstest = "0.26.0"
 
 [build-dependencies]
 build_const = "0.2.2"

--- a/ext/crates/fp/benches/criterion.rs
+++ b/ext/crates/fp/benches/criterion.rs
@@ -32,8 +32,8 @@ fn row_reductions(c: &mut Criterion) {
 
 fn random_vector(p: ValidPrime, dimension: usize) -> Vec<u32> {
     let mut result = Vec::with_capacity(dimension);
-    let mut rng = rand::thread_rng();
-    result.resize_with(dimension, || rng.gen::<u32>() % p);
+    let mut rng = rand::rng();
+    result.resize_with(dimension, || rng.random::<u32>() % p);
     result
 }
 

--- a/ext/crates/fp/src/vector/fp_wrapper/mod.rs
+++ b/ext/crates/fp/src/vector/fp_wrapper/mod.rs
@@ -286,8 +286,8 @@ mod tests {
     use crate::{prime::ValidPrime, vector::FpVector};
 
     fn random_vector(p: u32, dimension: usize) -> Vec<u32> {
-        let mut rng = rand::thread_rng();
-        (0..dimension).map(|_| rng.gen_range(0..p)).collect()
+        let mut rng = rand::rng();
+        (0..dimension).map(|_| rng.random_range(0..p)).collect()
     }
 
     #[rstest]

--- a/ext/crates/maybe-rayon/Cargo.toml
+++ b/ext/crates/maybe-rayon/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rayon = { version = "1.8.0", optional = true }
+rayon = { version = "1.10.0", optional = true }
 
 [features]
 default = []

--- a/ext/crates/once/Cargo.toml
+++ b/ext/crates/once/Cargo.toml
@@ -15,7 +15,7 @@ maybe-rayon = { path = "../maybe-rayon" }
 
 [dev-dependencies]
 criterion = "0.5"
-pprof = { version = "0.14", features = ["criterion", "flamegraph"] }
+pprof = { version = "0.15", features = ["criterion", "flamegraph"] }
 proptest = "1.7.0"
 rand = "0.9"
 

--- a/ext/crates/once/Cargo.toml
+++ b/ext/crates/once/Cargo.toml
@@ -16,7 +16,7 @@ maybe-rayon = { path = "../maybe-rayon" }
 [dev-dependencies]
 criterion = "0.5"
 pprof = { version = "0.14", features = ["criterion", "flamegraph"] }
-proptest = "1.6.0"
+proptest = "1.7.0"
 rand = "0.9"
 
 [features]

--- a/ext/crates/once/benches/criterion/main.rs
+++ b/ext/crates/once/benches/criterion/main.rs
@@ -1,5 +1,7 @@
+use std::hint::black_box;
+
 use criterion::{
-    black_box, criterion_group, criterion_main, measurement::WallTime, BenchmarkGroup, Criterion,
+    criterion_group, criterion_main, measurement::WallTime, BenchmarkGroup, Criterion,
 };
 use once::{MultiIndexed, OnceBiVec, TwoEndedGrove};
 use pprof::criterion::{Output, PProfProfiler};

--- a/ext/crates/sseq/Cargo.toml
+++ b/ext/crates/sseq/Cargo.toml
@@ -19,7 +19,7 @@ tracing = "0.1.41"
 
 [dev-dependencies]
 expect-test = "1.5.1"
-rand = "0.8"
+rand = "0.9"
 
 [features]
 default = ["odd-primes"]

--- a/ext/crates/sseq/Cargo.toml
+++ b/ext/crates/sseq/Cargo.toml
@@ -13,12 +13,12 @@ fp = { path = "../fp/", default-features = false }
 maybe-rayon = { path = "../maybe-rayon" }
 once = { path = "../once/" }
 
-serde = "1.0.0"
-serde_json = "1.0.0"
-tracing = "0.1.40"
+serde = "1.0.219"
+serde_json = "1.0.141"
+tracing = "0.1.41"
 
 [dev-dependencies]
-expect-test = "1.1.0"
+expect-test = "1.5.1"
 rand = "0.8"
 
 [features]

--- a/flake.nix
+++ b/flake.nix
@@ -36,6 +36,7 @@
         pkgs.hyperfine
         pkgs.binutils
         pkgs.cargo-binutils
+        pkgs.cargo-edit
       ];
     });
   };


### PR DESCRIPTION
I didn't upgrade Criterion to 0.7 because we need the `pprof` crate, which only works with 0.5 for now (see https://github.com/tikv/pprof-rs/issues/274). The dependencies for the webserver are already up to date.