### PR TITLE
Unify vector-like structs

### DIFF
--- a/ext/crates/fp/src/matrix/matrix_inner.rs
+++ b/ext/crates/fp/src/matrix/matrix_inner.rs
@@ -367,12 +367,12 @@ impl Matrix {
 
     pub fn row(&self, row: usize) -> FpSlice<'_> {
         let limb_range = row_to_limb_range(row, self.stride);
-        FpSlice::new(self.prime(), &self.data[limb_range], 0, self.columns)
+        FpSlice::_new(self.prime(), &self.data[limb_range], 0, self.columns)
     }
 
     pub fn row_mut(&mut self, row: usize) -> FpSliceMut<'_> {
         let limb_range = row_to_limb_range(row, self.stride);
-        FpSliceMut::new(self.prime(), &mut self.data[limb_range], 0, self.columns)
+        FpSliceMut::_new(self.prime(), &mut self.data[limb_range], 0, self.columns)
     }
 }
 
@@ -393,7 +393,7 @@ impl Matrix {
                 .data
                 .chunks_mut(self.stride)
                 .take(logical_rows) // Only iterate over logical rows
-                .map(move |row| FpSliceMut::new(p, row, 0, columns));
+                .map(move |row| FpSliceMut::_new(p, row, 0, columns));
             Either::Right(rows)
         }
     }
@@ -412,7 +412,7 @@ impl Matrix {
                 .data
                 .maybe_par_chunks_mut(self.stride)
                 .take(logical_rows) // Only iterate over logical rows
-                .map(move |row| FpSliceMut::new(p, row, 0, columns));
+                .map(move |row| FpSliceMut::_new(p, row, 0, columns));
             Either::Right(rows)
         }
     }
@@ -516,8 +516,8 @@ impl Matrix {
         let row1 = unsafe { std::slice::from_raw_parts_mut(ptr.add(i * self.stride), self.stride) };
         let row2 = unsafe { std::slice::from_raw_parts_mut(ptr.add(j * self.stride), self.stride) };
         (
-            FpSliceMut::new(self.prime(), row1, 0, self.columns),
-            FpSliceMut::new(self.prime(), row2, 0, self.columns),
+            FpSliceMut::_new(self.prime(), row1, 0, self.columns),
+            FpSliceMut::_new(self.prime(), row2, 0, self.columns),
         )
     }
 
@@ -1263,7 +1263,7 @@ impl<const N: usize> AugmentedMatrix<N> {
         let start_idx = self.start[start];
         let end_idx = self.end[end];
         let limb_range = row_to_limb_range(i, self.stride);
-        FpSliceMut::new(self.prime(), &mut self.data[limb_range], start_idx, end_idx)
+        FpSliceMut::_new(self.prime(), &mut self.data[limb_range], start_idx, end_idx)
     }
 
     pub fn row_segment(&self, i: usize, start: usize, end: usize) -> FpSlice<'_> {
@@ -1414,7 +1414,7 @@ impl<'a> MatrixSliceMut<'a> {
         let end = self.col_end;
         (0..self.rows).map(move |row_idx| {
             let limb_range = row_to_limb_range(row_idx, self.stride);
-            FpSlice::new(self.prime(), &self.data[limb_range], start, end)
+            FpSlice::_new(self.prime(), &self.data[limb_range], start, end)
         })
     }
 
@@ -1429,7 +1429,7 @@ impl<'a> MatrixSliceMut<'a> {
             let rows = self
                 .data
                 .chunks_mut(self.stride)
-                .map(move |row| FpSliceMut::new(p, row, start, end));
+                .map(move |row| FpSliceMut::_new(p, row, start, end));
             Either::Right(rows)
         }
     }
@@ -1447,14 +1447,14 @@ impl<'a> MatrixSliceMut<'a> {
             let rows = self
                 .data
                 .maybe_par_chunks_mut(self.stride)
-                .map(move |row| FpSliceMut::new(p, row, start, end));
+                .map(move |row| FpSliceMut::_new(p, row, start, end));
             Either::Right(rows)
         }
     }
 
     pub fn row(&mut self, row: usize) -> FpSlice<'_> {
         let limb_range = row_to_limb_range(row, self.stride);
