### PR TITLE
Make matrices hold a single allocation of limbs

### DIFF
--- a/ext/crates/algebra/src/module/homomorphism/full_module_homomorphism.rs
+++ b/ext/crates/algebra/src/module/homomorphism/full_module_homomorphism.rs
@@ -69,7 +69,7 @@ impl<S: Module, T: Module<Algebra = S::Algebra>> ModuleHomomorphism
     ) {
         let output_degree = input_degree - self.degree_shift;
         if let Some(matrix) = self.matrices.get(output_degree) {
-            result.add(matrix[input_idx].as_slice(), coeff);
+            result.add(matrix.row(input_idx), coeff);
         }
     }
 
@@ -224,7 +224,7 @@ impl<S: Module> IdentityHomomorphism<S> for FullModuleHomomorphism<S, S> {
             let dim = source.dimension(i);
             let mut matrix = Matrix::new(p, dim, dim);
             for k in 0..dim {
-                matrix[k].set_entry(k, 1);
+                matrix.row_mut(k).set_entry(k, 1);
             }
             matrices.push(matrix);
         }

--- a/ext/crates/algebra/src/module/homomorphism/mod.rs
+++ b/ext/crates/algebra/src/module/homomorphism/mod.rs
@@ -147,9 +147,7 @@ pub trait ModuleHomomorphism: Send + Sync {
         matrix
             .maybe_par_iter_mut()
             .enumerate()
-            .for_each(|(i, row)| {
-                self.apply_to_basis_element(row.as_slice_mut(), 1, degree, inputs[i])
-            });
+            .for_each(|(i, row)| self.apply_to_basis_element(row, 1, degree, inputs[i]));
 
         matrix
     }

--- a/ext/crates/fp/src/limb.rs
+++ b/ext/crates/fp/src/limb.rs
@@ -8,6 +8,44 @@ pub(crate) struct LimbBitIndexPair {
     pub(crate) bit_index: usize,
 }
 
