### PR TITLE
Rename `FqSlice::slice` -> `FqSlice::restrict`

### DIFF
--- a/ext/crates/algebra/src/module/free_module.rs
+++ b/ext/crates/algebra/src/module/free_module.rs
@@ -195,7 +195,7 @@ impl<const U: bool, A: MuAlgebra<U>> Module for MuFreeModule<U, A> {
             if input_start >= input.len() {
                 break;
             }
-            let input_slice = input.slice(input_start, input_end);
+            let input_slice = input.restrict(input_start, input_end);
             self.algebra.multiply_basis_element_by_element_unstable(
                 result.slice_mut(output_start, output_end),
                 coeff,
@@ -364,7 +364,7 @@ impl<const U: bool, A: MuAlgebra<U>> MuFreeModule<U, A> {
         let len = self
             .algebra()
             .dimension_unstable(degree - gen_degree, gen_degree);
-        v.slice(
+        v.restrict(
             std::cmp::min(v.len(), start),
             std::cmp::min(v.len(), start + len),
         )

--- a/ext/crates/algebra/src/module/homomorphism/free_module_homomorphism.rs
+++ b/ext/crates/algebra/src/module/homomorphism/free_module_homomorphism.rs
@@ -199,7 +199,7 @@ where
         for (i, new_output) in new_outputs.iter_mut().enumerate() {
             new_output
                 .as_slice_mut()
-                .assign(outputs_vectors.slice(target_dimension * i, target_dimension * (i + 1)));
+                .assign(outputs_vectors.restrict(target_dimension * i, target_dimension * (i + 1)));
         }
         self.outputs.push_checked(new_outputs, degree);
     }

--- a/ext/crates/fp/src/matrix/matrix_inner.rs
+++ b/ext/crates/fp/src/matrix/matrix_inner.rs
@@ -739,7 +739,7 @@ impl Matrix {
         for i in 0..first_kernel_row {
             preimage
                 .row_mut(i)
-                .assign(self.row(i).slice(first_source_col, columns));
+                .assign(self.row(i).restrict(first_source_col, columns));
         }
         QuasiInverse::new(Some(self.pivots()[..last_target_col].to_vec()), preimage)
     }
@@ -779,7 +779,7 @@ impl Matrix {
         for i in 0..first_kernel_row {
             image_matrix
                 .row_mut(i)
-                .assign(self.row(i).slice(0, last_target_col));
+                .assign(self.row(i).restrict(0, last_target_col));
         }
         image_matrix.pivots = self.pivots()[..last_target_col].to_vec();
         Subspace::from_matrix(image_matrix)
@@ -848,7 +848,7 @@ impl Matrix {
         for (i, mut row) in kernel.iter_mut().enumerate() {
             row.assign(
                 self.row(first_kernel_row + i)
-                    .slice(first_source_column, first_source_column + source_dimension),
+                    .restrict(first_source_column, first_source_column + source_dimension),
             );
         }
         Subspace::from_matrix(kernel)
@@ -1017,7 +1017,7 @@ impl Matrix {
     pub fn trim(&mut self, row_start: usize, row_end: usize, col_start: usize) {
         let mut new = Self::new(self.prime(), row_end - row_start, self.columns - col_start);
         for (i, mut row) in new.iter_mut().enumerate() {
-            row.assign(self.row(row_start + i).slice(col_start, self.columns));
+            row.assign(self.row(row_start + i).restrict(col_start, self.columns));
         }
         std::mem::swap(self, &mut new);
     }
@@ -1269,7 +1269,7 @@ impl<const N: usize> AugmentedMatrix<N> {
     pub fn row_segment(&self, i: usize, start: usize, end: usize) -> FpSlice<'_> {
         let start_idx = self.start[start];
         let end_idx = self.end[end];
-        self.row(i).slice(start_idx, end_idx)
+        self.row(i).restrict(start_idx, end_idx)
     }
 
     pub fn into_matrix(self) -> Matrix {
@@ -1358,7 +1358,7 @@ impl AugmentedMatrix<3> {
             for i in 0..self.end[0] {
                 cc_preimage
                     .row_mut(i)
-                    .assign(self.row(i).slice(self.start[2], self.end[2]));
+                    .assign(self.row(i).restrict(self.start[2], self.end[2]));
             }
             let cm_qi = QuasiInverse::new(None, cc_preimage);
 

--- a/ext/crates/fp/src/vector/fp_wrapper/mod.rs
+++ b/ext/crates/fp/src/vector/fp_wrapper/mod.rs
@@ -134,7 +134,7 @@ impl<'a> FpSlice<'a> {
         pub fn iter_nonzero(self) -> (dispatch FpVectorNonZeroIterator<'a>);
         pub fn @first_nonzero(&self) -> (Option<(usize, u32)>);
         pub fn is_zero(&self) -> bool;
-        pub fn slice(self, start: usize, end: usize) -> (dispatch FpSlice<'a>);
+        pub fn restrict(self, start: usize, end: usize) -> (dispatch FpSlice<'a>);
         pub fn to_owned(self) -> (dispatch FpVector);
 
         pub(crate) fn limbs(&self) -> (&[Limb]);

--- a/ext/crates/fp/src/vector/impl_fqslice.rs
+++ b/ext/crates/fp/src/vector/impl_fqslice.rs
@@ -75,7 +75,7 @@ impl<'a, F: Field> FqSlice<'a, F> {
     }
 
     #[must_use]
-    pub fn slice(self, start: usize, end: usize) -> Self {
+    pub fn restrict(self, start: usize, end: usize) -> Self {
         assert!(start <= end && end <= self.len());
 
         FqSlice::new(

--- a/ext/crates/fp/src/vector/impl_fqslicemut.rs
+++ b/ext/crates/fp/src/vector/impl_fqslicemut.rs
@@ -126,7 +126,7 @@ impl<'a, F: Field> FqSliceMut<'a, F> {
 
     pub fn add_offset(&mut self, other: FqSlice<'_, F>, c: FieldElement<F>, offset: usize) {
         self.slice_mut(offset, self.as_slice().len())
-            .add(other.slice(offset, other.len()), c)
+            .add(other.restrict(offset, other.len()), c)
     }
 
     /// Adds v otimes w to self.

--- a/ext/crates/sseq/src/differential.rs
+++ b/ext/crates/sseq/src/differential.rs
@@ -74,8 +74,8 @@ impl Differential {
             .filter(|d| !d.is_zero())
             .map(move |d| {
                 (
-                    d.slice(0, source_dim).to_owned(),
-                    d.slice(source_dim, source_dim + target_dim).to_owned(),
+                    d.restrict(0, source_dim).to_owned(),
+                    d.restrict(source_dim, source_dim + target_dim).to_owned(),
                 )
             })
             .collect()
@@ -116,7 +116,7 @@ impl Differential {
             target.add(
                 self.matrix
                     .row(row)
-                    .slice(self.source_dim, self.source_dim + self.target_dim),
+                    .restrict(self.source_dim, self.source_dim + self.target_dim),
                 c,
             );
         }
@@ -146,10 +146,10 @@ impl Differential {
         for (mut target, source) in matrix.iter_mut().zip(self.matrix.iter()) {
             target
                 .slice_mut(0, self.target_dim)
-                .assign(source.slice(self.source_dim, self.source_dim + self.target_dim));
+                .assign(source.restrict(self.source_dim, self.source_dim + self.target_dim));
             target
                 .slice_mut(self.target_dim, self.target_dim + self.source_dim)
-                .assign(source.slice(0, self.source_dim));
+                .assign(source.restrict(0, self.source_dim));
         }
         matrix.row_reduce();
         let qi = matrix.compute_quasi_inverse(self.target_dim, self.target_dim);

--- a/ext/crates/sseq/src/sseq.rs
+++ b/ext/crates/sseq/src/sseq.rs
@@ -317,7 +317,7 @@ impl<P: SseqProfile> Sseq<P> {
                         break;
                     }
                     self.page_data[b.x()][b.y()][r]
-                        .add_gen(row.slice(target_dim, target_dim + source_dim));
+                        .add_gen(row.restrict(target_dim, target_dim + source_dim));
                 }
             }
         }

--- a/ext/examples/secondary_massey.rs
+++ b/ext/examples/secondary_massey.rs
@@ -390,7 +390,7 @@ fn main() -> anyhow::Result<()> {
             {
                 print!("<{a_name}, {b_name}, ");
                 let has_ext = {
-                    let ext_part = g.slice(0, target_num_gens);
+                    let ext_part = g.restrict(0, target_num_gens);
                     if ext_part.iter_nonzero().count() > 0 {
                         print!(
                             "[{basis_string}]",
@@ -403,7 +403,7 @@ fn main() -> anyhow::Result<()> {
                     }
                 };
 
-                let lambda_part = g.slice(target_num_gens, target_all_gens);
+                let lambda_part = g.restrict(target_num_gens, target_all_gens);
                 let num_entries = lambda_part.iter_nonzero().count();
                 if num_entries > 0 {
                     if has_ext {
@@ -413,7 +413,7 @@ fn main() -> anyhow::Result<()> {
 
                     let basis_string = BidegreeElement::new(
                         c + LAMBDA_BIDEGREE,
-                        g.slice(target_num_gens, target_all_gens).to_owned(),
+                        g.restrict(target_num_gens, target_all_gens).to_owned(),
                     )
                     .to_basis_string();
                     if num_entries == 1 {
@@ -430,14 +430,14 @@ fn main() -> anyhow::Result<()> {
             scratch1.set_scratch_vector_size(source_lambda_num_gens);
 
             // First deal with the null-homotopy of ab
-            for (i, v) in g.slice(0, target_num_gens).iter_nonzero() {
+            for (i, v) in g.restrict(0, target_num_gens).iter_nonzero() {
                 scratch0
                     .iter_mut()
                     .zip_eq(&m0[i])
                     .for_each(|(a, b)| *a += v * b);
                 scratch1.as_slice_mut().add(m1.row(i), v);
             }
-            for (i, v) in g.slice(target_num_gens, target_all_gens).iter_nonzero() {
+            for (i, v) in g.restrict(target_num_gens, target_all_gens).iter_nonzero() {
                 scratch1.as_slice_mut().add(mt.row(i), v);
             }
             // Now do the -1 part of the null-homotopy of bc.
@@ -464,7 +464,7 @@ fn main() -> anyhow::Result<()> {
             scratch0.clear();
             scratch0.resize(prod_num_gens, 0);
 
-            for (i, v) in g.slice(0, target_num_gens).iter_nonzero() {
+            for (i, v) in g.restrict(0, target_num_gens).iter_nonzero() {
                 scratch0
                     .iter_mut()
                     .zip_eq(&mb[i])

--- a/ext/examples/steenrod.rs
+++ b/ext/examples/steenrod.rs
@@ -841,7 +841,9 @@ mod tensor_product_chain_complex {
 
                                     let mut entry = FpVector::new(p, dim);
                                     entry.as_slice_mut().assign(
-                                        matrix.row_segment(row, 1, 1).slice(offset, offset + dim),
+                                        matrix
+                                            .row_segment(row, 1, 1)
+                                            .restrict(offset, offset + dim),
                                     );
 
                                     if !entry.is_zero() {

--- a/ext/src/secondary.rs
+++ b/ext/src/secondary.rs
@@ -1114,7 +1114,7 @@ where
             lambda_part,
             None,
             b,
-            [class.slice(0, target_num_gens)].into_iter(),
+            [class.restrict(0, target_num_gens)].into_iter(),
             [prod_value.as_slice_mut()].into_iter(),
         );
         assert!(prod_value.slice(0, lower_num_gens).is_zero());
@@ -1129,7 +1129,7 @@ where
         matrix.apply(
             prod_value.slice_mut(lower_num_gens, lower_num_gens + lambda_num_gens),
             1,
-            class.slice(target_num_gens, target_num_gens + target_lambda_num_gens),
+            class.restrict(target_num_gens, target_num_gens + target_lambda_num_gens),
         );
 
         let diff_source = b + shift - Bidegree::n_s(-1, 1);


### PR DESCRIPTION
This differentiates it from other `slice` methods, which usually take `&self`. Split off from #214 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Replaced internal `slice()` method calls with `restrict()` across mathematical computation modules for improved boundary semantics.

* **API Changes**
  * Renamed public methods from `slice()` to `restrict()` in vector slice types. Callers must update to use the new method name; functionality remains unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->