-        FpSlice::new(
+        FpSlice::_new(
             self.prime(),
             &self.data[limb_range],
             self.col_start,
@@ -1464,7 +1464,7 @@ impl<'a> MatrixSliceMut<'a> {
 
     pub fn row_mut(&mut self, row: usize) -> FpSliceMut<'_> {
         let limb_range = row_to_limb_range(row, self.stride);
-        FpSliceMut::new(
+        FpSliceMut::_new(
             self.prime(),
             &mut self.data[limb_range],
             self.col_start,

--- a/ext/crates/fp/src/vector/fp_wrapper/helpers.rs
+++ b/ext/crates/fp/src/vector/fp_wrapper/helpers.rs
@@ -16,6 +16,7 @@ use itertools::Itertools;
 
 use super::{
     FqSlice, FqSliceMut, FqVector, FqVectorBase, FqVectorIterator, FqVectorNonZeroIterator, Repr,
+    ReprMut,
 };
 use crate::field::Field;
 
@@ -25,7 +26,7 @@ impl<const A: bool, R: Repr, F: Field> FqVectorBase<A, R, F> {
     }
 }
 
-impl<F: Field> FqVector<F> {
+impl<const A: bool, R: ReprMut, F: Field> FqVectorBase<A, R, F> {
     pub(super) fn scale_helper(&mut self, c: F::ElementContainer) {
         self.scale(self.fq().el(c))
     }
@@ -34,21 +35,14 @@ impl<F: Field> FqVector<F> {
         self.set_entry(index, self.fq().el(value))
     }
 
-    pub(super) fn add_helper(&mut self, other: &Self, c: F::ElementContainer) {
-        self.add(other, self.fq().el(c))
-    }
-
-    pub(super) fn add_offset_helper(
-        &mut self,
-        other: &Self,
-        c: F::ElementContainer,
-        offset: usize,
-    ) {
-        self.add_offset(other, self.fq().el(c), offset)
-    }
-
     pub(super) fn add_basis_element_helper(&mut self, index: usize, value: F::ElementContainer) {
         self.add_basis_element(index, self.fq().el(value))
+    }
+}
+
+impl<F: Field> FqVector<F> {
+    pub(super) fn add_helper(&mut self, other: &Self, c: F::ElementContainer) {
+        self.add(other, self.fq().el(c))
     }
 
     pub(super) fn copy_from_slice_helper(&mut self, other: &[F::ElementContainer]) {
@@ -75,6 +69,15 @@ impl<F: Field> FqVector<F> {
         self.add_carry(other, self.fq().el(c), rest)
     }
 
+    pub(super) fn add_offset_helper(
+        &mut self,
+        other: &Self,
+        c: F::ElementContainer,
+        offset: usize,
+    ) {
+        self.add_offset(other, self.fq().el(c), offset)
+    }
+
     pub(super) fn first_nonzero_helper(&self) -> Option<(usize, F::ElementContainer)> {
         self.first_nonzero().map(|(idx, c)| (idx, c.val()))
     }
@@ -87,10 +90,6 @@ impl<F: Field> FqSlice<'_, F> {
 }
 
 impl<F: Field> FqSliceMut<'_, F> {
-    pub(super) fn scale_helper(&mut self, c: F::ElementContainer) {
-        self.scale(self.fq().el(c))
-    }
-
     pub(super) fn add_helper(&mut self, other: FqSlice<F>, c: F::ElementContainer) {
         self.add(other, self.fq().el(c))
     }
@@ -102,14 +101,6 @@ impl<F: Field> FqSliceMut<'_, F> {
         offset: usize,
     ) {
         self.add_offset(other, self.fq().el(c), offset)
-    }
-
-    pub(super) fn set_entry_helper(&mut self, index: usize, value: F::ElementContainer) {
-        self.set_entry(index, self.fq().el(value))
-    }
-
-    pub(super) fn add_basis_element_helper(&mut self, index: usize, value: F::ElementContainer) {
-        self.add_basis_element(index, self.fq().el(value))
     }
 
     pub(super) fn add_masked_helper(

--- a/ext/crates/fp/src/vector/fp_wrapper/helpers.rs
+++ b/ext/crates/fp/src/vector/fp_wrapper/helpers.rs
@@ -14,16 +14,20 @@
 
 use itertools::Itertools;
 
-use super::{FqSlice, FqSliceMut, FqVector, FqVectorIterator, FqVectorNonZeroIterator};
+use super::{
+    FqSlice, FqSliceMut, FqVector, FqVectorBase, FqVectorIterator, FqVectorNonZeroIterator, Repr,
+};
 use crate::field::Field;
+
+impl<const A: bool, R: Repr, F: Field> FqVectorBase<A, R, F> {
+    pub(super) fn entry_helper(&self, index: usize) -> F::ElementContainer {
+        self.entry(index).val()
+    }
+}
 
 impl<F: Field> FqVector<F> {
     pub(super) fn scale_helper(&mut self, c: F::ElementContainer) {
         self.scale(self.fq().el(c))
-    }
-
-    pub(super) fn entry_helper(&self, index: usize) -> F::ElementContainer {
-        self.entry(index).val()
     }
 
     pub(super) fn set_entry_helper(&mut self, index: usize, value: F::ElementContainer) {
@@ -77,10 +81,6 @@ impl<F: Field> FqVector<F> {
 }
 
 impl<F: Field> FqSlice<'_, F> {
-    pub(super) fn entry_helper(&self, index: usize) -> F::ElementContainer {
-        self.entry(index).val()
-    }
-
     pub(super) fn first_nonzero_helper(&self) -> Option<(usize, F::ElementContainer)> {
         self.first_nonzero().map(|(idx, c)| (idx, c.val()))
     }

--- a/ext/crates/fp/src/vector/fp_wrapper/mod.rs
+++ b/ext/crates/fp/src/vector/fp_wrapper/mod.rs
@@ -257,33 +257,15 @@ impl<'de> Deserialize<'de> for FpVector {
     }
 }
 
-impl<'a, 'b> From<&'a mut FpSliceMut<'b>> for FpSliceMut<'a> {
-    fn from(slice: &'a mut FpSliceMut<'b>) -> Self {
-        slice.copy()
+impl<'a, const A: bool, R: Repr> From<&'a FpVectorBase<A, R>> for FpSlice<'a> {
+    fn from(value: &'a FpVectorBase<A, R>) -> Self {
+        value.as_slice()
     }
 }
 
-impl<'a, 'b> From<&'a FpSlice<'b>> for FpSlice<'a> {
-    fn from(slice: &'a FpSlice<'b>) -> Self {
-        *slice
-    }
-}
-
-impl<'a, 'b> From<&'a FpSliceMut<'b>> for FpSlice<'a> {
-    fn from(slice: &'a FpSliceMut<'b>) -> Self {
-        slice.as_slice()
-    }
-}
-
-impl<'a> From<&'a FpVector> for FpSlice<'a> {
-    fn from(v: &'a FpVector) -> Self {
-        v.as_slice()
-    }
-}
-
-impl<'a> From<&'a mut FpVector> for FpSliceMut<'a> {
-    fn from(v: &'a mut FpVector) -> Self {
-        v.as_slice_mut()
+impl<'a, const A: bool, R: ReprMut> From<&'a mut FpVectorBase<A, R>> for FpSliceMut<'a> {
+    fn from(value: &'a mut FpVectorBase<A, R>) -> Self {
+        value.as_slice_mut()
     }
 }
 

--- a/ext/crates/fp/src/vector/fp_wrapper/mod.rs
+++ b/ext/crates/fp/src/vector/fp_wrapper/mod.rs
@@ -18,7 +18,7 @@ use itertools::Itertools;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use super::{
-    FqSlice, FqSliceMut, FqVector, FqVectorBase, Repr,
+    FqSlice, FqSliceMut, FqVector, FqVectorBase, Repr, ReprMut,
     iter::{FqVectorIterator, FqVectorNonZeroIterator},
 };
 use crate::{
@@ -88,20 +88,27 @@ impl<const A: bool, R: Repr> FpVectorBase<A, R> {
     }
 }
 
+impl<const A: bool, R: ReprMut> FpVectorBase<A, R> {
+    dispatch_vector! {
+        pub fn slice_mut(&mut self, start: usize, end: usize) -> (dispatch FpSliceMut<'_>);
+        pub fn as_slice_mut(&mut self) -> (dispatch FpSliceMut<'_>);
+        pub fn set_to_zero(&mut self);
+        pub fn @scale(&mut self, c: u32);
+        pub fn @set_entry(&mut self, index: usize, value: u32);
+        pub fn @add_basis_element(&mut self, index: usize, value: u32);
+
+        pub(crate) fn limbs_mut(&mut self) -> (&mut [Limb]);
+    }
+}
+
 impl FpVector {
     dispatch_vector! {
-        pub fn @scale(&mut self, c: u32);
-        pub fn set_to_zero(&mut self);
-        pub fn @set_entry(&mut self, index: usize, value: u32);
         pub fn assign(&mut self, other: &Self);
         pub fn assign_partial(&mut self, other: &Self);
         pub fn @add(&mut self, other: &Self, c: u32);
         pub fn @add_offset(&mut self, other: &Self, c: u32, offset: usize);
-        pub fn slice_mut(&mut self, start: usize, end: usize) -> (dispatch FpSliceMut<'_>);
-        pub fn as_slice_mut(&mut self) -> (dispatch FpSliceMut<'_>);
         pub fn extend_len(&mut self, dim: usize);
         pub fn set_scratch_vector_size(&mut self, dim: usize);
-        pub fn @add_basis_element(&mut self, index: usize, value: u32);
         pub fn @copy_from_slice(&mut self, slice: &[u32]);
         pub fn @add_truncate(&mut self, other: &Self, c: u32) -> (Option<()>);
         pub fn sign_rule(&self, other: &Self) -> bool;
@@ -146,21 +153,14 @@ impl<'a> FpSlice<'a> {
 impl<'a> FpSliceMut<'a> {
     dispatch_vector! {
         pub(crate) fn _new<P: Prime>(p: P, limbs: &'a mut [Limb], start: usize, end: usize) -> (from FqSliceMut);
-        pub fn @scale(&mut self, c: u32);
-        pub fn set_to_zero(&mut self);
         pub fn @add(&mut self, other: FpSlice, c: u32);
         pub fn @add_offset(&mut self, other: FpSlice, c: u32, offset: usize);
         pub fn assign(&mut self, other: FpSlice);
         pub fn shl_assign(&mut self, shift: usize);
-        pub fn @set_entry(&mut self, index: usize, value: u32);
-        pub fn slice_mut(&mut self, start: usize, end: usize) -> (dispatch FpSliceMut<'_>);
-        pub fn @add_basis_element(&mut self, index: usize, value: u32);
         pub fn copy(&mut self) -> (dispatch FpSliceMut<'_>);
         pub fn @add_masked(&mut self, other: FpSlice, c: u32, mask: &[usize]);
         pub fn @add_unmasked(&mut self, other: FpSlice, c: u32, mask: &[usize]);
         pub fn @add_tensor(&mut self, offset: usize, coeff: u32, @left: FpSlice, right: FpSlice);
-
-        pub(crate) fn limbs_mut(&mut self) -> (&mut [Limb]);
     }
 }
 

--- a/ext/crates/fp/src/vector/fp_wrapper/mod.rs
+++ b/ext/crates/fp/src/vector/fp_wrapper/mod.rs
@@ -131,7 +131,7 @@ impl<'a> FpSlice<'a> {
         pub fn is_empty(&self) -> bool;
         pub fn @entry(&self, index: usize) -> u32;
         pub fn iter(&self) -> (dispatch FpVectorIterator<'_>);
-        pub fn iter_nonzero(self) -> (dispatch FpVectorNonZeroIterator<'a>);
+        pub fn iter_nonzero(&self) -> (dispatch FpVectorNonZeroIterator<'_>);
         pub fn @first_nonzero(&self) -> (Option<(usize, u32)>);
         pub fn is_zero(&self) -> bool;
         pub fn restrict(self, start: usize, end: usize) -> (dispatch FpSlice<'a>);

--- a/ext/crates/fp/src/vector/fp_wrapper/mod.rs
+++ b/ext/crates/fp/src/vector/fp_wrapper/mod.rs
@@ -125,7 +125,7 @@ impl FpVector {
 
 impl<'a> FpSlice<'a> {
     dispatch_vector! {
-        pub(crate) fn new<P: Prime>(p: P, limbs: &'a [Limb], start: usize, end: usize) -> (from FqSlice);
+        pub(crate) fn _new<P: Prime>(p: P, limbs: &'a [Limb], start: usize, end: usize) -> (from FqSlice);
         pub fn prime(&self) -> ValidPrime;
         pub fn len(&self) -> usize;
         pub fn is_empty(&self) -> bool;
@@ -143,7 +143,7 @@ impl<'a> FpSlice<'a> {
 
 impl<'a> FpSliceMut<'a> {
     dispatch_vector! {
-        pub(crate) fn new<P: Prime>(p: P, limbs: &'a mut [Limb], start: usize, end: usize) -> (from FqSliceMut);
+        pub(crate) fn _new<P: Prime>(p: P, limbs: &'a mut [Limb], start: usize, end: usize) -> (from FqSliceMut);
         pub fn prime(&self) -> ValidPrime;
         pub fn @scale(&mut self, c: u32);
         pub fn set_to_zero(&mut self);

--- a/ext/crates/fp/src/vector/fp_wrapper/mod.rs
+++ b/ext/crates/fp/src/vector/fp_wrapper/mod.rs
@@ -192,8 +192,8 @@ impl<const A: bool, R: Repr> std::fmt::Display for FpVectorBase<A, R> {
     }
 }
 
-impl From<&FpVector> for Vec<u32> {
-    fn from(v: &FpVector) -> Self {
+impl<const A: bool, R: Repr> From<&FpVectorBase<A, R>> for Vec<u32> {
+    fn from(v: &FpVectorBase<A, R>) -> Self {
         v.iter().collect()
     }
 }

--- a/ext/crates/fp/src/vector/fp_wrapper/mod.rs
+++ b/ext/crates/fp/src/vector/fp_wrapper/mod.rs
@@ -45,20 +45,17 @@ use macros_2::{dispatch_struct, dispatch_vector, impl_try_into, use_primes};
 
 use_primes!();
 
-cfg_if::cfg_if! {
-    if #[cfg(feature = "odd-primes")] {
-        #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-        pub enum FpVectorBase<const A: bool, R> {
-            _2(FqVectorBase<A, R, Fp<P2>>),
-            _3(FqVectorBase<A, R, Fp<P3>>),
-            _5(FqVectorBase<A, R, Fp<P5>>),
-            _7(FqVectorBase<A, R, Fp<P7>>),
-            Big(FqVectorBase<A, R, Fp<ValidPrime>>),
-        }
-    } else {
-        #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-        pub struct FpVectorBase<const A: bool, R>(FqVectorBase<A, R, Fp<P2>>);
-    }
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub enum FpVectorBase<const A: bool, R> {
+    _2(FqVectorBase<A, R, Fp<P2>>),
+    #[cfg(feature = "odd-primes")]
+    _3(FqVectorBase<A, R, Fp<P3>>),
+    #[cfg(feature = "odd-primes")]
+    _5(FqVectorBase<A, R, Fp<P5>>),
+    #[cfg(feature = "odd-primes")]
+    _7(FqVectorBase<A, R, Fp<P7>>),
+    #[cfg(feature = "odd-primes")]
+    Big(FqVectorBase<A, R, Fp<ValidPrime>>),
 }
 
 pub type FpVector = FpVectorBase<true, Vec<Limb>>;

--- a/ext/crates/fp/src/vector/fp_wrapper/mod.rs
+++ b/ext/crates/fp/src/vector/fp_wrapper/mod.rs
@@ -48,7 +48,7 @@ use_primes!();
 cfg_if::cfg_if! {
     if #[cfg(feature = "odd-primes")] {
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-        pub enum FpVectorBase<const A: bool, R: Repr> {
+        pub enum FpVectorBase<const A: bool, R> {
             _2(FqVectorBase<A, R, Fp<P2>>),
             _3(FqVectorBase<A, R, Fp<P3>>),
             _5(FqVectorBase<A, R, Fp<P5>>),
@@ -56,6 +56,7 @@ cfg_if::cfg_if! {
             Big(FqVectorBase<A, R, Fp<ValidPrime>>),
         }
     } else {
+        #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub struct FpVectorBase<const A: bool, R>(FqVectorBase<A, R, Fp<P2>>);
     }
 }

--- a/ext/crates/fp/src/vector/fp_wrapper/mod.rs
+++ b/ext/crates/fp/src/vector/fp_wrapper/mod.rs
@@ -170,13 +170,7 @@ impl FpVectorIterator<'_> {
     }
 }
 
-impl std::fmt::Display for FpVector {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        self.as_slice().fmt(f)
-    }
-}
-
-impl std::fmt::Display for FpSlice<'_> {
+impl<const A: bool, R: Repr> std::fmt::Display for FpVectorBase<A, R> {
     /// # Example
     /// ```
     /// # use fp::vector::FpVector;

--- a/ext/crates/fp/src/vector/fp_wrapper/mod.rs
+++ b/ext/crates/fp/src/vector/fp_wrapper/mod.rs
@@ -72,26 +72,33 @@ dispatch_struct! {
     pub FpVectorNonZeroIterator<'a> from FqVectorNonZeroIterator
 }
 
-impl FpVector {
+impl<const A: bool, R: Repr> FpVectorBase<A, R> {
     dispatch_vector! {
         pub fn prime(&self) -> ValidPrime;
         pub fn len(&self) -> usize;
         pub fn is_empty(&self) -> bool;
+        pub fn slice(&self, start: usize, end: usize) -> (dispatch FpSlice<'_>);
+        pub fn as_slice(&self) -> (dispatch FpSlice<'_>);
+        pub fn iter(&self) -> (dispatch FpVectorIterator<'_>);
+        pub fn iter_nonzero(&self) -> (dispatch FpVectorNonZeroIterator<'_>);
+        pub fn is_zero(&self) -> bool;
+        pub fn @entry(&self, index: usize) -> u32;
+
+        pub(crate) fn limbs(&self) -> (&[Limb]);
+    }
+}
+
+impl FpVector {
+    dispatch_vector! {
         pub fn @scale(&mut self, c: u32);
         pub fn set_to_zero(&mut self);
-        pub fn @entry(&self, index: usize) -> u32;
         pub fn @set_entry(&mut self, index: usize, value: u32);
         pub fn assign(&mut self, other: &Self);
         pub fn assign_partial(&mut self, other: &Self);
         pub fn @add(&mut self, other: &Self, c: u32);
         pub fn @add_offset(&mut self, other: &Self, c: u32, offset: usize);
-        pub fn slice(&self, start: usize, end: usize) -> (dispatch FpSlice<'_>);
-        pub fn as_slice(&self) -> (dispatch FpSlice<'_>);
         pub fn slice_mut(&mut self, start: usize, end: usize) -> (dispatch FpSliceMut<'_>);
         pub fn as_slice_mut(&mut self) -> (dispatch FpSliceMut<'_>);
-        pub fn is_zero(&self) -> bool;
-        pub fn iter(&self) -> (dispatch FpVectorIterator<'_>);
-        pub fn iter_nonzero(&self) -> (dispatch FpVectorNonZeroIterator<'_>);
         pub fn extend_len(&mut self, dim: usize);
         pub fn set_scratch_vector_size(&mut self, dim: usize);
         pub fn @add_basis_element(&mut self, index: usize, value: u32);
@@ -101,8 +108,6 @@ impl FpVector {
         pub fn @add_carry(&mut self, other: &Self, c: u32, rest: &mut [Self]) -> bool;
         pub fn @first_nonzero(&self) -> (Option<(usize, u32)>);
         pub fn density(&self) -> f32;
-
-        pub(crate) fn limbs(&self) -> (&[Limb]);
 
         pub fn new<P: Prime>(p: P, len: usize) -> (from FqVector);
         pub fn new_with_capacity<P: Prime>(p: P, len: usize, capacity: usize) -> (from FqVector);
@@ -132,25 +137,15 @@ impl FpVector {
 impl<'a> FpSlice<'a> {
     dispatch_vector! {
         pub(crate) fn _new<P: Prime>(p: P, limbs: &'a [Limb], start: usize, end: usize) -> (from FqSlice);
-        pub fn prime(&self) -> ValidPrime;
-        pub fn len(&self) -> usize;
-        pub fn is_empty(&self) -> bool;
-        pub fn @entry(&self, index: usize) -> u32;
-        pub fn iter(&self) -> (dispatch FpVectorIterator<'_>);
-        pub fn iter_nonzero(&self) -> (dispatch FpVectorNonZeroIterator<'_>);
         pub fn @first_nonzero(&self) -> (Option<(usize, u32)>);
-        pub fn is_zero(&self) -> bool;
         pub fn restrict(self, start: usize, end: usize) -> (dispatch FpSlice<'a>);
         pub fn to_owned(self) -> (dispatch FpVector);
-
-        pub(crate) fn limbs(&self) -> (&[Limb]);
     }
 }
 
 impl<'a> FpSliceMut<'a> {
     dispatch_vector! {
         pub(crate) fn _new<P: Prime>(p: P, limbs: &'a mut [Limb], start: usize, end: usize) -> (from FqSliceMut);
-        pub fn prime(&self) -> ValidPrime;
         pub fn @scale(&mut self, c: u32);
         pub fn set_to_zero(&mut self);
         pub fn @add(&mut self, other: FpSlice, c: u32);
@@ -158,7 +153,6 @@ impl<'a> FpSliceMut<'a> {
         pub fn assign(&mut self, other: FpSlice);
         pub fn shl_assign(&mut self, shift: usize);
         pub fn @set_entry(&mut self, index: usize, value: u32);
-        pub fn as_slice(&self) -> (dispatch FpSlice<'_>);
         pub fn slice_mut(&mut self, start: usize, end: usize) -> (dispatch FpSliceMut<'_>);
         pub fn @add_basis_element(&mut self, index: usize, value: u32);
         pub fn copy(&mut self) -> (dispatch FpSliceMut<'_>);
@@ -166,7 +160,6 @@ impl<'a> FpSliceMut<'a> {
         pub fn @add_unmasked(&mut self, other: FpSlice, c: u32, mask: &[usize]);
         pub fn @add_tensor(&mut self, offset: usize, coeff: u32, @left: FpSlice, right: FpSlice);
 
-        pub(crate) fn limbs(&self) -> (&[Limb]);
         pub(crate) fn limbs_mut(&mut self) -> (&mut [Limb]);
     }
 }

--- a/ext/crates/fp/src/vector/fp_wrapper/mod.rs
+++ b/ext/crates/fp/src/vector/fp_wrapper/mod.rs
@@ -130,7 +130,7 @@ impl<'a> FpSlice<'a> {
         pub fn len(&self) -> usize;
         pub fn is_empty(&self) -> bool;
         pub fn @entry(&self, index: usize) -> u32;
-        pub fn iter(self) -> (dispatch FpVectorIterator<'a>);
+        pub fn iter(&self) -> (dispatch FpVectorIterator<'_>);
         pub fn iter_nonzero(self) -> (dispatch FpVectorNonZeroIterator<'a>);
         pub fn @first_nonzero(&self) -> (Option<(usize, u32)>);
         pub fn is_zero(&self) -> bool;

--- a/ext/crates/fp/src/vector/impl_fqslice.rs
+++ b/ext/crates/fp/src/vector/impl_fqslice.rs
@@ -18,14 +18,6 @@ impl<'a, F: Field> FqSlice<'a, F> {
         self.fq().characteristic().to_dyn()
     }
 
-    pub fn len(&self) -> usize {
-        self.end() - self.start()
-    }
-
-    pub const fn is_empty(&self) -> bool {
-        self.start() == self.end()
-    }
-
     pub fn entry(&self, index: usize) -> FieldElement<F> {
         debug_assert!(
             index < self.len(),

--- a/ext/crates/fp/src/vector/impl_fqslice.rs
+++ b/ext/crates/fp/src/vector/impl_fqslice.rs
@@ -8,16 +8,11 @@ use crate::{
     constants,
     field::{Field, element::FieldElement},
     limb::Limb,
-    prime::{Prime, ValidPrime},
 };
 
 // Public methods
 
 impl<'a, F: Field> FqSlice<'a, F> {
-    pub fn prime(&self) -> ValidPrime {
-        self.fq().characteristic().to_dyn()
-    }
-
     pub fn entry(&self, index: usize) -> FieldElement<F> {
         debug_assert!(
             index < self.len(),

--- a/ext/crates/fp/src/vector/impl_fqslice.rs
+++ b/ext/crates/fp/src/vector/impl_fqslice.rs
@@ -4,30 +4,11 @@ use super::{
     inner::{FqSlice, FqVector},
     iter::{FqVectorIterator, FqVectorNonZeroIterator},
 };
-use crate::{
-    constants,
-    field::{Field, element::FieldElement},
-    limb::Limb,
-};
+use crate::{constants, field::Field, limb::Limb};
 
 // Public methods
 
 impl<'a, F: Field> FqSlice<'a, F> {
-    pub fn entry(&self, index: usize) -> FieldElement<F> {
-        debug_assert!(
-            index < self.len(),
-            "Index {} too large, length of vector is only {}.",
-            index,
-            self.len()
-        );
-        let bit_mask = self.fq().bitmask();
-        let limb_index = self.fq().limb_bit_index_pair(index + self.start());
-        let mut result = self.limbs()[limb_index.limb];
-        result >>= limb_index.bit_index;
-        result &= bit_mask;
-        self.fq().decode(result)
-    }
-
     /// TODO: implement prime 2 version
     pub fn iter(self) -> FqVectorIterator<'a, F> {
         FqVectorIterator::new(self)

--- a/ext/crates/fp/src/vector/impl_fqslice.rs
+++ b/ext/crates/fp/src/vector/impl_fqslice.rs
@@ -1,4 +1,4 @@
-use super::inner::{FqSlice, FqVector};
+use super::{FqSlice, FqVector, FqVectorBase, Repr};
 use crate::field::{Field, element::FieldElement};
 
 // Public methods
@@ -38,8 +38,8 @@ impl<'a, F: Field> FqSlice<'a, F> {
     }
 }
 
-impl<'a, F: Field> From<&'a FqVector<F>> for FqSlice<'a, F> {
-    fn from(v: &'a FqVector<F>) -> Self {
-        v.slice(0, v.len())
+impl<'a, const A: bool, R: Repr, F: Field> From<&'a FqVectorBase<A, R, F>> for FqSlice<'a, F> {
+    fn from(v: &'a FqVectorBase<A, R, F>) -> Self {
+        v.as_slice()
     }
 }

--- a/ext/crates/fp/src/vector/impl_fqslice.rs
+++ b/ext/crates/fp/src/vector/impl_fqslice.rs
@@ -4,7 +4,7 @@ use super::{
     inner::{FqSlice, FqVector},
     iter::{FqVectorIterator, FqVectorNonZeroIterator},
 };
-use crate::field::Field;
+use crate::field::{Field, element::FieldElement};
 
 // Public methods
 
@@ -20,26 +20,6 @@ impl<'a, F: Field> FqSlice<'a, F> {
 
     pub fn first_nonzero(&self) -> Option<(usize, FieldElement<F>)> {
         self.iter_nonzero().next()
-    }
-
-    pub fn is_zero(&self) -> bool {
-        let limb_range = self.limb_range();
-        if limb_range.is_empty() {
-            return true;
-        }
-        let (min_mask, max_mask) = self.limb_masks();
-        if self.limbs()[limb_range.start] & min_mask != 0 {
-            return false;
-        }
-
-        let inner_range = self.limb_range_inner();
-        if !inner_range.is_empty() && self.limbs()[inner_range].iter().any(|&x| x != 0) {
-            return false;
-        }
-        if self.limbs()[limb_range.end - 1] & max_mask != 0 {
-            return false;
-        }
-        true
     }
 
     #[must_use]

--- a/ext/crates/fp/src/vector/impl_fqslice.rs
+++ b/ext/crates/fp/src/vector/impl_fqslice.rs
@@ -2,18 +2,13 @@ use itertools::Itertools;
 
 use super::{
     inner::{FqSlice, FqVector},
-    iter::{FqVectorIterator, FqVectorNonZeroIterator},
+    iter::FqVectorNonZeroIterator,
 };
 use crate::field::{Field, element::FieldElement};
 
 // Public methods
 
 impl<'a, F: Field> FqSlice<'a, F> {
-    /// TODO: implement prime 2 version
-    pub fn iter(self) -> FqVectorIterator<'a, F> {
-        FqVectorIterator::new(self)
-    }
-
     pub fn iter_nonzero(self) -> FqVectorNonZeroIterator<'a, F> {
         FqVectorNonZeroIterator::new(self)
     }

--- a/ext/crates/fp/src/vector/impl_fqslice.rs
+++ b/ext/crates/fp/src/vector/impl_fqslice.rs
@@ -78,7 +78,7 @@ impl<'a, F: Field> FqSlice<'a, F> {
     pub fn restrict(self, start: usize, end: usize) -> Self {
         assert!(start <= end && end <= self.len());
 
-        FqSlice::new(
+        FqSlice::_new(
             self.fq(),
             self.into_limbs(),
             self.start() + start,

--- a/ext/crates/fp/src/vector/impl_fqslice.rs
+++ b/ext/crates/fp/src/vector/impl_fqslice.rs
@@ -1,18 +1,11 @@
 use itertools::Itertools;
 
-use super::{
-    inner::{FqSlice, FqVector},
-    iter::FqVectorNonZeroIterator,
-};
+use super::inner::{FqSlice, FqVector};
 use crate::field::{Field, element::FieldElement};
 
 // Public methods
 
 impl<'a, F: Field> FqSlice<'a, F> {
-    pub fn iter_nonzero(self) -> FqVectorNonZeroIterator<'a, F> {
-        FqVectorNonZeroIterator::new(self)
-    }
-
     pub fn first_nonzero(&self) -> Option<(usize, FieldElement<F>)> {
         self.iter_nonzero().next()
     }

--- a/ext/crates/fp/src/vector/impl_fqslice.rs
+++ b/ext/crates/fp/src/vector/impl_fqslice.rs
@@ -1,5 +1,3 @@
-use itertools::Itertools;
-
 use super::inner::{FqSlice, FqVector};
 use crate::field::{Field, element::FieldElement};
 
@@ -43,31 +41,5 @@ impl<'a, F: Field> FqSlice<'a, F> {
 impl<'a, F: Field> From<&'a FqVector<F>> for FqSlice<'a, F> {
     fn from(v: &'a FqVector<F>) -> Self {
         v.slice(0, v.len())
-    }
-}
-
-impl<F: Field> std::fmt::Display for FqSlice<'_, F> {
-    /// # Example
-    /// ```
-    /// # use fp::field::{Field, SmallFq};
-    /// # use fp::prime::{P2, ValidPrime};
-    /// # use fp::vector::FqVector;
-    /// let fq = SmallFq::new(P2, 3);
-    /// let v = FqVector::from_slice(fq, &[fq.zero(), fq.one(), fq.a(), fq.a() * fq.a()]);
-    /// assert_eq!(&format!("{v}"), "[0, 1, a, a^2]");
-    ///
-    /// // This only looks reasonable over prime fields of order less than 10
-    /// assert_eq!(&format!("{v:#}"), "01aa^2");
-    /// ```
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        if f.alternate() {
-            for v in self.iter() {
-                // If self.p >= 11, this will look funky
-                write!(f, "{v}")?;
-            }
-            Ok(())
-        } else {
-            write!(f, "[{}]", self.iter().format(", "))
-        }
     }
 }

--- a/ext/crates/fp/src/vector/impl_fqslicemut.rs
+++ b/ext/crates/fp/src/vector/impl_fqslicemut.rs
@@ -22,17 +22,6 @@ impl<F: Field> FqSliceMut<'_, F> {
         }
     }
 
-    pub fn set_entry(&mut self, index: usize, value: FieldElement<F>) {
-        assert_eq!(self.fq(), value.field());
-        assert!(index < self.as_slice().len());
-        let bit_mask = self.fq().bitmask();
-        let limb_index = self.fq().limb_bit_index_pair(index + self.start());
-        let mut result = self.limbs()[limb_index.limb];
-        result &= !(bit_mask << limb_index.bit_index);
-        result |= self.fq().encode(value) << limb_index.bit_index;
-        self.limbs_mut()[limb_index.limb] = result;
-    }
-
     fn reduce_limbs(&mut self) {
         let fq = self.fq();
         if fq.q() != 2 {

--- a/ext/crates/fp/src/vector/impl_fqslicemut.rs
+++ b/ext/crates/fp/src/vector/impl_fqslicemut.rs
@@ -10,17 +10,6 @@ use crate::{
 };
 
 impl<F: Field> FqSliceMut<'_, F> {
-    fn reduce_limbs(&mut self) {
-        let fq = self.fq();
-        if fq.q() != 2 {
-            let limb_range = self.as_slice().limb_range();
-
-            for limb in self.limbs_mut()[limb_range].iter_mut() {
-                *limb = fq.reduce(*limb);
-            }
-        }
-    }
-
     pub fn scale(&mut self, c: FieldElement<F>) {
         assert_eq!(self.fq(), c.field());
         let fq = self.fq();

--- a/ext/crates/fp/src/vector/impl_fqslicemut.rs
+++ b/ext/crates/fp/src/vector/impl_fqslicemut.rs
@@ -10,18 +10,6 @@ use crate::{
 };
 
 impl<F: Field> FqSliceMut<'_, F> {
-    pub fn add_basis_element(&mut self, index: usize, value: FieldElement<F>) {
-        assert_eq!(self.fq(), value.field());
-        if self.fq().q() == 2 {
-            let pair = self.fq().limb_bit_index_pair(index + self.start());
-            self.limbs_mut()[pair.limb] ^= self.fq().encode(value) << pair.bit_index;
-        } else {
-            let mut x = self.as_slice().entry(index);
-            x += value;
-            self.set_entry(index, x);
-        }
-    }
-
     fn reduce_limbs(&mut self) {
         let fq = self.fq();
         if fq.q() != 2 {

--- a/ext/crates/fp/src/vector/impl_fqslicemut.rs
+++ b/ext/crates/fp/src/vector/impl_fqslicemut.rs
@@ -56,21 +56,6 @@ impl<F: Field> FqSliceMut<'_, F> {
         self.reduce_limbs();
     }
 
-    pub fn set_to_zero(&mut self) {
-        let limb_range = self.as_slice().limb_range();
-        if limb_range.is_empty() {
-            return;
-        }
-        let (min_mask, max_mask) = self.as_slice().limb_masks();
-        self.limbs_mut()[limb_range.start] &= !min_mask;
-
-        let inner_range = self.as_slice().limb_range_inner();
-        for limb in self.limbs_mut()[inner_range].iter_mut() {
-            *limb = 0;
-        }
-        self.limbs_mut()[limb_range.end - 1] &= !max_mask;
-    }
-
     pub fn add(&mut self, other: FqSlice<'_, F>, c: FieldElement<F>) {
         assert_eq!(self.fq(), c.field());
         assert_eq!(self.fq(), other.fq());

--- a/ext/crates/fp/src/vector/impl_fqslicemut.rs
+++ b/ext/crates/fp/src/vector/impl_fqslicemut.rs
@@ -10,41 +10,6 @@ use crate::{
 };
 
 impl<F: Field> FqSliceMut<'_, F> {
-    pub fn scale(&mut self, c: FieldElement<F>) {
-        assert_eq!(self.fq(), c.field());
-        let fq = self.fq();
-
-        if fq.q() == 2 {
-            if c == fq.zero() {
-                self.set_to_zero();
-            }
-            return;
-        }
-
-        let limb_range = self.as_slice().limb_range();
-        if limb_range.is_empty() {
-            return;
-        }
-        let (min_mask, max_mask) = self.as_slice().limb_masks();
-
-        let limb = self.limbs()[limb_range.start];
-        let masked_limb = limb & min_mask;
-        let rest_limb = limb & !min_mask;
-        self.limbs_mut()[limb_range.start] = fq.fma_limb(0, masked_limb, c.clone()) | rest_limb;
-
-        let inner_range = self.as_slice().limb_range_inner();
-        for limb in self.limbs_mut()[inner_range].iter_mut() {
-            *limb = fq.fma_limb(0, *limb, c.clone());
-        }
-        if limb_range.len() > 1 {
-            let full_limb = self.limbs()[limb_range.end - 1];
-            let masked_limb = full_limb & max_mask;
-            let rest_limb = full_limb & !max_mask;
-            self.limbs_mut()[limb_range.end - 1] = fq.fma_limb(0, masked_limb, c) | rest_limb;
-        }
-        self.reduce_limbs();
-    }
-
     pub fn add(&mut self, other: FqSlice<'_, F>, c: FieldElement<F>) {
         assert_eq!(self.fq(), c.field());
         assert_eq!(self.fq(), other.fq());

--- a/ext/crates/fp/src/vector/impl_fqslicemut.rs
+++ b/ext/crates/fp/src/vector/impl_fqslicemut.rs
@@ -512,18 +512,6 @@ impl<F: Field> FqSliceMut<'_, F> {
         }
     }
 
-    pub fn slice_mut(&mut self, start: usize, end: usize) -> FqSliceMut<'_, F> {
-        assert!(start <= end && end <= self.as_slice().len());
-        let orig_start = self.start();
-
-        FqSliceMut::_new(
-            self.fq(),
-            self.limbs_mut(),
-            orig_start + start,
-            orig_start + end,
-        )
-    }
-
     #[inline]
     #[must_use]
     pub fn as_slice(&self) -> FqSlice<'_, F> {

--- a/ext/crates/fp/src/vector/impl_fqslicemut.rs
+++ b/ext/crates/fp/src/vector/impl_fqslicemut.rs
@@ -103,7 +103,7 @@ impl<'a, F: Field> FqSliceMut<'a, F> {
         assert_eq!(self.fq(), c.field());
         assert_eq!(self.fq(), other.fq());
 
-        if self.as_slice().is_empty() {
+        if self.is_empty() {
             return;
         }
 

--- a/ext/crates/fp/src/vector/impl_fqslicemut.rs
+++ b/ext/crates/fp/src/vector/impl_fqslicemut.rs
@@ -7,14 +7,9 @@ use crate::{
     constants,
     field::{Field, element::FieldElement},
     limb::Limb,
-    prime::{Prime, ValidPrime},
 };
 
-impl<'a, F: Field> FqSliceMut<'a, F> {
-    pub fn prime(&self) -> ValidPrime {
-        self.fq().characteristic().to_dyn()
-    }
-
+impl<F: Field> FqSliceMut<'_, F> {
     pub fn add_basis_element(&mut self, index: usize, value: FieldElement<F>) {
         assert_eq!(self.fq(), value.field());
         if self.fq().q() == 2 {

--- a/ext/crates/fp/src/vector/impl_fqslicemut.rs
+++ b/ext/crates/fp/src/vector/impl_fqslicemut.rs
@@ -521,7 +521,7 @@ impl<'a, F: Field> FqSliceMut<'a, F> {
         assert!(start <= end && end <= self.as_slice().len());
         let orig_start = self.start();
 
-        FqSliceMut::new(
+        FqSliceMut::_new(
             self.fq(),
             self.limbs_mut(),
             orig_start + start,
@@ -532,7 +532,7 @@ impl<'a, F: Field> FqSliceMut<'a, F> {
     #[inline]
     #[must_use]
     pub fn as_slice(&self) -> FqSlice<'_, F> {
-        FqSlice::new(self.fq(), self.limbs(), self.start(), self.end())
+        FqSlice::_new(self.fq(), self.limbs(), self.start(), self.end())
     }
 
     /// Generates a version of itself with a shorter lifetime
@@ -542,7 +542,7 @@ impl<'a, F: Field> FqSliceMut<'a, F> {
         let start = self.start();
         let end = self.end();
 
-        FqSliceMut::new(self.fq(), self.limbs_mut(), start, end)
+        FqSliceMut::_new(self.fq(), self.limbs_mut(), start, end)
     }
 }
 

--- a/ext/crates/fp/src/vector/impl_fqslicemut.rs
+++ b/ext/crates/fp/src/vector/impl_fqslicemut.rs
@@ -20,14 +20,14 @@ impl<F: Field> FqSliceMut<'_, F> {
 
         if self.fq().q() == 2 {
             if c != self.fq().zero() {
-                match self.as_slice().offset().cmp(&other.offset()) {
+                match self.offset().cmp(&other.offset()) {
                     Ordering::Equal => self.add_shift_none(other, self.fq().one()),
                     Ordering::Less => self.add_shift_left(other, self.fq().one()),
                     Ordering::Greater => self.add_shift_right(other, self.fq().one()),
                 };
             }
         } else {
-            match self.as_slice().offset().cmp(&other.offset()) {
+            match self.offset().cmp(&other.offset()) {
                 Ordering::Equal => self.add_shift_none(other, c),
                 Ordering::Less => self.add_shift_left(other, c),
                 Ordering::Greater => self.add_shift_right(other, c),
@@ -64,12 +64,12 @@ impl<F: Field> FqSliceMut<'_, F> {
     /// TODO: improve efficiency
     pub fn assign(&mut self, other: FqSlice<'_, F>) {
         assert_eq!(self.fq(), other.fq());
-        if self.as_slice().offset() != other.offset() {
+        if self.offset() != other.offset() {
             self.set_to_zero();
             self.add(other, self.fq().one());
             return;
         }
-        let target_range = self.as_slice().limb_range();
+        let target_range = self.limb_range();
         let source_range = other.limb_range();
 
         if target_range.is_empty() {
@@ -82,7 +82,7 @@ impl<F: Field> FqSliceMut<'_, F> {
         self.limbs_mut()[target_range.start] &= !min_mask;
         self.limbs_mut()[target_range.start] |= result;
 
-        let target_inner_range = self.as_slice().limb_range_inner();
+        let target_inner_range = self.limb_range_inner();
         let source_inner_range = other.limb_range_inner();
         if !target_inner_range.is_empty() && !source_inner_range.is_empty() {
             self.limbs_mut()[target_inner_range]
@@ -117,7 +117,7 @@ impl<F: Field> FqSliceMut<'_, F> {
         assert_eq!(self.fq(), other.fq());
         let fq = self.fq();
 
-        let target_range = self.as_slice().limb_range();
+        let target_range = self.limb_range();
         let source_range = other.limb_range();
 
         let (min_mask, max_mask) = other.limb_masks();
@@ -129,7 +129,7 @@ impl<F: Field> FqSliceMut<'_, F> {
         );
         self.limbs_mut()[target_range.start] = fq.reduce(self.limbs()[target_range.start]);
 
-        let target_inner_range = self.as_slice().limb_range_inner();
+        let target_inner_range = self.limb_range_inner();
         let source_inner_range = other.limb_range_inner();
         if !source_inner_range.is_empty() {
             for (left, right) in self.limbs_mut()[target_inner_range]
@@ -409,7 +409,7 @@ impl<F: Field> FqSliceMut<'_, F> {
         // TODO: If this ends up being a bottleneck, try to use PDEP/PEXT
         assert_eq!(self.fq(), c.field());
         assert_eq!(self.fq(), other.fq());
-        assert_eq!(self.as_slice().len(), mask.len());
+        assert_eq!(self.len(), mask.len());
         for (i, &x) in mask.iter().enumerate() {
             let entry = other.entry(x);
             if entry != self.fq().zero() {

--- a/ext/crates/fp/src/vector/impl_fqslicemut.rs
+++ b/ext/crates/fp/src/vector/impl_fqslicemut.rs
@@ -428,12 +428,6 @@ impl<F: Field> FqSliceMut<'_, F> {
         }
     }
 
-    #[inline]
-    #[must_use]
-    pub fn as_slice(&self) -> FqSlice<'_, F> {
-        FqSlice::_new(self.fq(), self.limbs(), self.start(), self.end())
-    }
-
     /// Generates a version of itself with a shorter lifetime
     #[inline]
     #[must_use]

--- a/ext/crates/fp/src/vector/impl_fqslicemut.rs
+++ b/ext/crates/fp/src/vector/impl_fqslicemut.rs
@@ -2,11 +2,11 @@ use std::cmp::Ordering;
 
 use itertools::Itertools;
 
-use super::inner::{FqSlice, FqSliceMut, FqVector};
 use crate::{
     constants,
     field::{Field, element::FieldElement},
     limb::Limb,
+    vector::{FqSlice, FqSliceMut, FqVectorBase, ReprMut},
 };
 
 impl<F: Field> FqSliceMut<'_, F> {
@@ -439,8 +439,10 @@ impl<F: Field> FqSliceMut<'_, F> {
     }
 }
 
-impl<'a, F: Field> From<&'a mut FqVector<F>> for FqSliceMut<'a, F> {
-    fn from(v: &'a mut FqVector<F>) -> Self {
-        v.slice_mut(0, v.len())
+impl<'a, const A: bool, R: ReprMut, F: Field> From<&'a mut FqVectorBase<A, R, F>>
+    for FqSliceMut<'a, F>
+{
+    fn from(v: &'a mut FqVectorBase<A, R, F>) -> Self {
+        v.as_slice_mut()
     }
 }

--- a/ext/crates/fp/src/vector/impl_fqvector.rs
+++ b/ext/crates/fp/src/vector/impl_fqvector.rs
@@ -51,12 +51,6 @@ impl<F: Field> FqVector<F> {
     }
 
     #[must_use]
-    pub fn slice(&self, start: usize, end: usize) -> FqSlice<'_, F> {
-        assert!(start <= end && end <= self.len());
-        FqSlice::_new(self.fq(), self.limbs(), start, end)
-    }
-
-    #[must_use]
     pub fn slice_mut(&mut self, start: usize, end: usize) -> FqSliceMut<'_, F> {
         assert!(start <= end && end <= self.len());
         FqSliceMut::_new(self.fq(), self.limbs_mut(), start, end)

--- a/ext/crates/fp/src/vector/impl_fqvector.rs
+++ b/ext/crates/fp/src/vector/impl_fqvector.rs
@@ -9,7 +9,6 @@ use super::{
 use crate::{
     field::{Field, element::FieldElement},
     limb::Limb,
-    prime::{Prime, ValidPrime},
 };
 
 impl<F: Field> FqVector<F> {
@@ -49,10 +48,6 @@ impl<F: Field> FqVector<F> {
         // necessary ones.
         let num_limbs = self.fq().number(self.len());
         crate::limb::to_bytes(&self.limbs()[..num_limbs], buffer)
-    }
-
-    pub fn prime(&self) -> ValidPrime {
-        self.fq().characteristic().to_dyn()
     }
 
     #[must_use]

--- a/ext/crates/fp/src/vector/impl_fqvector.rs
+++ b/ext/crates/fp/src/vector/impl_fqvector.rs
@@ -51,10 +51,6 @@ impl<F: Field> FqVector<F> {
         crate::limb::to_bytes(&self.limbs()[..num_limbs], buffer)
     }
 
-    pub const fn is_empty(&self) -> bool {
-        self.len() == 0
-    }
-
     pub fn prime(&self) -> ValidPrime {
         self.fq().characteristic().to_dyn()
     }

--- a/ext/crates/fp/src/vector/impl_fqvector.rs
+++ b/ext/crates/fp/src/vector/impl_fqvector.rs
@@ -2,10 +2,7 @@ use std::io;
 
 use itertools::Itertools;
 
-use super::{
-    inner::FqVector,
-    iter::{FqVectorIterator, FqVectorNonZeroIterator},
-};
+use super::{inner::FqVector, iter::FqVectorNonZeroIterator};
 use crate::{
     field::{Field, element::FieldElement},
     limb::Limb,
@@ -48,10 +45,6 @@ impl<F: Field> FqVector<F> {
         // necessary ones.
         let num_limbs = self.fq().number(self.len());
         crate::limb::to_bytes(&self.limbs()[..num_limbs], buffer)
-    }
-
-    pub fn iter(&self) -> FqVectorIterator<'_, F> {
-        self.as_slice().iter()
     }
 
     pub fn iter_nonzero(&self) -> FqVectorNonZeroIterator<'_, F> {

--- a/ext/crates/fp/src/vector/impl_fqvector.rs
+++ b/ext/crates/fp/src/vector/impl_fqvector.rs
@@ -62,11 +62,6 @@ impl<F: Field> FqVector<F> {
         self.into()
     }
 
-    pub fn add_basis_element(&mut self, index: usize, value: FieldElement<F>) {
-        assert_eq!(self.fq(), value.field());
-        self.as_slice_mut().add_basis_element(index, value);
-    }
-
     pub fn iter(&self) -> FqVectorIterator<'_, F> {
         self.as_slice().iter()
     }

--- a/ext/crates/fp/src/vector/impl_fqvector.rs
+++ b/ext/crates/fp/src/vector/impl_fqvector.rs
@@ -70,13 +70,6 @@ impl<F: Field> FqVector<F> {
         self.as_slice().iter_nonzero()
     }
 
-    pub fn set_to_zero(&mut self) {
-        // This is sound because `fq.encode(fq.zero())` is always zero.
-        for limb in self.limbs_mut() {
-            *limb = 0;
-        }
-    }
-
     pub fn scale(&mut self, c: FieldElement<F>) {
         assert_eq!(self.fq(), c.field());
         let fq = self.fq();

--- a/ext/crates/fp/src/vector/impl_fqvector.rs
+++ b/ext/crates/fp/src/vector/impl_fqvector.rs
@@ -62,13 +62,13 @@ impl<F: Field> FqVector<F> {
     #[must_use]
     pub fn slice(&self, start: usize, end: usize) -> FqSlice<'_, F> {
         assert!(start <= end && end <= self.len());
-        FqSlice::new(self.fq(), self.limbs(), start, end)
+        FqSlice::_new(self.fq(), self.limbs(), start, end)
     }
 
     #[must_use]
     pub fn slice_mut(&mut self, start: usize, end: usize) -> FqSliceMut<'_, F> {
         assert!(start <= end && end <= self.len());
-        FqSliceMut::new(self.fq(), self.limbs_mut(), start, end)
+        FqSliceMut::_new(self.fq(), self.limbs_mut(), start, end)
     }
 
     #[inline]

--- a/ext/crates/fp/src/vector/impl_fqvector.rs
+++ b/ext/crates/fp/src/vector/impl_fqvector.rs
@@ -2,7 +2,7 @@ use std::io;
 
 use itertools::Itertools;
 
-use super::{inner::FqVector, iter::FqVectorNonZeroIterator};
+use super::inner::FqVector;
 use crate::{
     field::{Field, element::FieldElement},
     limb::Limb,
@@ -45,10 +45,6 @@ impl<F: Field> FqVector<F> {
         // necessary ones.
         let num_limbs = self.fq().number(self.len());
         crate::limb::to_bytes(&self.limbs()[..num_limbs], buffer)
-    }
-
-    pub fn iter_nonzero(&self) -> FqVectorNonZeroIterator<'_, F> {
-        self.as_slice().iter_nonzero()
     }
 
     /// Add `other` to `self` on the assumption that the first `offset` entries of `other` are

--- a/ext/crates/fp/src/vector/impl_fqvector.rs
+++ b/ext/crates/fp/src/vector/impl_fqvector.rs
@@ -67,10 +67,6 @@ impl<F: Field> FqVector<F> {
         self.as_slice_mut().add_basis_element(index, value);
     }
 
-    pub fn entry(&self, index: usize) -> FieldElement<F> {
-        self.as_slice().entry(index)
-    }
-
     pub fn set_entry(&mut self, index: usize, value: FieldElement<F>) {
         assert_eq!(self.fq(), value.field());
         self.as_slice_mut().set_entry(index, value);

--- a/ext/crates/fp/src/vector/impl_fqvector.rs
+++ b/ext/crates/fp/src/vector/impl_fqvector.rs
@@ -50,12 +50,6 @@ impl<F: Field> FqVector<F> {
         crate::limb::to_bytes(&self.limbs()[..num_limbs], buffer)
     }
 
-    #[must_use]
-    pub fn slice_mut(&mut self, start: usize, end: usize) -> FqSliceMut<'_, F> {
-        assert!(start <= end && end <= self.len());
-        FqSliceMut::_new(self.fq(), self.limbs_mut(), start, end)
-    }
-
     #[inline]
     #[must_use]
     pub fn as_slice(&self) -> FqSlice<'_, F> {

--- a/ext/crates/fp/src/vector/impl_fqvector.rs
+++ b/ext/crates/fp/src/vector/impl_fqvector.rs
@@ -3,7 +3,7 @@ use std::io;
 use itertools::Itertools;
 
 use super::{
-    inner::{FqSliceMut, FqVector},
+    inner::FqVector,
     iter::{FqVectorIterator, FqVectorNonZeroIterator},
 };
 use crate::{
@@ -48,12 +48,6 @@ impl<F: Field> FqVector<F> {
         // necessary ones.
         let num_limbs = self.fq().number(self.len());
         crate::limb::to_bytes(&self.limbs()[..num_limbs], buffer)
-    }
-
-    #[inline]
-    #[must_use]
-    pub fn as_slice_mut(&mut self) -> FqSliceMut<'_, F> {
-        self.into()
     }
 
     pub fn iter(&self) -> FqVectorIterator<'_, F> {

--- a/ext/crates/fp/src/vector/impl_fqvector.rs
+++ b/ext/crates/fp/src/vector/impl_fqvector.rs
@@ -3,7 +3,7 @@ use std::io;
 use itertools::Itertools;
 
 use super::{
-    inner::{FqSlice, FqSliceMut, FqVector},
+    inner::{FqSliceMut, FqVector},
     iter::{FqVectorIterator, FqVectorNonZeroIterator},
 };
 use crate::{
@@ -48,12 +48,6 @@ impl<F: Field> FqVector<F> {
         // necessary ones.
         let num_limbs = self.fq().number(self.len());
         crate::limb::to_bytes(&self.limbs()[..num_limbs], buffer)
-    }
-
-    #[inline]
-    #[must_use]
-    pub fn as_slice(&self) -> FqSlice<'_, F> {
-        self.into()
     }
 
     #[inline]

--- a/ext/crates/fp/src/vector/impl_fqvector.rs
+++ b/ext/crates/fp/src/vector/impl_fqvector.rs
@@ -67,11 +67,6 @@ impl<F: Field> FqVector<F> {
         self.as_slice_mut().add_basis_element(index, value);
     }
 
-    pub fn set_entry(&mut self, index: usize, value: FieldElement<F>) {
-        assert_eq!(self.fq(), value.field());
-        self.as_slice_mut().set_entry(index, value);
-    }
-
     pub fn iter(&self) -> FqVectorIterator<'_, F> {
         self.as_slice().iter()
     }

--- a/ext/crates/fp/src/vector/impl_fqvector.rs
+++ b/ext/crates/fp/src/vector/impl_fqvector.rs
@@ -134,10 +134,6 @@ impl<F: Field> FqVector<F> {
         }
     }
 
-    pub fn is_zero(&self) -> bool {
-        self.limbs().iter().all(|&x| x == 0)
-    }
-
     /// This function ensures the length of the vector is at least `len`. See also
     /// `set_scratch_vector_size`.
     pub fn extend_len(&mut self, len: usize) {

--- a/ext/crates/fp/src/vector/impl_fqvector.rs
+++ b/ext/crates/fp/src/vector/impl_fqvector.rs
@@ -260,12 +260,6 @@ impl<F: Field> From<&FqVector<F>> for Vec<FieldElement<F>> {
     }
 }
 
-impl<F: Field> std::fmt::Display for FqVector<F> {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        self.as_slice().fmt(f)
-    }
-}
-
 #[cfg(feature = "proptest")]
 pub mod arbitrary {
     use proptest::prelude::*;

--- a/ext/crates/fp/src/vector/impl_fqvector.rs
+++ b/ext/crates/fp/src/vector/impl_fqvector.rs
@@ -70,20 +70,6 @@ impl<F: Field> FqVector<F> {
         self.as_slice().iter_nonzero()
     }
 
-    pub fn scale(&mut self, c: FieldElement<F>) {
-        assert_eq!(self.fq(), c.field());
-        let fq = self.fq();
-
-        if c == fq.zero() {
-            self.set_to_zero();
-        }
-        if fq.q() != 2 {
-            for limb in self.limbs_mut() {
-                *limb = fq.reduce(fq.fma_limb(0, *limb, c.clone()));
-            }
-        }
-    }
-
     /// Add `other` to `self` on the assumption that the first `offset` entries of `other` are
     /// empty.
     pub fn add_offset(&mut self, other: &Self, c: FieldElement<F>, offset: usize) {

--- a/ext/crates/fp/src/vector/inner.rs
+++ b/ext/crates/fp/src/vector/inner.rs
@@ -152,6 +152,19 @@ impl<const A: bool, R: Repr, F: Field> FqVectorBase<A, R, F> {
 }
 
 impl<const A: bool, R: ReprMut, F: Field> FqVectorBase<A, R, F> {
+    pub fn set_entry(&mut self, index: usize, value: FieldElement<F>) {
+        assert_eq!(self.fq(), value.field());
+        assert!(index < self.len());
+
+        let bit_mask = self.fq().bitmask();
+        let limb_index = self.fq().limb_bit_index_pair(index + self.start());
+
+        let mut result = self.limbs()[limb_index.limb];
+        result &= !(bit_mask << limb_index.bit_index);
+        result |= self.fq().encode(value) << limb_index.bit_index;
+        self.limbs_mut()[limb_index.limb] = result;
+    }
+
     #[must_use]
     pub fn slice_mut(&mut self, start: usize, end: usize) -> FqSliceMut<'_, F> {
         assert!(start <= end && end <= self.len());

--- a/ext/crates/fp/src/vector/inner.rs
+++ b/ext/crates/fp/src/vector/inner.rs
@@ -291,6 +291,17 @@ impl<const A: bool, R: ReprMut, F: Field> FqVectorBase<A, R, F> {
     pub(super) fn limbs_mut(&mut self) -> &mut [Limb] {
         &mut *self.limbs
     }
+
+    pub(super) fn reduce_limbs(&mut self) {
+        let fq = self.fq();
+        if fq.q() != 2 {
+            let limb_range = self.limb_range();
+
+            for limb in self.limbs_mut()[limb_range].iter_mut() {
+                *limb = fq.reduce(*limb);
+            }
+        }
+    }
 }
 
 impl<F: Field> FqVector<F> {

--- a/ext/crates/fp/src/vector/inner.rs
+++ b/ext/crates/fp/src/vector/inner.rs
@@ -6,7 +6,7 @@ use std::{
     ops::{Deref, DerefMut, Range},
 };
 
-use super::iter::FqVectorIterator;
+use super::iter::{FqVectorIterator, FqVectorNonZeroIterator};
 use crate::{
     field::{Field, element::FieldElement},
     limb::Limb,
@@ -131,6 +131,10 @@ impl<const A: bool, R: Repr, F: Field> FqVectorBase<A, R, F> {
     /// TODO: implement prime 2 version
     pub fn iter(&self) -> FqVectorIterator<'_, F> {
         FqVectorIterator::new(self.as_slice())
+    }
+
+    pub fn iter_nonzero(&self) -> FqVectorNonZeroIterator<'_, F> {
+        FqVectorNonZeroIterator::new(self.as_slice())
     }
 
     pub fn is_zero(&self) -> bool {

--- a/ext/crates/fp/src/vector/inner.rs
+++ b/ext/crates/fp/src/vector/inner.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use crate::{
-    field::Field,
+    field::{Field, element::FieldElement},
     limb::Limb,
     prime::{Prime, ValidPrime},
 };
@@ -121,6 +121,21 @@ impl<const A: bool, R: Repr, F: Field> FqVectorBase<A, R, F> {
             self.start() + start,
             self.start() + end,
         )
+    }
+
+    pub fn entry(&self, index: usize) -> FieldElement<F> {
+        debug_assert!(
+            index < self.len(),
+            "Index {} too large, length of vector is only {}.",
+            index,
+            self.len()
+        );
+        let bit_mask = self.fq().bitmask();
+        let limb_index = self.fq().limb_bit_index_pair(index + self.start());
+        let mut result = self.limbs()[limb_index.limb];
+        result >>= limb_index.bit_index;
+        result &= bit_mask;
+        self.fq().decode(result)
     }
 
     pub(super) fn start(&self) -> usize {

--- a/ext/crates/fp/src/vector/inner.rs
+++ b/ext/crates/fp/src/vector/inner.rs
@@ -6,6 +6,8 @@ use std::{
     ops::{Deref, DerefMut, Range},
 };
 
+use itertools::Itertools;
+
 use super::iter::{FqVectorIterator, FqVectorNonZeroIterator};
 use crate::{
     field::{Field, element::FieldElement},
@@ -366,6 +368,34 @@ impl<const A: bool, R: ReprMut, F: Field> FqVectorBase<A, R, F> {
         }
     }
 }
+
+impl<const A: bool, R: Repr, F: Field> std::fmt::Display for FqVectorBase<A, R, F> {
+    /// # Example
+    /// ```
+    /// # use fp::field::{Field, SmallFq};
+    /// # use fp::prime::{P2, ValidPrime};
+    /// # use fp::vector::FqVector;
+    /// let fq = SmallFq::new(P2, 3);
+    /// let v = FqVector::from_slice(fq, &[fq.zero(), fq.one(), fq.a(), fq.a() * fq.a()]);
+    /// assert_eq!(&format!("{v}"), "[0, 1, a, a^2]");
+    ///
+    /// // This only looks reasonable over prime fields of order less than 10
+    /// assert_eq!(&format!("{v:#}"), "01aa^2");
+    /// ```
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        if f.alternate() {
+            for v in self.iter() {
+                // If self.p >= 11, this will look funky
+                write!(f, "{v}")?;
+            }
+            Ok(())
+        } else {
+            write!(f, "[{}]", self.iter().format(", "))
+        }
+    }
+}
+
+// Accessors
 
 impl<F: Field> FqVector<F> {
     pub fn from_raw_parts(fq: F, len: usize, limbs: Vec<Limb>) -> Self {

--- a/ext/crates/fp/src/vector/inner.rs
+++ b/ext/crates/fp/src/vector/inner.rs
@@ -203,6 +203,29 @@ impl<const A: bool, R: Repr, F: Field> FqVectorBase<A, R, F> {
 }
 
 impl<const A: bool, R: ReprMut, F: Field> FqVectorBase<A, R, F> {
+    pub fn set_to_zero(&mut self) {
+        if A {
+            // This is sound because `fq.encode(fq.zero())` is always zero.
+            for limb in self.limbs_mut() {
+                *limb = 0;
+            }
+            return;
+        }
+
+        let limb_range = self.limb_range();
+        if limb_range.is_empty() {
+            return;
+        }
+        let (min_mask, max_mask) = self.limb_masks();
+        self.limbs_mut()[limb_range.start] &= !min_mask;
+
+        let inner_range = self.limb_range_inner();
+        for limb in self.limbs_mut()[inner_range].iter_mut() {
+            *limb = 0;
+        }
+        self.limbs_mut()[limb_range.end - 1] &= !max_mask;
+    }
+
     pub fn set_entry(&mut self, index: usize, value: FieldElement<F>) {
         assert_eq!(self.fq(), value.field());
         assert!(index < self.len());

--- a/ext/crates/fp/src/vector/inner.rs
+++ b/ext/crates/fp/src/vector/inner.rs
@@ -111,6 +111,18 @@ impl<const A: bool, R: Repr, F: Field> FqVectorBase<A, R, F> {
         self.len() == 0
     }
 
+    #[must_use]
+    pub fn slice(&self, start: usize, end: usize) -> FqSlice<'_, F> {
+        assert!(start <= end && end <= self.len());
+
+        FqSlice::_new(
+            self.fq(),
+            self.limbs(),
+            self.start() + start,
+            self.start() + end,
+        )
+    }
+
     pub(super) fn start(&self) -> usize {
         self.start
     }

--- a/ext/crates/fp/src/vector/inner.rs
+++ b/ext/crates/fp/src/vector/inner.rs
@@ -123,6 +123,30 @@ impl<const A: bool, R: Repr, F: Field> FqVectorBase<A, R, F> {
         )
     }
 
+    pub fn is_zero(&self) -> bool {
+        if A {
+            return self.limbs().iter().all(|&x| x == 0);
+        }
+
+        let limb_range = self.limb_range();
+        if limb_range.is_empty() {
+            return true;
+        }
+        let (min_mask, max_mask) = self.limb_masks();
+        if self.limbs()[limb_range.start] & min_mask != 0 {
+            return false;
+        }
+
+        let inner_range = self.limb_range_inner();
+        if !inner_range.is_empty() && self.limbs()[inner_range].iter().any(|&x| x != 0) {
+            return false;
+        }
+        if self.limbs()[limb_range.end - 1] & max_mask != 0 {
+            return false;
+        }
+        true
+    }
+
     pub fn entry(&self, index: usize) -> FieldElement<F> {
         debug_assert!(
             index < self.len(),

--- a/ext/crates/fp/src/vector/inner.rs
+++ b/ext/crates/fp/src/vector/inner.rs
@@ -231,6 +231,12 @@ impl<const A: bool, R: Repr, F: Field> FqVectorBase<A, R, F> {
 }
 
 impl<const A: bool, R: ReprMut, F: Field> FqVectorBase<A, R, F> {
+    #[inline]
+    #[must_use]
+    pub fn as_slice_mut(&mut self) -> FqSliceMut<'_, F> {
+        self.slice_mut(0, self.len())
+    }
+
     pub fn set_to_zero(&mut self) {
         if A {
             // This is sound because `fq.encode(fq.zero())` is always zero.

--- a/ext/crates/fp/src/vector/inner.rs
+++ b/ext/crates/fp/src/vector/inner.rs
@@ -123,6 +123,10 @@ impl<const A: bool, R: Repr, F: Field> FqVectorBase<A, R, F> {
         )
     }
 
+    pub fn as_slice(&self) -> FqSlice<'_, F> {
+        self.slice(0, self.len())
+    }
+
     pub fn is_zero(&self) -> bool {
         if A {
             return self.limbs().iter().all(|&x| x == 0);

--- a/ext/crates/fp/src/vector/inner.rs
+++ b/ext/crates/fp/src/vector/inner.rs
@@ -6,6 +6,7 @@ use std::{
     ops::{Deref, DerefMut, Range},
 };
 
+use super::iter::FqVectorIterator;
 use crate::{
     field::{Field, element::FieldElement},
     limb::Limb,
@@ -125,6 +126,11 @@ impl<const A: bool, R: Repr, F: Field> FqVectorBase<A, R, F> {
 
     pub fn as_slice(&self) -> FqSlice<'_, F> {
         self.slice(0, self.len())
+    }
+
+    /// TODO: implement prime 2 version
+    pub fn iter(&self) -> FqVectorIterator<'_, F> {
+        FqVectorIterator::new(self.as_slice())
     }
 
     pub fn is_zero(&self) -> bool {

--- a/ext/crates/fp/src/vector/inner.rs
+++ b/ext/crates/fp/src/vector/inner.rs
@@ -16,6 +16,18 @@ pub trait ReprMut: DerefMut<Target = [Limb]> {}
 
 impl<T: DerefMut<Target = [Limb]>> ReprMut for T {}
 
+/// A vector over a finite field.
+///
+/// Interally, it packs entries of the vectors into limbs. However, this is an abstraction that must
+/// not leave the `fp` library.
+///
+/// We are generic over a number of types to provide maximal flexibility:
+/// - `A` determines whether the vector type is aligned, i.e. if it always starts on a limb
+///   boundary. This allows a number of methods to use a fast path.
+/// - `R` determines where the limbs are stored. An owned vector will own its limbs in a `Vec`, but
+///   a (mutable) slice will hold a (mutable) reference, etc. This allows for more exotic storage
+///   options such as `Cow` or `Arc`.
+/// - `F` is the underlying field.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct FqVectorBase<const A: bool, R: Repr, F: Field> {
     fq: F,
@@ -29,10 +41,6 @@ pub type FqSlice<'a, F> = FqVectorBase<false, &'a [Limb], F>;
 pub type FqSliceMut<'a, F> = FqVectorBase<false, &'a mut [Limb], F>;
 pub type FqCow<'a, F> = FqVectorBase<false, Cow<'a, [Limb]>, F>;
 
-// /// A vector over a finite field.
-// ///
-// /// Interally, it packs entries of the vectors into limbs. However, this is an abstraction that must
-// /// not leave the `fp` library.
 // #[derive(Debug, Hash, Eq, PartialEq, Clone)]
 // pub struct FqVector<F: Field> {
 //     fq: F,

--- a/ext/crates/fp/src/vector/inner.rs
+++ b/ext/crates/fp/src/vector/inner.rs
@@ -165,6 +165,18 @@ impl<const A: bool, R: ReprMut, F: Field> FqVectorBase<A, R, F> {
         self.limbs_mut()[limb_index.limb] = result;
     }
 
+    pub fn add_basis_element(&mut self, index: usize, value: FieldElement<F>) {
+        assert_eq!(self.fq(), value.field());
+        if self.fq().q() == 2 {
+            let pair = self.fq().limb_bit_index_pair(index + self.start());
+            self.limbs_mut()[pair.limb] ^= self.fq().encode(value) << pair.bit_index;
+        } else {
+            let mut x = self.entry(index);
+            x += value;
+            self.set_entry(index, x);
+        }
+    }
+
     #[must_use]
     pub fn slice_mut(&mut self, start: usize, end: usize) -> FqSliceMut<'_, F> {
         assert!(start <= end && end <= self.len());

--- a/ext/crates/fp/src/vector/inner.rs
+++ b/ext/crates/fp/src/vector/inner.rs
@@ -6,7 +6,11 @@ use std::{
     ops::{Deref, DerefMut},
 };
 
-use crate::{field::Field, limb::Limb};
+use crate::{
+    field::Field,
+    limb::Limb,
+    prime::{Prime, ValidPrime},
+};
 
 pub trait Repr: Deref<Target = [Limb]> {}
 
@@ -93,6 +97,10 @@ impl<const A: bool, R: Repr, F: Field> FqVectorBase<A, R, F> {
 
     pub fn fq(&self) -> F {
         self.fq
+    }
+
+    pub fn prime(&self) -> ValidPrime {
+        self.fq().characteristic().to_dyn()
     }
 
     pub fn len(&self) -> usize {

--- a/ext/crates/fp/src/vector/inner.rs
+++ b/ext/crates/fp/src/vector/inner.rs
@@ -137,6 +137,19 @@ impl<const A: bool, R: Repr, F: Field> FqVectorBase<A, R, F> {
 }
 
 impl<const A: bool, R: ReprMut, F: Field> FqVectorBase<A, R, F> {
+    #[must_use]
+    pub fn slice_mut(&mut self, start: usize, end: usize) -> FqSliceMut<'_, F> {
+        assert!(start <= end && end <= self.len());
+        let orig_start = self.start();
+
+        FqSliceMut::_new(
+            self.fq(),
+            self.limbs_mut(),
+            orig_start + start,
+            orig_start + end,
+        )
+    }
+
     pub(super) fn limbs_mut(&mut self) -> &mut [Limb] {
         &mut *self.limbs
     }

--- a/ext/crates/fp/src/vector/inner.rs
+++ b/ext/crates/fp/src/vector/inner.rs
@@ -1,80 +1,80 @@
 // This generates better llvm optimization
 #![allow(clippy::int_plus_one)]
 
+use std::{
+    borrow::Cow,
+    ops::{Deref, DerefMut},
+};
+
 use crate::{field::Field, limb::Limb};
 
-/// A vector over a finite field.
-///
-/// Interally, it packs entries of the vectors into limbs. However, this is an abstraction that must
-/// not leave the `fp` library.
-#[derive(Debug, Hash, Eq, PartialEq, Clone)]
-pub struct FqVector<F: Field> {
-    fq: F,
-    len: usize,
-    limbs: Vec<Limb>,
-}
+pub trait Repr: Deref<Target = [Limb]> {}
 
-/// A slice of an `FqVector`.
-///
-/// This immutably borrows the vector and implements `Copy`.
-#[derive(Debug, Copy, Clone)]
-pub struct FqSlice<'a, F: Field> {
+impl<T: Deref<Target = [Limb]>> Repr for T {}
+
+pub trait ReprMut: DerefMut<Target = [Limb]> {}
+
+impl<T: DerefMut<Target = [Limb]>> ReprMut for T {}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub struct FqVectorBase<const A: bool, R: Repr, F: Field> {
     fq: F,
-    limbs: &'a [Limb],
+    limbs: R,
     start: usize,
     end: usize,
 }
 
-/// A mutable slice of an `FqVector`.
-///
-/// This mutably borrows the vector. Since it is a mutable borrow, it cannot implement `Copy`.
-/// However, it has a [`FqSliceMut::copy`] function that imitates the reborrowing, that mutably
-/// borrows `FqSliceMut` and returns a `FqSliceMut` with a shorter lifetime.
-#[derive(Debug)]
-pub struct FqSliceMut<'a, F: Field> {
-    fq: F,
-    limbs: &'a mut [Limb],
-    start: usize,
-    end: usize,
-}
+pub type FqVector<F> = FqVectorBase<true, Vec<Limb>, F>;
+pub type FqSlice<'a, F> = FqVectorBase<false, &'a [Limb], F>;
+pub type FqSliceMut<'a, F> = FqVectorBase<false, &'a mut [Limb], F>;
+pub type FqCow<'a, F> = FqVectorBase<false, Cow<'a, [Limb]>, F>;
+
+// /// A vector over a finite field.
+// ///
+// /// Interally, it packs entries of the vectors into limbs. However, this is an abstraction that must
+// /// not leave the `fp` library.
+// #[derive(Debug, Hash, Eq, PartialEq, Clone)]
+// pub struct FqVector<F: Field> {
+//     fq: F,
+//     len: usize,
+//     limbs: Vec<Limb>,
+// }
+
+// /// A slice of an `FqVector`.
+// ///
+// /// This immutably borrows the vector and implements `Copy`.
+// #[derive(Debug, Copy, Clone)]
+// pub struct FqSlice<'a, F: Field> {
+//     fq: F,
+//     limbs: &'a [Limb],
+//     start: usize,
+//     end: usize,
+// }
+
+// /// A mutable slice of an `FqVector`.
+// ///
+// /// This mutably borrows the vector. Since it is a mutable borrow, it cannot implement `Copy`.
+// /// However, it has a [`FqSliceMut::copy`] function that imitates the reborrowing, that mutably
+// /// borrows `FqSliceMut` and returns a `FqSliceMut` with a shorter lifetime.
+// #[derive(Debug)]
+// pub struct FqSliceMut<'a, F: Field> {
+//     fq: F,
+//     limbs: &'a mut [Limb],
+//     start: usize,
+//     end: usize,
+// }
 
 // See impl_* for implementations
 
 // Accessors
 
-impl<F: Field> FqVector<F> {
-    pub fn from_raw_parts(fq: F, len: usize, limbs: Vec<Limb>) -> Self {
-        debug_assert_eq!(limbs.len(), fq.number(len));
-        Self { fq, len, limbs }
-    }
+impl<const A: bool, R: Repr, F: Field> FqVectorBase<A, R, F> {
+    pub(super) fn _new(fq: F, limbs: R, start: usize, end: usize) -> Self {
+        assert!(start <= end);
+        if A {
+            assert!(start.is_multiple_of(fq.entries_per_limb()));
+        }
 
-    pub fn fq(&self) -> F {
-        self.fq
-    }
-
-    pub const fn len(&self) -> usize {
-        self.len
-    }
-
-    pub(super) fn limbs(&self) -> &[Limb] {
-        &self.limbs
-    }
-
-    pub(super) fn limbs_mut(&mut self) -> &mut [Limb] {
-        &mut self.limbs
-    }
-
-    pub(super) fn vec_mut(&mut self) -> &mut Vec<Limb> {
-        &mut self.limbs
-    }
-
-    pub(super) fn len_mut(&mut self) -> &mut usize {
-        &mut self.len
-    }
-}
-
-impl<'a, F: Field> FqSlice<'a, F> {
-    pub(super) fn new(fq: F, limbs: &'a [Limb], start: usize, end: usize) -> Self {
         Self {
             fq,
             limbs,
@@ -87,6 +87,38 @@ impl<'a, F: Field> FqSlice<'a, F> {
         self.fq
     }
 
+    pub(super) fn limbs(&self) -> &[Limb] {
+        &self.limbs
+    }
+}
+
+impl<const A: bool, R: ReprMut, F: Field> FqVectorBase<A, R, F> {
+    pub(super) fn limbs_mut(&mut self) -> &mut [Limb] {
+        &mut *self.limbs
+    }
+}
+
+impl<F: Field> FqVector<F> {
+    pub fn from_raw_parts(fq: F, len: usize, limbs: Vec<Limb>) -> Self {
+        debug_assert_eq!(limbs.len(), fq.number(len));
+
+        Self::_new(fq, limbs, 0, len)
+    }
+
+    pub const fn len(&self) -> usize {
+        self.end
+    }
+
+    pub(super) fn vec_mut(&mut self) -> &mut Vec<Limb> {
+        &mut self.limbs
+    }
+
+    pub(super) fn len_mut(&mut self) -> &mut usize {
+        &mut self.end
+    }
+}
+
+impl<'a, F: Field> FqSlice<'a, F> {
     pub(super) fn into_limbs(self) -> &'a [Limb] {
         self.limbs
     }
@@ -98,26 +130,9 @@ impl<'a, F: Field> FqSlice<'a, F> {
     pub(super) const fn end(&self) -> usize {
         self.end
     }
-
-    pub(super) fn limbs(&self) -> &[Limb] {
-        self.limbs
-    }
 }
 
 impl<'a, F: Field> FqSliceMut<'a, F> {
-    pub(super) fn new(fq: F, limbs: &'a mut [Limb], start: usize, end: usize) -> Self {
-        Self {
-            fq,
-            limbs,
-            start,
-            end,
-        }
-    }
-
-    pub fn fq(&self) -> F {
-        self.fq
-    }
-
     pub(super) fn start(&self) -> usize {
         self.start
     }
@@ -128,13 +143,5 @@ impl<'a, F: Field> FqSliceMut<'a, F> {
 
     pub(super) fn end_mut(&mut self) -> &mut usize {
         &mut self.end
-    }
-
-    pub(super) fn limbs(&self) -> &[Limb] {
-        self.limbs
-    }
-
-    pub(super) fn limbs_mut(&mut self) -> &mut [Limb] {
-        self.limbs
     }
 }

--- a/ext/crates/fp/src/vector/inner.rs
+++ b/ext/crates/fp/src/vector/inner.rs
@@ -354,7 +354,7 @@ impl<const A: bool, R: ReprMut, F: Field> FqVectorBase<A, R, F> {
     }
 
     pub(super) fn limbs_mut(&mut self) -> &mut [Limb] {
-        &mut *self.limbs
+        &mut self.limbs
     }
 
     pub(super) fn reduce_limbs(&mut self) {

--- a/ext/crates/fp/src/vector/inner.rs
+++ b/ext/crates/fp/src/vector/inner.rs
@@ -25,8 +25,8 @@ impl<T: DerefMut<Target = [Limb]>> ReprMut for T {}
 
 /// A vector over a finite field.
 ///
-/// Interally, it packs entries of the vectors into limbs. However, this is an abstraction that must
-/// not leave the `fp` library.
+/// Internally, it packs entries of the vectors into limbs. However, this is an abstraction that
+/// must not leave the `fp` library.
 ///
 /// We are generic over a number of types to provide maximal flexibility:
 /// - `A` determines whether the vector type is aligned, i.e. if it always starts on a limb
@@ -47,39 +47,6 @@ pub type FqVector<F> = FqVectorBase<true, Vec<Limb>, F>;
 pub type FqSlice<'a, F> = FqVectorBase<false, &'a [Limb], F>;
 pub type FqSliceMut<'a, F> = FqVectorBase<false, &'a mut [Limb], F>;
 pub type FqCow<'a, F> = FqVectorBase<false, Cow<'a, [Limb]>, F>;
-
-// #[derive(Debug, Hash, Eq, PartialEq, Clone)]
-// pub struct FqVector<F: Field> {
-//     fq: F,
-//     len: usize,
-//     limbs: Vec<Limb>,
-// }
-
-// /// A slice of an `FqVector`.
-// ///
-// /// This immutably borrows the vector and implements `Copy`.
-// #[derive(Debug, Copy, Clone)]
-// pub struct FqSlice<'a, F: Field> {
-//     fq: F,
-//     limbs: &'a [Limb],
-//     start: usize,
-//     end: usize,
-// }
-
-// /// A mutable slice of an `FqVector`.
-// ///
-// /// This mutably borrows the vector. Since it is a mutable borrow, it cannot implement `Copy`.
-// /// However, it has a [`FqSliceMut::copy`] function that imitates the reborrowing, that mutably
-// /// borrows `FqSliceMut` and returns a `FqSliceMut` with a shorter lifetime.
-// #[derive(Debug)]
-// pub struct FqSliceMut<'a, F: Field> {
-//     fq: F,
-//     limbs: &'a mut [Limb],
-//     start: usize,
-//     end: usize,
-// }
-
-// See impl_* for implementations
 
 // Accessors
 

--- a/ext/crates/fp/src/vector/inner.rs
+++ b/ext/crates/fp/src/vector/inner.rs
@@ -95,6 +95,22 @@ impl<const A: bool, R: Repr, F: Field> FqVectorBase<A, R, F> {
         self.fq
     }
 
+    pub fn len(&self) -> usize {
+        self.end() - self.start()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    pub(super) fn start(&self) -> usize {
+        self.start
+    }
+
+    pub(super) fn end(&self) -> usize {
+        self.end
+    }
+
     pub(super) fn limbs(&self) -> &[Limb] {
         &self.limbs
     }
@@ -113,10 +129,6 @@ impl<F: Field> FqVector<F> {
         Self::_new(fq, limbs, 0, len)
     }
 
-    pub const fn len(&self) -> usize {
-        self.end
-    }
-
     pub(super) fn vec_mut(&mut self) -> &mut Vec<Limb> {
         &mut self.limbs
     }
@@ -130,25 +142,9 @@ impl<'a, F: Field> FqSlice<'a, F> {
     pub(super) fn into_limbs(self) -> &'a [Limb] {
         self.limbs
     }
-
-    pub(super) const fn start(&self) -> usize {
-        self.start
-    }
-
-    pub(super) const fn end(&self) -> usize {
-        self.end
-    }
 }
 
 impl<'a, F: Field> FqSliceMut<'a, F> {
-    pub(super) fn start(&self) -> usize {
-        self.start
-    }
-
-    pub(super) fn end(&self) -> usize {
-        self.end
-    }
-
     pub(super) fn end_mut(&mut self) -> &mut usize {
         &mut self.end
     }

--- a/ext/crates/fp/src/vector/inner.rs
+++ b/ext/crates/fp/src/vector/inner.rs
@@ -245,6 +245,7 @@ impl<const A: bool, R: ReprMut, F: Field> FqVectorBase<A, R, F> {
 
         if c == fq.zero() {
             self.set_to_zero();
+            return;
         }
 
         if fq.q() == 2 {

--- a/ext/crates/fp/src/vector/inner.rs
+++ b/ext/crates/fp/src/vector/inner.rs
@@ -36,7 +36,7 @@ impl<T: DerefMut<Target = [Limb]>> ReprMut for T {}
 ///   options such as `Cow` or `Arc`.
 /// - `F` is the underlying field.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub struct FqVectorBase<const A: bool, R: Repr, F: Field> {
+pub struct FqVectorBase<const A: bool, R, F> {
     fq: F,
     limbs: R,
     start: usize,


### PR DESCRIPTION
This PR abstracts away the common logic behind `FqVector`, `FqSlice` and `FqSliceMut`. This leads to simplifications and the possibility of adding more variants in the future.

Currently, my main objective is switching to using `FpCow` in `BidegreeElement`s to avoid unnecessary clones and make them usable in performance-critical code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Refactor
* Introduced a single generic base for vector types, replacing multiple specialized wrappers and consolidating vector/slice APIs.
* Trimmed and reorganized public vector and slice methods (fewer direct accessors, iterators and formatting implementations removed).
* Adjusted matrix row and slice construction to use an internal constructor; external behavior and signatures remain compatible.
* Simplified public surface to a smaller, more consistent set of vector/matrix operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->