### PR TITLE
Avoid rayon priority inversion in step_resolution scheduling

### DIFF
--- a/ext/src/nassau.rs
+++ b/ext/src/nassau.rs
@@ -40,12 +40,13 @@ use sseq::coordinates::{Bidegree, BidegreeGenerator};
 use crate::{
     chain_complex::{AugmentedChainComplex, ChainComplex, FiniteChainComplex, FreeChainComplex},
     save::{SaveDirectory, SaveKind},
-    utils::LogWriter,
+    utils::{LogWriter, parallel::ParallelGuard},
 };
 
 /// See [`resolution::SenderData`](../resolution/struct.SenderData.html). This differs by not having the `new` field.
 struct SenderData {
     b: Bidegree,
+    retry: bool,
     sender: mpsc::Sender<Self>,
 }
 
@@ -54,6 +55,17 @@ impl SenderData {
         sender
             .send(Self {
                 b,
+                retry: false,
+                sender: sender.clone(),
+            })
+            .unwrap()
+    }
+
+    pub(crate) fn send_retry(b: Bidegree, sender: mpsc::Sender<Self>) {
+        sender
+            .send(Self {
+                b,
+                retry: true,
                 sender: sender.clone(),
             })
             .unwrap()
@@ -603,7 +615,10 @@ impl<M: ZeroModule<Algebra = MilnorAlgebra>> Resolution<M> {
             .collect();
         let next_masked_dim = next_mask.len();
 
-        let full_matrix = self.differentials[b.s() - 1].get_partial_matrix(b.t(), &target_mask);
+        let full_matrix = {
+            let _guard = ParallelGuard::new();
+            self.differentials[b.s() - 1].get_partial_matrix(b.t(), &target_mask)
+        };
         let mut masked_matrix =
             AugmentedMatrix::new(p, target_masked_dim, [next_masked_dim, target_masked_dim]);
 
@@ -669,9 +684,11 @@ impl<M: ZeroModule<Algebra = MilnorAlgebra>> Resolution<M> {
             target_mask.extend(subalgebra.signature_mask(&algebra, target, b.t(), &signature));
             next_mask.extend(subalgebra.signature_mask(&algebra, next, b.t(), &signature));
 
-            let full_matrix = self
-                .differential(b.s() - 1)
-                .get_partial_matrix(b.t(), &target_mask);
+            let full_matrix = {
+                let _guard = ParallelGuard::new();
+                self.differential(b.s() - 1)
+                    .get_partial_matrix(b.t(), &target_mask)
+            };
 
             let mut masked_matrix =
                 AugmentedMatrix::new(p, target_mask.len(), [next_mask.len(), target_mask.len()]);
@@ -754,7 +771,10 @@ impl<M: ZeroModule<Algebra = MilnorAlgebra>> Resolution<M> {
                 source_dim + target_dim,
                 0,
             );
-            chain_map.get_matrix(matrix.segment(0, 0), t);
+            {
+                let _guard = ParallelGuard::new();
+                chain_map.get_matrix(matrix.segment(0, 0), t);
+            }
             matrix.segment(1, 1).add_identity();
 
             matrix.row_reduce();
@@ -792,7 +812,10 @@ impl<M: ZeroModule<Algebra = MilnorAlgebra>> Resolution<M> {
 
         let mut matrix =
             AugmentedMatrix::<2>::new(p, target_dim, [cc_module.dimension(t), target_dim]);
-        self.chain_maps[0].get_matrix(matrix.segment(0, 0), t);
+        {
+            let _guard = ParallelGuard::new();
+            self.chain_maps[0].get_matrix(matrix.segment(0, 0), t);
+        }
         matrix.segment(1, 1).add_identity();
         matrix.row_reduce();
         let desired_image = matrix.compute_kernel();
@@ -804,7 +827,10 @@ impl<M: ZeroModule<Algebra = MilnorAlgebra>> Resolution<M> {
             source_dim + MAX_NEW_GENS,
             0,
         );
-        self.differentials[1].get_matrix(matrix.segment(0, 0), t);
+        {
+            let _guard = ParallelGuard::new();
+            self.differentials[1].get_matrix(matrix.segment(0, 0), t);
+        }
         matrix.segment(1, 1).add_identity();
         matrix.row_reduce();
 
@@ -930,13 +956,21 @@ impl<M: ZeroModule<Algebra = MilnorAlgebra>> Resolution<M> {
                     let tracing_span = tracing_span.clone();
                     scope.spawn(move |_| {
                         let _tracing_guard = tracing_span.enter();
+                        if crate::utils::parallel::is_in_parallel() {
+                            SenderData::send_retry(b, sender);
+                            return;
+                        }
                         self.step_resolution(b);
                         SenderData::send(b, sender);
                     });
                 }
             };
 
-            while let Ok(SenderData { b, sender }) = receiver.recv() {
+            while let Ok(SenderData { b, retry, sender }) = receiver.recv() {
+                if retry {
+                    f(b, sender);
+                    continue;
+                }
                 assert!(progress[b.s() as usize] == b.t() - 1);
                 progress[b.s() as usize] = b.t();
 

--- a/ext/src/resolution.rs
+++ b/ext/src/resolution.rs
@@ -23,6 +23,7 @@ use sseq::coordinates::{Bidegree, BidegreeGenerator};
 use crate::{
     chain_complex::{AugmentedChainComplex, ChainComplex},
     save::{SaveDirectory, SaveKind},
+    utils::parallel::ParallelGuard,
 };
 
 /// In [`MuResolution::compute_through_stem`] and [`MuResolution::compute_through_bidegree`], we pass
@@ -32,6 +33,8 @@ struct SenderData {
     b: Bidegree,
     /// Whether this bidegree was newly calculated or have already been calculated.
     new: bool,
+    /// Whether this job should be retried due to priority inversion avoidance.
+    retry: bool,
     /// The sender object used to send the `SenderData`. We put this in the struct and pass it
     /// around the mpsc, so that when all senders are dropped, we know the computation has
     /// completed. Compared to keeping track of calculations manually, this has the advantage of
@@ -45,6 +48,18 @@ impl SenderData {
             .send(Self {
                 b,
                 new,
+                retry: false,
+                sender: sender.clone(),
+            })
+            .unwrap()
+    }
+
+    fn send_retry(b: Bidegree, sender: mpsc::Sender<Self>) {
+        sender
+            .send(Self {
+                b,
+                new: false,
+                retry: true,
                 sender: sender.clone(),
             })
             .unwrap()
@@ -238,8 +253,11 @@ where
             [target_cc_dimension, target_res_dimension, source_dimension],
         );
 
-        current_chain_map.get_matrix(matrix.segment(0, 0), b.t());
-        current_differential.get_matrix(matrix.segment(1, 1), b.t());
+        {
+            let _guard = ParallelGuard::new();
+            current_chain_map.get_matrix(matrix.segment(0, 0), b.t());
+            current_differential.get_matrix(matrix.segment(1, 1), b.t());
+        }
         matrix.segment(2, 2).add_identity();
         matrix.row_reduce();
 
@@ -469,8 +487,11 @@ where
         );
         // Get the map (d, f) : X_{s, t} -> X_{s-1, t} (+) C_{s, t} into matrix
 
-        current_chain_map.get_matrix(matrix.segment(0, 0), b.t());
-        current_differential.get_matrix(matrix.segment(1, 1), b.t());
+        {
+            let _guard = ParallelGuard::new();
+            current_chain_map.get_matrix(matrix.segment(0, 0), b.t());
+            current_differential.get_matrix(matrix.segment(1, 1), b.t());
+        }
         matrix.segment(2, 2).add_identity();
 
         matrix.row_reduce();
@@ -740,13 +761,27 @@ where
                     let tracing_span = tracing_span.clone();
                     scope.spawn(move |_| {
                         let _tracing_guard = tracing_span.enter();
+                        if crate::utils::parallel::is_in_parallel() {
+                            SenderData::send_retry(b, sender);
+                            return;
+                        }
                         self.step_resolution(b);
                         SenderData::send(b, true, sender);
                     });
                 }
             };
 
-            while let Ok(SenderData { b, new, sender }) = receiver.recv() {
+            while let Ok(SenderData {
+                b,
+                new,
+                retry,
+                sender,
+            }) = receiver.recv()
+            {
+                if retry {
+                    f(b, sender);
+                    continue;
+                }
                 assert!(progress[b.s() as usize] == b.t() - 1);
                 progress[b.s() as usize] = b.t();
 
@@ -798,13 +833,27 @@ where
                     let tracing_span = tracing_span.clone();
                     scope.spawn(move |_| {
                         let _tracing_guard = tracing_span.enter();
+                        if crate::utils::parallel::is_in_parallel() {
+                            SenderData::send_retry(b, sender);
+                            return;
+                        }
                         self.step_resolution(b);
                         SenderData::send(b, true, sender);
                     });
                 }
             };
 
-            while let Ok(SenderData { b, new, sender }) = receiver.recv() {
+            while let Ok(SenderData {
+                b,
+                new,
+                retry,
+                sender,
+            }) = receiver.recv()
+            {
+                if retry {
+                    f(b, sender);
+                    continue;
+                }
                 assert!(progress[b.s() as usize] == b.t() - 1);
                 progress[b.s() as usize] = b.t();
 

--- a/ext/src/utils.rs
+++ b/ext/src/utils.rs
@@ -548,6 +548,35 @@ mod logging {
 
 pub use logging::{LogWriter, ext_tracing_subscriber, init_logging};
 
+pub(crate) mod parallel {
+
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    static PARALLEL_DEPTH: AtomicUsize = AtomicUsize::new(0);
+
+    /// RAII guard that increments [`PARALLEL_DEPTH`] on creation and decrements on drop. Used to mark
+    /// regions where `par_iter_mut` work is active, so that `step_resolution` jobs can detect priority
+    /// inversion and retry.
+    pub(crate) struct ParallelGuard;
+
+    impl ParallelGuard {
+        pub(crate) fn new() -> Self {
+            PARALLEL_DEPTH.fetch_add(1, Ordering::Release);
+            Self
+        }
+    }
+
+    impl Drop for ParallelGuard {
+        fn drop(&mut self) {
+            PARALLEL_DEPTH.fetch_sub(1, Ordering::Release);
+        }
+    }
+
+    pub(crate) fn is_in_parallel() -> bool {
+        PARALLEL_DEPTH.load(Ordering::Acquire) > 0
+    }
+}
+
 /// The value of the SECONDARY_JOB environment variable.
 ///
 /// This is used for distributing the `secondary`. If set, only data with `s = SECONDARY_JOB` will


### PR DESCRIPTION
When rayon workers finish inner parallel work (par_iter_mut in get_partial_matrix/get_matrix) and wait at join points, work-stealing can cause them to pick up another step_resolution job, blocking the original from completing. This crosses thread boundaries: any thread in the join tree can steal a long job.

Fix: track active parallel sections with a global atomic counter (PARALLEL_DEPTH). Before each get_partial_matrix/get_matrix call, a ParallelGuard increments the counter; it decrements on drop. Spawned step_resolution closures check is_in_parallel() and send a retry message if true. The scheduler re-queues retried jobs, and the freed thread returns to rayon's pool where it helps finish the active parallel section -- turning the retry into productive work.

See https://github.com/rayon-rs/rayon/issues/957

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced parallel execution control and worker scheduling to improve reliability during concurrent computations.
  * Implemented retry mechanisms for work queue management to ensure robust task processing in parallel environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->