### PR TITLE
Update main function in resolve.rs

### DIFF
--- a/ext/examples/resolve.rs
+++ b/ext/examples/resolve.rs
@@ -14,8 +14,9 @@
 //! ·
 //! ```
 
-use ext::chain_complex::{ChainComplex, FreeChainComplex};
+use ext::chain_complex::{ChainComplex};
 use sseq::coordinates::Bidegree;
+use algebra::module::Module;
 
 fn main() -> anyhow::Result<()> {
     ext::utils::init_logging()?;
@@ -28,6 +29,16 @@ fn main() -> anyhow::Result<()> {
     );
     res.compute_through_bidegree(max);
 
-    println!("{}", res.graded_dimension_string());
+    println!("E2 page:");
+    for s in 0..=max.s() {
+        for t in s..=max.t() {
+            let dim = res.module(s).dimension(t);
+            if dim > 0 {
+                println!("({},{}): Z/2Z^{}", s, t, dim);
+            }
+        }
+    }
+
+    // println!("{}", res.graded_dimension_string());
     Ok(())
 }


### PR DESCRIPTION
Refactor main function to improve output of E2 page dimensions to use Python parser to avoid python_ext usage [I read the output with my python script].  

Please disregard the PR if you plan to use python_ext or it doesn't align with the coding style of the repo

Removed FreeChainComplex because **warning: unused import: `FreeChainComplex`**