+/// Read an array of `Limb`s.
+pub(crate) fn from_bytes(limbs: &mut [Limb], data: &mut impl std::io::Read) -> std::io::Result<()> {
+    if cfg!(target_endian = "little") {
+        let num_bytes = std::mem::size_of_val(limbs);
+        unsafe {
+            let buf: &mut [u8] =
+                std::slice::from_raw_parts_mut(limbs.as_mut_ptr() as *mut u8, num_bytes);
+            data.read_exact(buf).unwrap();
+        }
+    } else {
+        for entry in limbs {
+            let mut bytes: [u8; size_of::<Limb>()] = [0; size_of::<Limb>()];
+            data.read_exact(&mut bytes)?;
+            *entry = Limb::from_le_bytes(bytes);
+        }
+    };
+    Ok(())
+}
+
+/// Store an array of `Limb`s.
+pub(crate) fn to_bytes(limbs: &[Limb], data: &mut impl std::io::Write) -> std::io::Result<()> {
+    let num_limbs = limbs.len();
+
+    if cfg!(target_endian = "little") {
+        let num_bytes = std::mem::size_of_val(limbs);
+        unsafe {
+            let buf: &[u8] = std::slice::from_raw_parts_mut(limbs.as_ptr() as *mut u8, num_bytes);
+            data.write_all(buf)?;
+        }
+    } else {
+        for limb in &limbs[0..num_limbs] {
+            let bytes = limb.to_le_bytes();
+            data.write_all(&bytes)?;
+        }
+    }
+    Ok(())
+}
+
 pub(crate) fn sign_rule(mut target: Limb, mut source: Limb) -> u32 {
     let mut result = 0;
     let mut n = 1;

--- a/ext/crates/fp/src/matrix/matrix_inner.rs
+++ b/ext/crates/fp/src/matrix/matrix_inner.rs
@@ -1,14 +1,12 @@
-use std::{
-    fmt, io,
-    ops::{Index, IndexMut},
-};
+use std::{fmt, io};
 
 use itertools::Itertools;
 use maybe_rayon::prelude::*;
 
 use super::{QuasiInverse, Subspace};
 use crate::{
-    field::{Field, Fp},
+    field::{field_internal::FieldInternal, Field, Fp},
+    limb::Limb,
     matrix::m4ri::M4riTable,
     prime::{self, ValidPrime},
     vector::{FpSlice, FpSliceMut, FpVector},
@@ -22,8 +20,10 @@ use crate::{
 #[derive(Clone)]
 pub struct Matrix {
     fp: Fp<ValidPrime>,
+    rows: usize,
     columns: usize,
-    vectors: Vec<FpVector>,
+    data: Vec<Limb>,
+    stride: usize,
     /// The pivot columns of the matrix. `pivots[n]` is `k` if column `n` is the `k`th pivot
     /// column, and a negative number otherwise. Said negative number is often -1 but this is not
     /// guaranteed.
@@ -32,7 +32,7 @@ pub struct Matrix {
 
 impl PartialEq for Matrix {
     fn eq(&self, other: &Self) -> bool {
-        self.vectors == other.vectors
+        self.data == other.data
     }
 }
 
@@ -42,16 +42,7 @@ impl Matrix {
     /// Produces a new matrix over F_p with the specified number of rows and columns, initialized
     /// to the 0 matrix.
     pub fn new(p: ValidPrime, rows: usize, columns: usize) -> Self {
-        let mut vectors: Vec<FpVector> = Vec::with_capacity(rows);
-        for _ in 0..rows {
-            vectors.push(FpVector::new(p, columns));
-        }
-        Self {
-            fp: Fp::new(p),
-            columns,
-            vectors,
-            pivots: Vec::new(),
-        }
+        Self::new_with_capacity(p, rows, columns, rows, columns)
     }
 
     pub fn new_with_capacity(
@@ -61,14 +52,17 @@ impl Matrix {
         rows_capacity: usize,
         columns_capacity: usize,
     ) -> Self {
-        let mut vectors: Vec<FpVector> = Vec::with_capacity(rows_capacity);
-        for _ in 0..rows {
-            vectors.push(FpVector::new_with_capacity(p, columns, columns_capacity));
-        }
+        let fp = Fp::new(p);
+        let stride = fp.number(columns_capacity);
+        let mut data = Vec::with_capacity(rows_capacity * stride);
+        data.resize(rows * stride, 0);
+
         Self {
-            fp: Fp::new(p),
+            fp,
+            rows,
             columns,
-            vectors,
+            data,
+            stride,
             pivots: Vec::new(),
         }
     }
@@ -83,23 +77,30 @@ impl Matrix {
         p: ValidPrime,
         rows: usize,
         columns: usize,
-        data: &mut impl io::Read,
+        buffer: &mut impl io::Read,
     ) -> io::Result<Self> {
-        let mut vectors: Vec<FpVector> = Vec::with_capacity(rows);
-        for _ in 0..rows {
-            vectors.push(FpVector::from_bytes(p, columns, data)?);
+        let fp = Fp::new(p);
+        let stride = fp.number(columns);
+        let mut data: Vec<Limb> = vec![0; stride * rows];
+        for row_idx in 0..rows {
+            let row_range = row_idx * stride..(row_idx + 1) * stride;
+            crate::limb::from_bytes(&mut data[row_range], buffer)?;
         }
         Ok(Self {
             fp: Fp::new(p),
+            rows,
             columns,
-            vectors,
+            data,
+            stride,
             pivots: Vec::new(),
         })
     }
 
     pub fn to_bytes(&self, data: &mut impl io::Write) -> io::Result<()> {
-        for v in &self.vectors {
-            v.to_bytes(data)?;
+        let limbs_per_row = self.fp.number(self.columns);
+        for row_idx in 0..self.rows() {
+            let row_range = row_idx * self.stride..row_idx * self.stride + limbs_per_row;
+            crate::limb::to_bytes(&self.data[row_range], data)?;
         }
         Ok(())
     }
@@ -148,7 +149,7 @@ impl Matrix {
 
     /// Gets the number of rows in the matrix.
     pub fn rows(&self) -> usize {
-        self.vectors.len()
+        self.rows
     }
 
     /// Gets the number of columns in the matrix.
@@ -172,11 +173,20 @@ impl Matrix {
 
     /// Produces a Matrix from a vector of FpVectors. We pass in the number of columns because all
     /// `0 x n` matrices will have an empty Vec, and we have to distinguish between them.
-    pub fn from_rows(p: ValidPrime, rows: Vec<FpVector>, columns: usize) -> Self {
+    pub fn from_rows(p: ValidPrime, input: Vec<FpVector>, columns: usize) -> Self {
+        let fp = Fp::new(p);
+        let rows = input.len();
+        let stride = fp.number(columns);
+        let mut data = Vec::with_capacity(rows * stride);
+        for row in &input {
+            data.extend_from_slice(row.limbs());
+        }
         Self {
-            fp: Fp::new(p),
+            fp,
+            rows,
             columns,
-            vectors: rows,
+            data,
+            stride,
             pivots: Vec::new(),
         }
     }
@@ -199,25 +209,39 @@ impl Matrix {
     /// let m = Matrix::from_vec(p, &input);
     /// ```
     pub fn from_vec(p: ValidPrime, input: &[Vec<u32>]) -> Self {
+        let fp = Fp::new(p);
         let rows = input.len();
         if rows == 0 {
             return Self::new(p, 0, 0);
         }
         let columns = input[0].len();
-        let mut vectors = Vec::with_capacity(rows);
+        let stride = fp.number(columns);
+        let mut data = Vec::with_capacity(rows * stride);
         for row in input {
-            vectors.push(FpVector::from_slice(p, row));
+            for chunk in row.chunks(fp.entries_per_limb()) {
+                data.push(fp.pack(chunk.iter().map(|x| fp.element(*x))));
+            }
         }
         Self {
-            fp: Fp::new(p),
+            fp,
+            rows,
             columns,
-            vectors,
+            data,
+            stride,
             pivots: Vec::new(),
         }
     }
 
     pub fn to_vec(&self) -> Vec<Vec<u32>> {
-        self.vectors.iter().map(Vec::<u32>::from).collect()
+        self.data
+            .iter()
+            .chunks(self.stride)
+            .into_iter()
+            .map(|row| {
+                row.flat_map(|&limb| self.fp.unpack(limb).map(|x| x.val()))
+                    .collect()
+            })
+            .collect()
     }
 
     /// Produces a padded augmented matrix from an `&[Vec<u32>]` object (produces [A|0|I] from
@@ -240,9 +264,9 @@ impl Matrix {
         let padded_cols = FpVector::padded_len(p, cols);
         let mut m = Self::new(p, rows, padded_cols + rows);
 
-        for i in 0..rows {
-            for j in 0..cols {
-                m[i].set_entry(j, input[i][j]);
+        for (i, row) in input.iter().enumerate() {
+            for (j, &value) in row.iter().enumerate() {
+                m.row_mut(i).set_entry(j, value);
             }
         }
         m.slice_mut(0, rows, padded_cols, padded_cols + rows)
@@ -251,19 +275,17 @@ impl Matrix {
     }
 
     pub fn is_zero(&self) -> bool {
-        self.vectors.iter().all(FpVector::is_zero)
+        self.data.iter().all(|limb| *limb == 0)
     }
 
     pub fn set_to_zero(&mut self) {
-        for i in 0..self.rows() {
-            self[i].set_to_zero();
+        for limb in self.data.iter_mut() {
+            *limb = 0;
         }
     }
 
     pub fn assign(&mut self, other: &Self) {
-        for i in 0..self.rows() {
-            self[i].assign(&other[i]);
-        }
+        self.data = other.data.clone();
     }
 
     pub fn as_slice_mut(&mut self) -> MatrixSliceMut<'_> {
@@ -277,62 +299,60 @@ impl Matrix {
         col_start: usize,
         col_end: usize,
     ) -> MatrixSliceMut<'_> {
+        let row_range = row_start..row_end;
+        let limb_range = row_start * self.stride..row_end * self.stride;
         MatrixSliceMut {
-            vectors: &mut self.vectors[row_start..row_end],
+            fp: self.fp,
+            rows: row_range.len(),
+            data: &mut self.data[limb_range],
             col_start,
             col_end,
+            stride: self.stride,
         }
     }
 
     pub fn row(&self, row: usize) -> FpSlice<'_> {
-        self.vectors[row].as_slice()
+        let row_range = row * self.stride..(row + 1) * self.stride;
+        FpSlice::new(self.prime(), &self.data[row_range], 0, self.columns)
     }
 
     pub fn row_mut(&mut self, row: usize) -> FpSliceMut<'_> {
-        self.vectors[row].as_slice_mut()
+        let row_range = row * self.stride..(row + 1) * self.stride;
+        FpSliceMut::new(self.prime(), &mut self.data[row_range], 0, self.columns)
     }
 }
 
 impl Matrix {
-    pub fn iter(&self) -> std::slice::Iter<'_, FpVector> {
-        self.vectors.iter()
+    pub fn iter(&self) -> impl Iterator<Item = FpSlice<'_>> {
+        (0..self.rows).map(move |row_idx| self.row(row_idx))
     }
 
-    pub fn iter_mut(&mut self) -> std::slice::IterMut<'_, FpVector> {
-        self.vectors.iter_mut()
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = FpSliceMut<'_>> {
+        let p = self.prime();
+        let columns = self.columns;
+
+        // This is written weird because we need to handle the case where stride is 0 as a special
+        // case. This is because `chunks_mut` panics if the argument is 0.
+        match self.stride {
+            0 => None,
+            s => Some(
+                self.data
+                    .chunks_mut(s)
+                    .map(move |row| FpSliceMut::new(p, row, 0, columns)),
+            ),
+        }
+        .into_iter()
+        .flatten()
     }
 
     pub fn maybe_par_iter_mut(
         &mut self,
-    ) -> impl MaybeIndexedParallelIterator<Item = &mut FpVector> + '_ {
-        self.vectors.maybe_par_iter_mut()
-    }
-}
-
-impl IntoIterator for Matrix {
-    type IntoIter = std::vec::IntoIter<FpVector>;
-    type Item = FpVector;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.vectors.into_iter()
-    }
-}
-
-impl<'a> IntoIterator for &'a Matrix {
-    type IntoIter = std::slice::Iter<'a, FpVector>;
-    type Item = &'a FpVector;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.iter()
-    }
-}
-
-impl<'a> IntoIterator for &'a mut Matrix {
-    type IntoIter = std::slice::IterMut<'a, FpVector>;
-    type Item = &'a mut FpVector;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.iter_mut()
+    ) -> impl MaybeIndexedParallelIterator<Item = FpSliceMut<'_>> {
+        let p = self.prime();
+        let columns = self.columns;
+        self.data
+            .maybe_par_chunks_mut(self.stride)
+            .map(move |row| FpSliceMut::new(p, row, 0, columns))
     }
 }
 
@@ -369,28 +389,6 @@ impl fmt::Debug for Matrix {
     }
 }
 
-impl<I> Index<I> for Matrix
-where
-    Vec<FpVector>: Index<I>,
-{
-    type Output = <Vec<FpVector> as Index<I>>::Output;
-
-    /// Returns the ith row of the matrix
-    fn index(&self, i: I) -> &Self::Output {
-        &self.vectors[i]
-    }
-}
-
-impl<I> IndexMut<I> for Matrix
-where
-    Vec<FpVector>: IndexMut<I>,
-{
-    /// Returns the ith row of the matrix
-    fn index_mut(&mut self, i: I) -> &mut Self::Output {
-        &mut self.vectors[i]
-    }
-}
-
 impl Matrix {
     /// A no-nonsense, safe, row operation. Adds `c * self[source]` to `self[target]`.
     pub fn safe_row_op(&mut self, target: usize, source: usize, c: u32) {
@@ -398,8 +396,8 @@ impl Matrix {
         assert!(source < self.rows());
         assert!(target < self.rows());
 
-        let (target, source) = unsafe { self.split_borrow(target, source) };
-        target.add(source, c)
+        let (mut target, source) = unsafe { self.split_borrow(target, source) };
+        target.add(source.as_slice(), c)
     }
 
     /// Performs a row operation using `pivot_column` as the pivot column. This assumes that the
@@ -415,12 +413,12 @@ impl Matrix {
         prime: ValidPrime,
     ) {
         debug_assert_ne!(target, source);
-        let coef = self.vectors[target].entry(pivot_column);
+        let coef = self.row(target).entry(pivot_column);
         if coef == 0 {
             return;
         }
-        let (target, source) = self.split_borrow(target, source);
-        target.add_offset(source, prime - coef, pivot_column);
+        let (mut target, source) = self.split_borrow(target, source);
+        target.add_offset(source.as_slice(), prime - coef, pivot_column);
     }
 
     /// A version of [`Matrix::row_op`] without the zero assumption.
@@ -435,12 +433,12 @@ impl Matrix {
         prime: ValidPrime,
     ) {
         debug_assert_ne!(target, source);
-        let coef = self.vectors[target].entry(pivot_column);
+        let coef = self.row(target).entry(pivot_column);
         if coef == 0 {
             return;
         }
-        let (target, source) = self.split_borrow(target, source);
-        target.add(source, prime - coef);
+        let (mut target, source) = self.split_borrow(target, source);
+        target.add(source.as_slice(), prime - coef);
     }
 
     /// Mutably borrows `x[i]` and `x[j]`.
@@ -451,9 +449,21 @@ impl Matrix {
         &mut self,
         i: usize,
         j: usize,
-    ) -> (&mut FpVector, &mut FpVector) {
-        let ptr = self.vectors.as_mut_ptr();
-        (&mut *ptr.add(i), &mut *ptr.add(j))
+    ) -> (FpSliceMut<'_>, FpSliceMut<'_>) {
+        let ptr = self.data.as_mut_ptr();
+        let row1 = std::slice::from_raw_parts_mut(ptr.add(i * self.stride), self.stride);
+        let row2 = std::slice::from_raw_parts_mut(ptr.add(j * self.stride), self.stride);
+        (
+            FpSliceMut::new(self.prime(), row1, 0, self.columns),
+            FpSliceMut::new(self.prime(), row2, 0, self.columns),
+        )
+    }
+
+    pub fn swap_rows(&mut self, i: usize, j: usize) {
+        for limb_idx in 0..self.stride {
+            self.data
+                .swap(i * self.stride + limb_idx, j * self.stride + limb_idx);
+        }
     }
 
     /// This is very similar to row_reduce, except we only need to get to row echelon form, not
@@ -475,7 +485,7 @@ impl Matrix {
             // Search down column for a nonzero entry.
             let mut pivot_row = rows;
             for i in pivot..rows {
-                if self[i].entry(pivot_column) != 0 {
+                if self.row(i).entry(pivot_column) != 0 {
                     pivot_row = i;
                     break;
                 }
@@ -489,13 +499,13 @@ impl Matrix {
 
             // Pivot_row contains a row with a pivot in current column.
             // Swap pivot row up.
-            self.vectors.swap(pivot, pivot_row);
+            self.swap_rows(pivot, pivot_row);
             // println!("({}) <==> ({}): \n{}", pivot, pivot_row, self);
 
             // // Divide pivot row by pivot entry
-            let c = self[pivot].entry(pivot_column);
+            let c = self.row(pivot).entry(pivot_column);
             let c_inv = prime::inverse(p, c);
-            self[pivot].scale(c_inv);
+            self.row_mut(pivot).scale(c_inv);
             // println!("({}) <== {} * ({}): \n{}", pivot, c_inv, pivot, self);
 
             for i in pivot_row + 1..rows {
@@ -549,7 +559,7 @@ impl Matrix {
             for i in 0..self.rows() {
                 table.reduce_naive(&mut *self, i);
 
-                if let Some((c, _)) = self[i].first_nonzero() {
+                if let Some((c, _)) = self.row(i).first_nonzero() {
                     self.pivots[c] = i as isize;
                     for &row in table.rows() {
                         unsafe {
@@ -561,10 +571,10 @@ impl Matrix {
                     if table.len() == k {
                         table.generate(self);
                         for j in 0..table.rows()[0] {
-                            table.reduce(self[j].limbs_mut());
+                            table.reduce(self.row_mut(j).limbs_mut());
                         }
                         for j in i + 1..self.rows() {
-                            table.reduce(self[j].limbs_mut());
+                            table.reduce(self.row_mut(j).limbs_mut());
                         }
                         table.clear();
                     }
@@ -575,15 +585,15 @@ impl Matrix {
             if !table.is_empty() {
                 table.generate(self);
                 for j in 0..table.rows()[0] {
-                    table.reduce(self[j].limbs_mut());
+                    table.reduce(self.row_mut(j).limbs_mut());
                 }
                 table.clear();
             }
         } else {
             for i in 0..self.rows() {
-                if let Some((c, v)) = self[i].first_nonzero() {
+                if let Some((c, v)) = self.row(i).first_nonzero() {
                     self.pivots[c] = i as isize;
-                    self[i].scale(prime::inverse(p, v));
+                    self.row_mut(i).scale(prime::inverse(p, v));
                     for j in 0..self.rows() {
                         if i == j {
                             continue;
@@ -600,25 +610,20 @@ impl Matrix {
 
         // Now reorder the vectors. There are O(n) in-place permutation algorithms but the way we
         // get the permutation makes the naive strategy easier.
-        let old_capacity = self.vectors.capacity();
-        let mut old_rows = std::mem::replace(&mut self.vectors, Vec::with_capacity(old_capacity));
+        let old_len = self.data.len();
+        let old_data = std::mem::replace(&mut self.data, vec![0; old_len]);
 
-        for row in &mut self.pivots {
-            if *row >= 0 {
-                self.vectors.push(std::mem::replace(
-                    &mut old_rows[*row as usize],
-                    FpVector::new(p, 0),
-                ));
-                *row = self.vectors.len() as isize - 1;
-            }
+        let mut new_row_idx = 0;
+        for old_row in self.pivots.iter_mut().filter(|row| **row >= 0) {
+            let old_row_idx = *old_row as usize;
+            let old_row_range = old_row_idx * self.stride..(old_row_idx + 1) * self.stride;
+            let new_row_range = new_row_idx * self.stride..(new_row_idx + 1) * self.stride;
+            self.data[new_row_range].copy_from_slice(&old_data[old_row_range]);
+            *old_row = new_row_idx as isize;
+            new_row_idx += 1;
         }
 
-        let num_rows = self.vectors.len();
-        for row in empty_rows {
-            self.vectors
-                .push(std::mem::replace(&mut old_rows[row], FpVector::new(p, 0)))
-        }
-        num_rows
+        new_row_idx
     }
 }
 
@@ -670,9 +675,9 @@ impl Matrix {
         let first_kernel_row = self.find_first_row_in_block(first_source_col);
         let mut preimage = Self::new(p, first_kernel_row, source_columns);
         for i in 0..first_kernel_row {
-            preimage[i]
-                .as_slice_mut()
-                .assign(self[i].slice(first_source_col, columns));
+            preimage
+                .row_mut(i)
+                .assign(self.row(i).slice(first_source_col, columns));
         }
         QuasiInverse::new(Some(self.pivots()[..last_target_col].to_vec()), preimage)
     }
@@ -710,9 +715,9 @@ impl Matrix {
         let first_kernel_row = self.find_first_row_in_block(first_source_col);
         let mut image_matrix = Self::new(p, first_kernel_row, last_target_col);
         for i in 0..first_kernel_row {
-            image_matrix[i]
-                .as_slice_mut()
-                .assign(self[i].slice(0, last_target_col));
+            image_matrix
+                .row_mut(i)
+                .assign(self.row(i).slice(0, last_target_col));
         }
         image_matrix.pivots = self.pivots()[..last_target_col].to_vec();
         Subspace::from_matrix(image_matrix)
@@ -778,9 +783,9 @@ impl Matrix {
                 column_to_pivot_row[i + first_source_column] - first_kernel_row as isize;
         }
         // Copy kernel matrix into kernel
-        for (i, row) in kernel.iter_mut().enumerate() {
-            row.as_slice_mut().assign(
-                self.vectors[first_kernel_row + i]
+        for (i, mut row) in kernel.iter_mut().enumerate() {
+            row.assign(
+                self.row(first_kernel_row + i)
                     .slice(first_source_column, first_source_column + source_dimension),
             );
         }
@@ -789,12 +794,39 @@ impl Matrix {
 
     pub fn extend_column_dimension(&mut self, columns: usize) {
         if columns > self.columns {
-            for row in &mut self.vectors {
-                row.extend_len(columns);
-            }
+            self.extend_column_capacity(columns);
             self.columns = columns;
             self.pivots.resize(columns, -1);
         }
+    }
+
+    pub fn extend_column_capacity(&mut self, columns: usize) {
+        let new_stride = self.fp.number(columns);
+        if new_stride > self.stride {
+            self.data.resize(new_stride * self.rows, 0);
+            // Shift row data backwards, starting from the end to avoid overwriting data.
+            for row_idx in (0..self.rows).rev() {
+                let old_row_range = row_idx * self.stride..(row_idx + 1) * self.stride;
+                let new_row_range_copy_part =
+                    row_idx * new_stride..row_idx * new_stride + self.stride;
+                let new_row_range_zero_part =
+                    row_idx * new_stride + self.stride..(row_idx + 1) * new_stride;
+                for (old_limb_idx, new_limb_idx) in old_row_range.zip_eq(new_row_range_copy_part) {
+                    self.data[new_limb_idx] = self.data[old_limb_idx];
+                }
+                for limb in &mut self.data[new_row_range_zero_part] {
+                    *limb = 0;
+                }
+            }
+            self.stride = new_stride;
+        }
+    }
+
+    /// Add a row to the matrix and return a mutable reference to it.
+    pub fn add_row(&mut self) -> FpSliceMut<'_> {
+        self.data.resize((self.rows + 1) * self.stride, 0);
+        self.rows += 1;
+        self.row_mut(self.rows - 1)
     }
 
     /// Given a matrix M in rref, add rows to make the matrix surjective when restricted to the
@@ -821,16 +853,17 @@ impl Matrix {
         extra_column_capacity: usize,
     ) -> Vec<usize> {
         let mut added_pivots = Vec::new();
-        let columns = self.columns();
+        self.extend_column_capacity(self.columns + extra_column_capacity);
 
-        for (i, &pivot) in self.pivots[start_column..end_column].iter().enumerate() {
+        for (i, &pivot) in self.pivots.clone()[start_column..end_column]
+            .iter()
+            .enumerate()
+        {
             if pivot >= 0 {
                 continue;
             }
-            let mut new_row =
-                FpVector::new_with_capacity(self.prime(), columns, columns + extra_column_capacity);
+            let mut new_row = self.add_row();
             new_row.set_entry(i, 1);
-            self.vectors.push(new_row);
             added_pivots.push(i);
         }
         added_pivots
@@ -857,7 +890,7 @@ impl Matrix {
         let desired_pivots = desired_image.pivots();
         let early_end_column = std::cmp::min(end_column, desired_pivots.len() + start_column);
 
-        let columns = self.columns();
+        self.extend_column_capacity(self.columns + extra_column_capacity);
 
         for i in start_column..early_end_column {
             debug_assert!(
@@ -873,16 +906,13 @@ impl Matrix {
             let kernel_vector_row = desired_pivots[i - start_column] as usize;
             let new_image = desired_image.row(kernel_vector_row);
 
-            let mut new_row =
-                FpVector::new_with_capacity(self.prime(), columns, columns + extra_column_capacity);
+            let mut new_row = self.add_row();
             new_row
                 .slice_mut(
                     start_column,
                     start_column + desired_image.ambient_dimension(),
                 )
                 .assign(new_image);
-
-            self.vectors.push(new_row);
 
             added_pivots.push(i);
         }
@@ -909,20 +939,24 @@ impl Matrix {
     pub fn apply(&self, mut result: FpSliceMut, coeff: u32, input: FpSlice) {
         debug_assert_eq!(input.len(), self.rows());
         for i in 0..input.len() {
-            result.add(
-                self.vectors[i].as_slice(),
-                (coeff * input.entry(i)) % self.prime(),
-            );
+            result.add(self.row(i), (coeff * input.entry(i)) % self.prime());
         }
     }
 
     pub fn trim(&mut self, row_start: usize, row_end: usize, col_start: usize) {
-        self.vectors.truncate(row_end);
-        self.vectors.drain(0..row_start);
-        for v in &mut self.vectors {
-            v.trim_start(col_start);
+        self.rows = row_end - row_start;
+        self.data.truncate(row_end * self.stride);
+        self.data.drain(0..row_start * self.stride);
+        for mut row in self.iter_mut() {
+            row.shl_assign(col_start);
         }
         self.columns -= col_start;
+    }
+
+    /// Rotate the rows downwards in the range `range`.
+    pub fn rotate_down(&mut self, range: std::ops::Range<usize>, shift: usize) {
+        let limb_range = range.start * self.stride..range.end * self.stride;
+        self.data[limb_range].rotate_right(shift * self.stride)
     }
 }
 
@@ -937,7 +971,9 @@ impl std::ops::Mul for &Matrix {
         for i in 0..self.rows() {
             for j in 0..rhs.columns() {
                 for k in 0..self.columns() {
-                    result[i].add_basis_element(j, self[i].entry(k) * rhs[k].entry(j));
+                    result
+                        .row_mut(i)
+                        .add_basis_element(j, self.row(i).entry(k) * rhs.row(k).entry(j));
                 }
             }
         }
@@ -949,7 +985,7 @@ impl std::ops::MulAssign<u32> for Matrix {
     fn mul_assign(&mut self, rhs: u32) {
         #[allow(clippy::suspicious_op_assign_impl)]
         let rhs = rhs % self.prime();
-        for row in self.iter_mut() {
+        for mut row in self.iter_mut() {
             row.scale(rhs);
         }
     }
@@ -961,8 +997,8 @@ impl std::ops::AddAssign<&Self> for Matrix {
         assert_eq!(self.columns(), rhs.columns());
         assert_eq!(self.rows(), rhs.rows());
 
-        for (i, row) in self.iter_mut().enumerate() {
-            row.add(&rhs[i], 1);
+        for (i, mut row) in self.iter_mut().enumerate() {
+            row.add(rhs.row(i), 1);
         }
     }
 }
@@ -1057,7 +1093,7 @@ pub mod arbitrary {
                 })
                 .prop_map(|(mut m, pivot_cols)| {
                     // Ensure rows start with 0s followed by a 1 in their pivot column
-                    for (row_idx, row) in m.iter_mut().enumerate() {
+                    for (row_idx, mut row) in m.iter_mut().enumerate() {
                         if let Some(&col_idx) = pivot_cols.get(row_idx) {
                             row.slice_mut(0, col_idx).set_to_zero();
                             row.set_entry(col_idx, 1);
@@ -1067,7 +1103,7 @@ pub mod arbitrary {
                     }
                     // Set all other entries in the pivot columns to 0
                     for (row_idx, &col_idx) in pivot_cols.iter().enumerate() {
-                        for row in m.iter_mut().take(row_idx) {
+                        for mut row in m.iter_mut().take(row_idx) {
                             row.set_entry(col_idx, 0);
                         }
                     }
@@ -1158,13 +1194,14 @@ impl<const N: usize> AugmentedMatrix<N> {
     pub fn row_segment_mut(&mut self, i: usize, start: usize, end: usize) -> FpSliceMut<'_> {
         let start_idx = self.start[start];
         let end_idx = self.end[end];
-        self[i].slice_mut(start_idx, end_idx)
+        let row_range = i * self.stride..(i + 1) * self.stride;
+        FpSliceMut::new(self.prime(), &mut self.data[row_range], start_idx, end_idx)
     }
 
     pub fn row_segment(&self, i: usize, start: usize, end: usize) -> FpSlice<'_> {
         let start_idx = self.start[start];
         let end_idx = self.end[end];
-        self[i].slice(start_idx, end_idx)
+        self.row(i).slice(start_idx, end_idx)
     }
 
     pub fn into_matrix(self) -> Matrix {
@@ -1221,8 +1258,8 @@ impl AugmentedMatrix<2> {
 impl AugmentedMatrix<3> {
     pub fn drop_first(mut self) -> AugmentedMatrix<2> {
         let offset = self.start[1];
-        for row in self.inner.iter_mut() {
-            row.trim_start(offset);
+        for mut row in self.inner.iter_mut() {
+            row.shl_assign(offset);
         }
         self.inner.columns -= offset;
         AugmentedMatrix::<2> {
@@ -1240,6 +1277,7 @@ impl AugmentedMatrix<3> {
     /// strictly necessary but is fine in most applications.
     pub fn compute_quasi_inverses(mut self) -> (QuasiInverse, QuasiInverse) {
         let p = self.prime();
+        let stride = self.stride;
 
         let source_columns = self.end[2] - self.start[2];
 
@@ -1250,14 +1288,15 @@ impl AugmentedMatrix<3> {
         } else {
             let mut cc_preimage = Matrix::new(p, self.end[0], source_columns);
             for i in 0..self.end[0] {
-                cc_preimage[i]
-                    .as_slice_mut()
-                    .assign(self[i].slice(self.start[2], self.end[2]));
+                cc_preimage
+                    .row_mut(i)
+                    .assign(self.row(i).slice(self.start[2], self.end[2]));
             }
             let cm_qi = QuasiInverse::new(None, cc_preimage);
 
             let first_kernel_row = self.find_first_row_in_block(self.start[2]);
-            self.vectors.truncate(first_kernel_row);
+            self.rows = first_kernel_row;
+            self.data.truncate(first_kernel_row * stride);
 
             let mut res_matrix = self.drop_first();
             res_matrix.row_reduce();
@@ -1269,64 +1308,102 @@ impl AugmentedMatrix<3> {
 }
 
 pub struct MatrixSliceMut<'a> {
-    vectors: &'a mut [FpVector],
+    fp: Fp<ValidPrime>,
+    data: &'a mut [Limb],
+    rows: usize,
     col_start: usize,
     col_end: usize,
+    stride: usize,
 }
 
 impl<'a> MatrixSliceMut<'a> {
+    pub fn prime(&self) -> ValidPrime {
+        self.fp.characteristic()
+    }
+
     pub fn columns(&self) -> usize {
         self.col_end - self.col_start
     }
 
     pub fn rows(&self) -> usize {
-        self.vectors.len()
+        self.rows
     }
 
     pub fn row_slice<'b: 'a>(&'b mut self, row_start: usize, row_end: usize) -> MatrixSliceMut<'b> {
+        let row_range = row_start * self.stride..row_end * self.stride;
         Self {
-            vectors: &mut self.vectors[row_start..row_end],
+            fp: self.fp,
+            data: &mut self.data[row_range],
+            rows: self.rows,
             col_start: self.col_start,
             col_end: self.col_end,
+            stride: self.stride,
         }
     }
 
     pub fn iter(&self) -> impl Iterator<Item = FpSlice<'_>> + '_ {
         let start = self.col_start;
         let end = self.col_end;
-        self.vectors.iter().map(move |x| x.slice(start, end))
+        (0..self.rows).map(move |row_idx| {
+            let row_range = row_idx * self.stride..(row_idx + 1) * self.stride;
+            FpSlice::new(self.prime(), &self.data[row_range], start, end)
+        })
     }
 
     pub fn iter_mut(&mut self) -> impl Iterator<Item = FpSliceMut<'_>> + '_ {
+        let p = self.prime();
         let start = self.col_start;
         let end = self.col_end;
-        self.vectors
-            .iter_mut()
-            .map(move |x| x.slice_mut(start, end))
+
+        // This is written weird because we need to handle the case where stride is 0 as a special
+        // case. This is because `chunks_mut` panics if the argument is 0.
+        match self.stride {
+            0 => None,
+            s => Some(
+                self.data
+                    .chunks_mut(s)
+                    .map(move |row| FpSliceMut::new(p, row, start, end)),
+            ),
+        }
+        .into_iter()
+        .flatten()
     }
 
     pub fn maybe_par_iter_mut(
         &mut self,
     ) -> impl MaybeIndexedParallelIterator<Item = FpSliceMut<'_>> + '_ {
+        let p = self.prime();
         let start = self.col_start;
         let end = self.col_end;
-        self.vectors
-            .maybe_par_iter_mut()
-            .map(move |x| x.slice_mut(start, end))
+        self.data
+            .maybe_par_chunks_mut(self.stride)
+            .map(move |row| FpSliceMut::new(p, row, start, end))
     }
 
     pub fn row(&mut self, row: usize) -> FpSlice<'_> {
-        self.vectors[row].slice(self.col_start, self.col_end)
+        let row_range = row * self.stride..(row + 1) * self.stride;
+        FpSlice::new(
+            self.prime(),
+            &self.data[row_range],
+            self.col_start,
+            self.col_end,
+        )
     }
 
     pub fn row_mut(&mut self, row: usize) -> FpSliceMut<'_> {
-        self.vectors[row].slice_mut(self.col_start, self.col_end)
+        let row_range = row * self.stride..(row + 1) * self.stride;
+        FpSliceMut::new(
+            self.prime(),
+            &mut self.data[row_range],
+            self.col_start,
+            self.col_end,
+        )
     }
 
     pub fn add_identity(&mut self) {
         debug_assert_eq!(self.rows(), self.columns());
-        for (i, row) in self.vectors.iter_mut().enumerate() {
-            row.add_basis_element(self.col_start + i, 1);
+        for row_idx in 0..self.rows {
+            self.row_mut(row_idx).add_basis_element(row_idx, 1);
         }
     }
 
@@ -1334,8 +1411,8 @@ impl<'a> MatrixSliceMut<'a> {
     pub fn add_masked(&mut self, other: &Matrix, mask: &[usize]) {
         assert_eq!(self.rows(), other.rows());
 
-        for (mut l, r) in self.iter_mut().zip(other) {
-            l.add_masked(r.as_slice(), 1, mask);
+        for (mut l, r) in self.iter_mut().zip(other.iter()) {
+            l.add_masked(r, 1, mask);
         }
     }
 }
@@ -1393,8 +1470,8 @@ mod tests {
             let mut m = Matrix::from_vec(p, input);
             println!("{m}");
             m.row_reduce();
-            for i in 0..input.len() {
-                assert_eq!(Vec::<u32>::from(&m[i]), goal_output[i]);
+            for (i, goal_row) in goal_output.iter().enumerate() {
+                assert_eq!(m.row(i).iter().collect::<Vec<_>>(), *goal_row);
             }
             assert_eq!(m.pivots(), &goal_pivots)
         }

--- a/ext/crates/fp/src/matrix/quasi_inverse.rs
+++ b/ext/crates/fp/src/matrix/quasi_inverse.rs
@@ -141,7 +141,7 @@ impl QuasiInverse {
                 }
             }
             if c != 0 {
-                target.add(self.preimage[row].as_slice(), (coeff * c) % p);
+                target.add(self.preimage.row(row), (coeff * c) % p);
             }
             row += 1;
         }

--- a/ext/crates/fp/src/matrix/subquotient.rs
+++ b/ext/crates/fp/src/matrix/subquotient.rs
@@ -105,7 +105,7 @@ impl Subquotient {
 
         self.gens.update_then_row_reduce(|gens_matrix| {
             for elt in gens_matrix.iter_mut().take(self.dimension) {
-                self.quotient.reduce(elt.as_slice_mut());
+                self.quotient.reduce(elt);
             }
         });
 
@@ -166,7 +166,7 @@ impl Subquotient {
 
         sub.update_then_row_reduce(|sub_matrix| {
             for row in sub_matrix.iter_mut().take(dim) {
-                quotient.reduce(row.as_slice_mut());
+                quotient.reduce(row);
             }
         });
 

--- a/ext/crates/fp/src/vector/fp_wrapper/helpers.rs
+++ b/ext/crates/fp/src/vector/fp_wrapper/helpers.rs
@@ -80,6 +80,10 @@ impl<F: Field> FqSlice<'_, F> {
     pub(super) fn entry_helper(&self, index: usize) -> F::ElementContainer {
         self.entry(index).val()
     }
+
+    pub(super) fn first_nonzero_helper(&self) -> Option<(usize, F::ElementContainer)> {
+        self.first_nonzero().map(|(idx, c)| (idx, c.val()))
+    }
 }
 
 impl<F: Field> FqSliceMut<'_, F> {
@@ -89,6 +93,15 @@ impl<F: Field> FqSliceMut<'_, F> {
 
     pub(super) fn add_helper(&mut self, other: FqSlice<F>, c: F::ElementContainer) {
         self.add(other, self.fq.el(c))
+    }
+
+    pub(super) fn add_offset_helper(
+        &mut self,
+        other: FqSlice<F>,
+        c: F::ElementContainer,
+        offset: usize,
+    ) {
+        self.add_offset(other, self.fq.el(c), offset)
     }
 
     pub(super) fn set_entry_helper(&mut self, index: usize, value: F::ElementContainer) {

--- a/ext/crates/fp/src/vector/fp_wrapper/mod.rs
+++ b/ext/crates/fp/src/vector/fp_wrapper/mod.rs
@@ -88,7 +88,6 @@ impl FpVector {
         pub fn set_scratch_vector_size(&mut self, dim: usize);
         pub fn @add_basis_element(&mut self, index: usize, value: u32);
         pub fn @copy_from_slice(&mut self, slice: &[u32]);
-        pub(crate) fn trim_start(&mut self, n: usize);
         pub fn @add_truncate(&mut self, other: &Self, c: u32) -> (Option<()>);
         pub fn sign_rule(&self, other: &Self) -> bool;
         pub fn @add_carry(&mut self, other: &Self, c: u32, rest: &mut [Self]) -> bool;
@@ -96,7 +95,6 @@ impl FpVector {
         pub fn density(&self) -> f32;
 
         pub(crate) fn limbs(&self) -> (&[Limb]);
-        pub(crate) fn limbs_mut(&mut self) -> (&mut [Limb]);
 
         pub fn new<P: Prime>(p: P, len: usize) -> (from FqVector);
         pub fn new_with_capacity<P: Prime>(p: P, len: usize, capacity: usize) -> (from FqVector);
@@ -125,25 +123,32 @@ impl FpVector {
 
 impl<'a> FpSlice<'a> {
     dispatch_vector! {
+        pub(crate) fn new<P: Prime>(p: P, limbs: &'a [Limb], start: usize, end: usize) -> (from FqSlice);
         pub fn prime(&self) -> ValidPrime;
         pub fn len(&self) -> usize;
         pub fn is_empty(&self) -> bool;
         pub fn @entry(&self, index: usize) -> u32;
         pub fn iter(self) -> (dispatch FpVectorIterator<'a>);
         pub fn iter_nonzero(self) -> (dispatch FpVectorNonZeroIterator<'a>);
+        pub fn @first_nonzero(&self) -> (Option<(usize, u32)>);
         pub fn is_zero(&self) -> bool;
         pub fn slice(self, start: usize, end: usize) -> (dispatch FpSlice<'a>);
         pub fn to_owned(self) -> (dispatch FpVector);
+
+        pub(crate) fn limbs(&self) -> (&[Limb]);
     }
 }
 
-impl FpSliceMut<'_> {
+impl<'a> FpSliceMut<'a> {
     dispatch_vector! {
+        pub(crate) fn new<P: Prime>(p: P, limbs: &'a mut [Limb], start: usize, end: usize) -> (from FqSliceMut);
         pub fn prime(&self) -> ValidPrime;
         pub fn @scale(&mut self, c: u32);
         pub fn set_to_zero(&mut self);
         pub fn @add(&mut self, other: FpSlice, c: u32);
+        pub fn @add_offset(&mut self, other: FpSlice, c: u32, offset: usize);
         pub fn assign(&mut self, other: FpSlice);
+        pub fn shl_assign(&mut self, shift: usize);
         pub fn @set_entry(&mut self, index: usize, value: u32);
         pub fn as_slice(&self) -> (dispatch FpSlice<'_>);
         pub fn slice_mut(&mut self, start: usize, end: usize) -> (dispatch FpSliceMut<'_>);
@@ -152,6 +157,9 @@ impl FpSliceMut<'_> {
         pub fn @add_masked(&mut self, other: FpSlice, c: u32, mask: &[usize]);
         pub fn @add_unmasked(&mut self, other: FpSlice, c: u32, mask: &[usize]);
         pub fn @add_tensor(&mut self, offset: usize, coeff: u32, @left: FpSlice, right: FpSlice);
+
+        pub(crate) fn limbs(&self) -> (&[Limb]);
+        pub(crate) fn limbs_mut(&mut self) -> (&mut [Limb]);
     }
 }
 

--- a/ext/crates/fp/src/vector/impl_fqslice.rs
+++ b/ext/crates/fp/src/vector/impl_fqslice.rs
@@ -14,6 +14,15 @@ use crate::{
 // Public methods
 
 impl<'a, F: Field> FqSlice<'a, F> {
+    pub(crate) fn new(fq: F, limbs: &'a [Limb], start: usize, end: usize) -> Self {
+        FqSlice {
+            fq,
+            limbs,
+            start,
+            end,
+        }
+    }
+
     pub fn prime(&self) -> ValidPrime {
         self.fq.characteristic().to_dyn()
     }
@@ -48,6 +57,10 @@ impl<'a, F: Field> FqSlice<'a, F> {
 
     pub fn iter_nonzero(self) -> FqVectorNonZeroIterator<'a, F> {
         FqVectorNonZeroIterator::new(self)
+    }
+
+    pub fn first_nonzero(&self) -> Option<(usize, FieldElement<F>)> {
+        self.iter_nonzero().next()
     }
 
     pub fn is_zero(&self) -> bool {
@@ -102,6 +115,10 @@ impl<'a, F: Field> FqSlice<'a, F> {
 
 // Limb methods
 impl<F: Field> FqSlice<'_, F> {
+    pub(crate) fn limbs(&self) -> &[Limb] {
+        self.limbs
+    }
+
     #[inline]
     pub(super) fn offset(&self) -> usize {
         let bit_length = self.fq.bit_length();

--- a/ext/crates/fp/src/vector/impl_fqvector.rs
+++ b/ext/crates/fp/src/vector/impl_fqvector.rs
@@ -48,44 +48,14 @@ impl<F: Field> FqVector<F> {
     }
 
     pub fn update_from_bytes(&mut self, data: &mut impl io::Read) -> io::Result<()> {
-        let limbs = self.limbs_mut();
-
-        if cfg!(target_endian = "little") {
-            let num_bytes = std::mem::size_of_val(limbs);
-            unsafe {
-                let buf: &mut [u8] =
-                    std::slice::from_raw_parts_mut(limbs.as_mut_ptr() as *mut u8, num_bytes);
-                data.read_exact(buf).unwrap();
-            }
-        } else {
-            for entry in limbs {
-                let mut bytes: [u8; size_of::<Limb>()] = [0; size_of::<Limb>()];
-                data.read_exact(&mut bytes)?;
-                *entry = Limb::from_le_bytes(bytes);
-            }
-        };
-        Ok(())
+        crate::limb::from_bytes(self.limbs_mut(), data)
     }
 
     pub fn to_bytes(&self, buffer: &mut impl io::Write) -> io::Result<()> {
         // self.limbs is allowed to have more limbs than necessary, but we only save the
         // necessary ones.
         let num_limbs = self.fq.number(self.len());
-
-        if cfg!(target_endian = "little") {
-            let num_bytes = num_limbs * size_of::<Limb>();
-            unsafe {
-                let buf: &[u8] =
-                    std::slice::from_raw_parts_mut(self.limbs().as_ptr() as *mut u8, num_bytes);
-                buffer.write_all(buf)?;
-            }
-        } else {
-            for limb in &self.limbs()[0..num_limbs] {
-                let bytes = limb.to_le_bytes();
-                buffer.write_all(&bytes)?;
-            }
-        }
-        Ok(())
+        crate::limb::to_bytes(&self.limbs()[..num_limbs], buffer)
     }
 
     pub fn fq(&self) -> F {
@@ -263,17 +233,6 @@ impl<F: Field> FqVector<F> {
                 .chunks(self.fq.entries_per_limb())
                 .map(|x| self.fq.pack(x.iter().cloned())),
         );
-    }
-
-    /// Permanently remove the first `n` elements in the vector. `n` must be a multiple of
-    /// the number of entries per limb
-    pub(crate) fn trim_start(&mut self, n: usize) {
-        assert!(n <= self.len);
-        let entries_per = self.fq.entries_per_limb();
-        assert_eq!(n % entries_per, 0);
-        let num_limbs = n / entries_per;
-        self.limbs.drain(0..num_limbs);
-        self.len -= n;
     }
 
     pub fn sign_rule(&self, other: &Self) -> bool {

--- a/ext/crates/maybe-rayon/src/concurrent.rs
+++ b/ext/crates/maybe-rayon/src/concurrent.rs
@@ -12,10 +12,6 @@ pub mod prelude {
         }
     }
 
-    pub trait MaybeIntoParallelRefMutIterator<'data>: IntoParallelRefMutIterator<'data> {
-        fn maybe_par_iter_mut(&'data mut self) -> Self::Iter;
-    }
-
     pub type MaybeIterBridge<I> = rayon::iter::IterBridge<I>;
 
     pub trait MaybeParallelBridge: ParallelBridge {
@@ -43,14 +39,6 @@ pub mod prelude {
     impl<I: IndexedParallelIterator> MaybeIndexedParallelIterator for I {}
 
     impl<I: IntoParallelIterator> IntoMaybeParallelIterator for I {}
-
-    impl<'data, I: IntoParallelRefMutIterator<'data> + ?Sized>
-        MaybeIntoParallelRefMutIterator<'data> for I
-    {
-        fn maybe_par_iter_mut(&'data mut self) -> Self::Iter {
-            self.par_iter_mut()
-        }
-    }
 
     impl<I: ParallelBridge> MaybeParallelBridge for I {}
 

--- a/ext/crates/maybe-rayon/src/concurrent.rs
+++ b/ext/crates/maybe-rayon/src/concurrent.rs
@@ -6,8 +6,10 @@ pub mod prelude {
 
     pub trait MaybeIndexedParallelIterator: IndexedParallelIterator {}
 
-    pub trait IntoMaybeParallelIterator: IntoParallelIterator {
-        fn into_maybe_par_iter(self) -> Self::Iter;
+    pub trait IntoMaybeParallelIterator: IntoParallelIterator + Sized {
+        fn into_maybe_par_iter(self) -> Self::Iter {
+            self.into_par_iter()
+        }
     }
 
     pub trait MaybeIntoParallelRefMutIterator<'data>: IntoParallelRefMutIterator<'data> {
@@ -22,17 +24,25 @@ pub mod prelude {
         }
     }
 
+    pub trait MaybeParallelSliceMut<T: Send>: ParallelSliceMut<T> {
+        fn maybe_par_chunks_mut<'data>(
+            &'data mut self,
+            chunk_size: usize,
+        ) -> impl MaybeIndexedParallelIterator<Item = &'data mut [T]>
+        where
+            T: 'data,
+        {
+            self.par_chunks_mut(chunk_size)
+        }
+    }
+
     // Implementations
 
     impl<I: ParallelIterator> MaybeParallelIterator for I {}
 
     impl<I: IndexedParallelIterator> MaybeIndexedParallelIterator for I {}
 
-    impl<I: IntoParallelIterator> IntoMaybeParallelIterator for I {
-        fn into_maybe_par_iter(self) -> Self::Iter {
-            self.into_par_iter()
-        }
-    }
+    impl<I: IntoParallelIterator> IntoMaybeParallelIterator for I {}
 
     impl<'data, I: IntoParallelRefMutIterator<'data> + ?Sized>
         MaybeIntoParallelRefMutIterator<'data> for I
@@ -43,6 +53,8 @@ pub mod prelude {
     }
 
     impl<I: ParallelBridge> MaybeParallelBridge for I {}
+
+    impl<T: Send> MaybeParallelSliceMut<T> for [T] {}
 }
 
 pub fn join<A, B, RA, RB>(oper_a: A, oper_b: B) -> (RA, RB)

--- a/ext/crates/maybe-rayon/src/sequential.rs
+++ b/ext/crates/maybe-rayon/src/sequential.rs
@@ -9,12 +9,6 @@ pub mod prelude {
         }
     }
 
-    pub trait MaybeIntoParallelRefMutIterator<'data> {
-        type Iter;
-
-        fn maybe_par_iter_mut(&'data mut self) -> Self::Iter;
-    }
-
     pub struct MaybeIterBridge<Iter>(Iter);
 
     pub trait MaybeParallelBridge: Sized {
@@ -39,17 +33,6 @@ pub mod prelude {
     impl<I: Iterator> MaybeIndexedParallelIterator for I {}
 
     impl<I: IntoIterator> IntoMaybeParallelIterator for I {}
-
-    impl<'data, I: 'data + ?Sized> MaybeIntoParallelRefMutIterator<'data> for I
-    where
-        &'data mut I: IntoIterator,
-    {
-        type Iter = <&'data mut I as IntoIterator>::IntoIter;
-
-        fn maybe_par_iter_mut(&'data mut self) -> Self::Iter {
-            self.into_iter()
-        }
-    }
 
     impl<Iter: Iterator> Iterator for MaybeIterBridge<Iter> {
         type Item = Iter::Item;

--- a/ext/crates/sseq/src/sseq.rs
+++ b/ext/crates/sseq/src/sseq.rs
@@ -188,7 +188,7 @@ impl<P: SseqProfile> Sseq<P> {
             );
 
             for class in self.permanent_classes[x][y].basis() {
-                differential.add(class.as_slice(), None);
+                differential.add(class, None);
             }
             self.differentials[x][y].push(differential);
         }
@@ -302,7 +302,7 @@ impl<P: SseqProfile> Sseq<P> {
                     source_dim + target_dim,
                 );
 
-                for (row, gen) in
+                for (mut row, gen) in
                     std::iter::zip(matrix.iter_mut(), self.page_data[x][y][r - 1].gens())
                 {
                     row.slice_mut(target_dim, target_dim + source_dim)
@@ -321,7 +321,7 @@ impl<P: SseqProfile> Sseq<P> {
 
                 let first_kernel_row = matrix.find_first_row_in_block(target_dim);
 
-                for row in &matrix[first_kernel_row..] {
+                for row in matrix.iter().skip(first_kernel_row) {
                     if row.is_zero() {
                         break;
                     }

--- a/ext/examples/lift_hom.rs
+++ b/ext/examples/lift_hom.rs
@@ -118,9 +118,9 @@ fn main() -> anyhow::Result<()> {
         if matrix.rows() == 0 || matrix.columns() == 0 {
             hom.extend_step(input, None);
         } else {
-            for (idx, row) in matrix.iter_mut().enumerate() {
+            for (idx, mut row) in matrix.iter_mut().enumerate() {
                 let gen = BidegreeGenerator::new(input, idx);
-                let v: Vec<u32> = query::vector(&format!("f(x_{gen}"), row.len());
+                let v: Vec<u32> = query::vector(&format!("f(x_{gen}"), row.as_slice().len());
                 for (i, &x) in v.iter().enumerate() {
                     row.set_entry(i, x);
                 }

--- a/ext/examples/mahowald_invariant.rs
+++ b/ext/examples/mahowald_invariant.rs
@@ -56,7 +56,11 @@ use ext::{
     resolution_homomorphism::{MuResolutionHomomorphism, ResolutionHomomorphism},
     utils,
 };
-use fp::{matrix::Matrix, prime::TWO, vector::FpVector};
+use fp::{
+    matrix::Matrix,
+    prime::TWO,
+    vector::{FpSlice, FpVector},
+};
 use serde_json::json;
 use sseq::coordinates::{Bidegree, BidegreeElement, BidegreeGenerator};
 
@@ -210,7 +214,8 @@ impl PKData {
 
                 if rank > 0 {
                     let kernel_subspace = matrix.compute_kernel(padded_columns);
-                    let indeterminacy_basis = kernel_subspace.basis().to_vec();
+                    let indeterminacy_basis: Vec<FpVector> =
+                        kernel_subspace.basis().map(FpSlice::to_owned).collect();
                     let image_subspace = matrix.compute_image(p_k_gens, padded_columns);
                     let quasi_inverse = matrix.compute_quasi_inverse(p_k_gens, padded_columns);
 

--- a/ext/examples/massey.rs
+++ b/ext/examples/massey.rs
@@ -85,6 +85,7 @@ fn main() -> anyhow::Result<()> {
         product.segment(1, 1).add_identity();
 
         let mut matrix = Matrix::new(p, num_gens, 1);
+        #[allow(clippy::needless_range_loop)]
         for idx in 0..num_gens {
             let hom = Arc::new(ResolutionHomomorphism::new(
                 String::new(),
@@ -93,9 +94,9 @@ fn main() -> anyhow::Result<()> {
                 c,
             ));
 
-            matrix[idx].set_entry(0, 1);
+            matrix.row_mut(idx).set_entry(0, 1);
             hom.extend_step(c, Some(&matrix));
-            matrix[idx].set_entry(0, 0);
+            matrix.row_mut(idx).set_entry(0, 0);
 
             hom.extend_through_stem(tot);
 
@@ -116,7 +117,7 @@ fn main() -> anyhow::Result<()> {
             for (k, &v) in b_class.iter().enumerate() {
                 if v != 0 {
                     let gen = BidegreeGenerator::new(b, k);
-                    hom.act(product[idx].slice_mut(0, product_num_gens), v, gen);
+                    hom.act(product.row_mut(idx).slice_mut(0, product_num_gens), v, gen);
                 }
             }
         }

--- a/ext/examples/secondary_massey.rs
+++ b/ext/examples/secondary_massey.rs
@@ -79,7 +79,7 @@ fn get_hom(
         } else {
             let v: Vec<u32> = query::vector(&format!("Input Ext class {ext_name}"), num_gens);
             for (i, &x) in v.iter().enumerate() {
-                matrix[i].set_entry(0, x);
+                matrix.row_mut(i).set_entry(0, x);
                 class.set_entry(i, x);
             }
         }
@@ -299,14 +299,14 @@ fn main() -> anyhow::Result<()> {
                         .get_map(c.s() + b.underlying().shift.s())
                         .hom_k(c.t()),
                 );
-                for (gen, out) in target_page_data
+                for (gen, mut out) in target_page_data
                     .subspace_gens()
                     .zip_eq(product_matrix.iter_mut())
                 {
                     out.slice_mut(prod_num_gens, prod_num_gens + target_num_gens)
                         .add(gen, 1);
                     for (i, v) in gen.iter_nonzero() {
-                        out.slice_mut(0, prod_num_gens).add(m0[i].as_slice(), v);
+                        out.slice_mut(0, prod_num_gens).add(m0.row(i), v);
                     }
                 }
                 product_matrix.row_reduce();
@@ -327,14 +327,14 @@ fn main() -> anyhow::Result<()> {
                     b_lambda.as_deref(),
                     Some(&unit_sseq),
                     c,
-                    e2_kernel.basis().iter().map(FpVector::as_slice),
-                    product_matrix[0..e2_ker_dim]
-                        .iter_mut()
-                        .map(|x| x.slice_mut(0, prod_all_gens)),
+                    e2_kernel.basis(),
+                    product_matrix
+                        .slice_mut(0, e2_ker_dim, 0, prod_all_gens)
+                        .iter_mut(),
                 );
-                for (v, t) in e2_kernel.basis().iter().zip(product_matrix.iter_mut()) {
+                for (v, mut t) in e2_kernel.basis().zip(product_matrix.iter_mut()) {
                     t.slice_mut(prod_all_gens, prod_all_gens + target_num_gens)
-                        .assign(v.as_slice());
+                        .assign(v);
                 }
 
                 // Now add the lambda multiples
@@ -350,10 +350,9 @@ fn main() -> anyhow::Result<()> {
                     if v >= 0 {
                         continue;
                     }
-                    let row = &mut product_matrix[e2_ker_dim + count as usize];
+                    let mut row = product_matrix.row_mut(e2_ker_dim + count as usize);
                     row.add_basis_element(prod_all_gens + target_num_gens + i, 1);
-                    row.slice_mut(prod_num_gens, prod_all_gens)
-                        .add(m[i].as_slice(), 1);
+                    row.slice_mut(prod_num_gens, prod_all_gens).add(m.row(i), 1);
                     product_lambda_page_data
                         .reduce_by_quotient(row.slice_mut(prod_num_gens, prod_all_gens));
                     count += 1;
@@ -436,10 +435,10 @@ fn main() -> anyhow::Result<()> {
                     .iter_mut()
                     .zip_eq(&m0[i])
                     .for_each(|(a, b)| *a += v * b);
-                scratch1.add(&m1[i], v);
+                scratch1.as_slice_mut().add(m1.row(i), v);
             }
             for (i, v) in gen.slice(target_num_gens, target_all_gens).iter_nonzero() {
-                scratch1.add(&mt[i], v);
+                scratch1.as_slice_mut().add(mt.row(i), v);
             }
             // Now do the -1 part of the null-homotopy of bc.
             {
@@ -455,7 +454,7 @@ fn main() -> anyhow::Result<()> {
 
             for (i, v) in scratch0.iter().enumerate() {
                 let extra = *v / p;
-                scratch1.add(&mp[i], extra % p);
+                scratch1.as_slice_mut().add(mp.row(i), extra % p);
             }
 
             print!("[{}]", scratch0.iter().map(|x| *x % p).format(", "));

--- a/ext/examples/secondary_product.rs
+++ b/ext/examples/secondary_product.rs
@@ -58,7 +58,7 @@ fn main() -> anyhow::Result<()> {
     }
     let v: Vec<u32> = query::vector("Input ext class", matrix.rows());
     for (i, &x) in v.iter().enumerate() {
-        matrix[i].set_entry(0, x);
+        matrix.row_mut(i).set_entry(0, x);
     }
 
     if !is_unit {

--- a/ext/examples/steenrod.rs
+++ b/ext/examples/steenrod.rs
@@ -155,7 +155,7 @@ fn main() -> anyhow::Result<()> {
                         m.apply(result.as_slice_mut(), 1, t, dx.as_slice());
                     }
                     assert!(d_target.apply_quasi_inverse(
-                        output_matrix[j].as_slice_mut(),
+                        output_matrix.row_mut(j),
                         t,
                         result.as_slice(),
                     ));
@@ -761,7 +761,7 @@ mod tensor_product_chain_complex {
                             .differential(self.source_s - s)
                             .apply_to_basis_element(result.as_slice_mut(), 1, right_t, ri);
                         for li in 0..source_left_dim {
-                            let row = &mut matrix[row_count + li * source_right_dim + ri];
+                            let mut row = matrix.row_mut(row_count + li * source_right_dim + ri);
                             row.slice_mut(
                                 target_offset + li * target_right_dim,
                                 target_offset + (li + 1) * target_right_dim,
@@ -799,7 +799,7 @@ mod tensor_product_chain_complex {
                             li,
                         );
                         for ri in 0..source_right_dim {
-                            let row = &mut matrix[row_count];
+                            let mut row = matrix.row_mut(row_count);
                             for (i, x) in result.iter_nonzero() {
                                 row.add_basis_element(target_offset + i * target_right_dim + ri, x);
                             }

--- a/ext/src/nassau.rs
+++ b/ext/src/nassau.rs
@@ -159,12 +159,11 @@ impl MilnorSubalgebra {
         let mut scratch = FpVector::new(p, target.dimension(target_degree));
         let mut result = Matrix::new(p, source_mask.len(), target_mask.len());
 
-        for (row, &masked_index) in std::iter::zip(result.iter_mut(), &source_mask) {
+        for (mut row, &masked_index) in std::iter::zip(result.iter_mut(), &source_mask) {
             scratch.set_to_zero();
             hom.apply_to_basis_element(scratch.as_slice_mut(), 1, degree, masked_index);
 
-            row.as_slice_mut()
-                .add_masked(scratch.as_slice(), 1, &target_mask);
+            row.add_masked(scratch.as_slice(), 1, &target_mask);
         }
         result
     }
@@ -639,11 +638,14 @@ impl<M: ZeroModule<Algebra = MilnorAlgebra>> Resolution<M> {
         let mut xs = vec![FpVector::new(p, target_dim); num_new_gens];
         let mut dxs = vec![FpVector::new(p, next.dimension(b.t())); num_new_gens];
 
-        for ((x, x_masked), dx) in xs.iter_mut().zip_eq(&n[next_row..]).zip_eq(&mut dxs) {
-            x.as_slice_mut()
-                .add_unmasked(x_masked.as_slice(), 1, &target_mask);
+        for ((x, x_masked), dx) in xs
+            .iter_mut()
+            .zip_eq(n.iter().skip(next_row))
+            .zip_eq(&mut dxs)
+        {
+            x.as_slice_mut().add_unmasked(x_masked, 1, &target_mask);
             for (i, _) in x_masked.iter_nonzero() {
-                dx.add(&full_matrix[i], 1);
+                dx.as_slice_mut().add(full_matrix.row(i), 1);
             }
         }
 
@@ -681,13 +683,13 @@ impl<M: ZeroModule<Algebra = MilnorAlgebra>> Resolution<M> {
                         continue;
                     }
                     if dx.entry(v) != 0 {
-                        scratch.add(&preimage[row], 1);
+                        scratch.as_slice_mut().add(preimage.row(row), 1);
                     }
                     row += 1;
                 }
                 for (i, _) in scratch.iter_nonzero() {
                     x.add_basis_element(target_mask[i], 1);
-                    dx.add(&full_matrix[i], 1);
+                    dx.as_slice_mut().add(full_matrix.row(i), 1);
                 }
             }
             Self::write_qi(
@@ -1114,7 +1116,7 @@ impl<M: ZeroModule<Algebra = MilnorAlgebra>> ChainComplex for Resolution<M> {
 
                 // Now reduce by these elements
                 for i in 0..dx_matrix.rows() {
-                    let masked_col = dx_matrix[i].first_nonzero().unwrap().0;
+                    let masked_col = dx_matrix.row(i).first_nonzero().unwrap().0;
                     assert_eq!(dx_matrix.pivots()[masked_col], i as isize);
                     let col = target_zero_mask[masked_col];
 

--- a/ext/src/resolution.rs
+++ b/ext/src/resolution.rs
@@ -555,7 +555,7 @@ where
             matrix.extend_column_dimension(columns + num_new_gens);
 
             for i in source_dimension..new_rows {
-                matrix.inner[i].set_entry(matrix.start[2] + i, 1);
+                matrix.inner.row_mut(i).set_entry(matrix.start[2] + i, 1);
             }
 
             // We are now supposed to row reduce the matrix. However, running the full row
@@ -598,7 +598,7 @@ where
 
             for old_col in 0..matrix.columns() {
                 if old_col == next_new_col {
-                    matrix[next_old_row..=source_dimension + next_new_row].rotate_right(1);
+                    matrix.rotate_down(next_old_row..source_dimension + next_new_row + 1, 1);
                     matrix.pivots_mut()[old_col] = next_old_row as isize;
                     match new_gens.next() {
                         Some((x, y)) => {

--- a/ext/src/resolution_homomorphism.rs
+++ b/ext/src/resolution_homomorphism.rs
@@ -363,7 +363,7 @@ where
 
         let mut matrix = Matrix::new(result.source.prime(), num_gens, 1);
         for (k, &v) in class.iter().enumerate() {
-            matrix[k].set_entry(0, v);
+            matrix.row_mut(k).set_entry(0, v);
         }
 
         result.extend_step(shift, Some(&matrix));
@@ -396,7 +396,7 @@ where
                     assert!(chain_map.apply_quasi_inverse(
                         output_vec.as_slice_mut(),
                         output.t(),
-                        input.as_slice(),
+                        input,
                     ));
                 }
                 outputs

--- a/ext/src/secondary.rs
+++ b/ext/src/secondary.rs
@@ -1039,14 +1039,14 @@ where
                     .zip_eq(&m0[i])
                     .for_each(|(a, b)| *a += v * b * sign);
                 out.slice_mut(source_num_gens, source_num_gens + lambda_num_gens)
-                    .add(m1[i].as_slice(), (v * sign) % p);
+                    .add(m1.row(i), (v * sign) % p);
             }
             for (i, v) in scratch0.iter().enumerate() {
                 out.add_basis_element(i, *v % p);
 
                 let extra = *v / p;
                 out.slice_mut(source_num_gens, source_num_gens + lambda_num_gens)
-                    .add(mp[i].as_slice(), (extra * filtration_one_sign) % p);
+                    .add(mp.row(i), (extra * filtration_one_sign) % p);
             }
             if let Some(page_data) = page_data {
                 page_data.reduce_by_quotient(

--- a/ext/src/utils.rs
+++ b/ext/src/utils.rs
@@ -250,7 +250,7 @@ where
                 .number_of_gens_in_degree(cofiber.t()),
             1,
         );
-        new_output[cofiber.idx()].set_entry(0, 1);
+        new_output.row_mut(cofiber.idx()).set_entry(0, 1);
 
         map.add_generators_from_matrix_rows(cofiber.t(), new_output.as_slice_mut());
         map.extend_by_zero((max_degree + cofiber.degree()).t());

--- a/ext/src/yoneda.rs
+++ b/ext/src/yoneda.rs
@@ -251,10 +251,10 @@ where
                     let mut differentials =
                         Matrix::new(p, prev.dimension(t), curr.module.dimension(t));
 
-                    for (i, row) in differentials.iter_mut().enumerate() {
+                    for (i, mut row) in differentials.iter_mut().enumerate() {
                         let j = prev.basis_list[t][i];
-                        d.apply_to_basis_element(row.as_slice_mut(), 1, t, j);
-                        curr.reduce(t, row.as_slice_mut());
+                        d.apply_to_basis_element(row.copy(), 1, t, j);
+                        curr.reduce(t, row);
                     }
 
                     let mut result = Subspace::from_matrix(differentials);
@@ -345,8 +345,8 @@ where
                     source.quotient_basis_elements(t, start..end);
 
                     let needs_to_revert = diff_im.update_then_row_reduce(|diff_im_matrix| {
-                        for row in diff_im_matrix.iter_mut() {
-                            source.reduce(t, row.as_slice_mut());
+                        for mut row in diff_im_matrix.iter_mut() {
+                            source.reduce(t, row.copy());
                             if row.as_slice().is_zero() {
                                 return true;
                             }
@@ -459,16 +459,18 @@ where
                 images.find_pivots_permutation(pivot_columns.iter().map(|(_, i)| *i)),
             );
 
-            let mut source_iter =
-                std::iter::zip(&matrix, orig_pivot_columns.iter()).filter_map(|(row, col)| {
+            let get_source_iter = || {
+                std::iter::zip(matrix.iter(), orig_pivot_columns.iter()).filter_map(|(row, col)| {
                     if chosen_cols.contains(col) {
                         None
                     } else {
-                        Some(row.as_slice())
+                        Some(row)
                     }
-                });
+                })
+            };
+            let mut source_iter = get_source_iter();
+            let mut source_iter2 = get_source_iter();
 
-            let mut source_iter2 = source_iter.clone();
             source.quotient_vectors(t, |mut row| {
                 row.add(source_iter.next()?, 1);
                 Some(())
@@ -611,7 +613,7 @@ where
     let matrix = matrix.into_tail_segment(first_kernel_row, source_dimension, 1);
 
     let mut image_matrix = Matrix::new(p, image_rows, source_orig_dimension);
-    for (target, source) in std::iter::zip(
+    for (mut target, source) in std::iter::zip(
         image_matrix.iter_mut(),
         matrix.iter().skip(first_image_row - first_kernel_row),
     ) {

--- a/web_ext/sseq_gui/src/resolution_wrapper.rs
+++ b/web_ext/sseq_gui/src/resolution_wrapper.rs
@@ -116,9 +116,9 @@ impl Resolution<ext::CCC> {
                 let rows = json_map_data.len();
                 let cols = json_map_data[0].len();
                 let mut map_data = Matrix::new(result.prime(), rows, cols);
-                for r in 0..rows {
-                    for c in 0..cols {
-                        map_data.row_mut(r).set_entry(c, json_map_data[r][c]);
+                for (r, row) in json_map_data.iter().enumerate() {
+                    for (c, value) in row.iter().enumerate() {
+                        map_data.row_mut(r).set_entry(c, *value);
                     }
                 }
                 result.add_self_map(self_map_deg, name, map_data);

--- a/web_ext/sseq_gui/src/resolution_wrapper.rs
+++ b/web_ext/sseq_gui/src/resolution_wrapper.rs
@@ -118,7 +118,7 @@ impl Resolution<ext::CCC> {
                 let mut map_data = Matrix::new(result.prime(), rows, cols);
                 for r in 0..rows {
                     for c in 0..cols {
-                        map_data[r].set_entry(c, json_map_data[r][c]);
+                        map_data.row_mut(r).set_entry(c, json_map_data[r][c]);
                     }
                 }
                 result.add_self_map(self_map_deg, name, map_data);
@@ -355,9 +355,9 @@ impl<CC: ChainComplex> Resolution<CC> {
                     Arc::clone(&self.unit_resolution().inner),
                     b,
                 );
-                unit_vector[j].set_entry(0, 1);
+                unit_vector.row_mut(j).set_entry(0, 1);
                 f.extend_step(b, Some(&unit_vector));
-                unit_vector[j].set_to_zero();
+                unit_vector.row_mut(j).set_to_zero();
                 maps.push(f);
             }
         }

--- a/web_ext/sseq_gui/src/sseq.rs
+++ b/web_ext/sseq_gui/src/sseq.rs
@@ -255,11 +255,11 @@ impl<P: SseqProfile> SseqWrapper<P> {
                 .map(|m| m.get(y - prod_y))
             {
                 for i in 0..matrix.rows() {
-                    if matrix[i].is_zero() {
+                    if matrix.row(i).is_zero() {
                         continue;
                     }
                     decompositions.push((
-                        matrix[i].clone(),
+                        matrix.row(i).to_owned(),
                         format!("{name} {}", self.class_names[x - prod_x][y - prod_y][i]),
                         prod_x,
                         prod_y,
@@ -275,7 +275,12 @@ impl<P: SseqProfile> SseqWrapper<P> {
                 x,
                 y,
                 state,
-                permanents: self.inner.permanent_classes(x, y).basis().to_vec(),
+                permanents: self
+                    .inner
+                    .permanent_classes(x, y)
+                    .basis()
+                    .map(FpSlice::to_owned)
+                    .collect(),
                 class_names: self.class_names[x][y].clone(),
                 decompositions,
                 classes: self
@@ -450,7 +455,12 @@ impl<P: SseqProfile> SseqWrapper<P> {
             }
         }
 
-        let permanent_classes = self.inner.permanent_classes(x, y).basis().to_vec();
+        let permanent_classes = self
+            .inner
+            .permanent_classes(x, y)
+            .basis()
+            .map(FpSlice::to_owned)
+            .collect::<Vec<_>>();
         for class in permanent_classes {
             self.inner
                 .leibniz(i32::MAX, x, y, class.as_slice(), &product.inner, target);


### PR DESCRIPTION
This improves cache locality and may allow the compiler to apply some new optimizations. This also lays the groundwork for more elaborate row-reduction algorithms in the future.