### PR TITLE
Add trying variants to a bunch of APIs

### DIFF
--- a/ext/crates/algebra/src/algebra/adem_algebra.rs
+++ b/ext/crates/algebra/src/algebra/adem_algebra.rs
@@ -1496,6 +1496,30 @@ mod tests {
     }
 
     #[test]
+    fn try_basis_element_to_string_adem() {
+        let p = ValidPrime::new(2);
+        let algebra = AdemAlgebra::new(p, false);
+        algebra.compute_basis(8);
+
+        // Valid (degree, idx) pairs: the non-panicking variant agrees with the
+        // panicking `basis_element_to_string` and returns `Some`.
+        for d in 0..=8 {
+            for i in 0..algebra.dimension(d) {
+                assert_eq!(
+                    algebra.try_basis_element_to_string(d, i),
+                    Some(algebra.basis_element_to_string(d, i)),
+                );
+            }
+        }
+
+        // Negative degree returns `None` rather than panicking.
+        assert_eq!(algebra.try_basis_element_to_string(-1, 0), None);
+
+        // Out-of-range index returns `None` rather than panicking (key guard).
+        assert_eq!(algebra.try_basis_element_to_string(1, 999), None);
+    }
+
+    #[test]
     fn basis_element_from_string_total_adem() {
         let p = ValidPrime::new(2);
         let algebra = AdemAlgebra::new(p, false);

--- a/ext/crates/algebra/src/algebra/adem_algebra.rs
+++ b/ext/crates/algebra/src/algebra/adem_algebra.rs
@@ -1319,23 +1319,28 @@ impl AdemAlgebra {
         result
     }
 
-    pub fn beps_pn(&self, e: u32, x: u32) -> (i32, usize) {
+    /// Return the degree and index of $\beta^e P^x$, or `None` if the element is not present.
+    pub fn try_beps_pn(&self, e: u32, x: u32) -> Option<(i32, usize)> {
         if x == 0 && e == 1 {
-            return (1, 0);
+            return Some((1, 0));
         } else if x == 0 {
-            return (0, 0);
+            return Some((0, 0));
         }
 
         let p = self.prime();
         let q = if self.generic { 2 * p - 2 } else { 1 };
         let degree = (x * q + e) as i32;
-        let index = self.basis_element_to_index(&AdemBasisElement {
+        self.try_basis_element_to_index(&AdemBasisElement {
             degree,
             bocksteins: e,
             ps: vec![x],
             p_or_sq: self.prime() != 2,
-        });
-        (degree, index)
+        })
+        .map(|index| (degree, index))
+    }
+
+    pub fn beps_pn(&self, e: u32, x: u32) -> (i32, usize) {
+        self.try_beps_pn(e, x).unwrap()
     }
 }
 
@@ -1470,6 +1475,26 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn try_beps_pn_adem() {
+        let p = ValidPrime::new(2);
+        let algebra = AdemAlgebra::new(p, false);
+        algebra.compute_basis(32);
+
+        // For valid inputs the non-panicking variant agrees with `beps_pn`.
+        for x in 0..=32 {
+            assert_eq!(algebra.try_beps_pn(0, x), Some(algebra.beps_pn(0, x)));
+            assert!(algebra.try_beps_pn(0, x).is_some());
+        }
+        // Hard-coded special cases (x == 0).
+        assert_eq!(algebra.try_beps_pn(0, 0), Some((0, 0)));
+        assert_eq!(algebra.try_beps_pn(1, 0), Some((1, 0)));
+
+        // At p = 2 every Sq^x is admissible, so once its degree is computed the
+        // lookup always succeeds: the unrestricted Adem algebra has no genuine
+        // `None` case to exhibit here (cf. the profiled Milnor test).
     }
 
     use crate::module::ModuleFailedRelationError;

--- a/ext/crates/algebra/src/algebra/adem_algebra.rs
+++ b/ext/crates/algebra/src/algebra/adem_algebra.rs
@@ -301,15 +301,13 @@ impl Algebra for AdemAlgebra {
         }
 
         self.compute_basis(degree);
-        Some((
+        self.try_basis_element_to_index(&AdemBasisElement {
+            ps,
+            bocksteins,
             degree,
-            self.basis_element_to_index(&AdemBasisElement {
-                ps,
-                bocksteins,
-                degree,
-                p_or_sq: self.generic,
-            }),
-        ))
+            p_or_sq: self.generic,
+        })
+        .map(|idx| (degree, idx))
     }
 }
 
@@ -1495,6 +1493,33 @@ mod tests {
         // At p = 2 every Sq^x is admissible, so once its degree is computed the
         // lookup always succeeds: the unrestricted Adem algebra has no genuine
         // `None` case to exhibit here (cf. the profiled Milnor test).
+    }
+
+    #[test]
+    fn basis_element_from_string_total_adem() {
+        let p = ValidPrime::new(2);
+        let algebra = AdemAlgebra::new(p, false);
+        // Compute high enough that the degrees of all parsed candidates below
+        // (including the inadmissible Sq1 Sq2 in degree 3) are available, so we
+        // exercise the now-`None` lookup path rather than an uncomputed degree.
+        algebra.compute_basis(8);
+
+        // Sanity: valid admissible names round-trip through the canonical string.
+        for name in ["Sq1", "Sq2", "Sq2 Sq1"] {
+            let (d, i) = algebra
+                .basis_element_from_string(name)
+                .unwrap_or_else(|| panic!("expected Some for {name}"));
+            assert_eq!(algebra.basis_element_to_string(d, i), name);
+        }
+
+        // Syntactically-valid names that name no basis element must return `None`
+        // (they previously panicked in `basis_element_to_index`).
+        //
+        // "Sq0" parses to ps=[0], degree 0 -- no such basis element exists.
+        assert_eq!(algebra.basis_element_from_string("Sq0"), None);
+        // "Sq1 Sq2" parses to the inadmissible ps=[1,2], degree 3. Its degree is
+        // computed, so this hits the basis lookup, which finds nothing.
+        assert_eq!(algebra.basis_element_from_string("Sq1 Sq2"), None);
     }
 
     use crate::module::ModuleFailedRelationError;

--- a/ext/crates/algebra/src/algebra/algebra_trait.rs
+++ b/ext/crates/algebra/src/algebra/algebra_trait.rs
@@ -160,6 +160,24 @@ pub trait Algebra: std::fmt::Display + Send + Sync + 'static {
     /// Converts a basis element into a string for display.
     fn basis_element_to_string(&self, degree: i32, idx: usize) -> String;
 
+    /// Non-panicking variant of [`Self::basis_element_to_string`]. Returns `None`
+    /// when `degree` is negative or `idx` is out of range for that degree, instead
+    /// of panicking. Computes the basis up to `degree` first.
+    ///
+    /// These are the usual failure conditions. An implementation of
+    /// [`Self::basis_element_to_string`] that can fail for other reasons should override both
+    /// that method and this one, keeping them consistent.
+    fn try_basis_element_to_string(&self, degree: i32, idx: usize) -> Option<String> {
+        if degree < 0 {
+            return None;
+        }
+        self.compute_basis(degree);
+        if idx >= self.dimension(degree) {
+            return None;
+        }
+        Some(self.basis_element_to_string(degree, idx))
+    }
+
     /// Converts a string to a basis element. This must be a one-sided inverse inverse to
     /// both basis_element_to_string and generator_to_string (if [`GeneratedAlgebra`] is
     /// implemented).

--- a/ext/crates/algebra/src/algebra/milnor_algebra.rs
+++ b/ext/crates/algebra/src/algebra/milnor_algebra.rs
@@ -583,9 +583,9 @@ impl Algebra for MilnorAlgebra {
         let p = self.prime();
 
         let mut parser = alt((
-            map(char('1'), |_| (0, 0)),
-            map(char('b'), |_| (1, 0)),
-            map(preceded(p_or_sq, digits), |i| self.beps_pn(0, i)),
+            map(char('1'), |_| Some((0, 0))),
+            map(char('b'), |_| Some((1, 0))),
+            map(preceded(p_or_sq, digits), |i| self.try_beps_pn(0, i)),
             map((tag("P^"), digits, char('_'), digits), |(_, s, _, t)| {
                 let entry = p.pow(s);
                 let degree = entry as i32 * self.q() * combinatorics::xi_degrees(p)[t];
@@ -596,7 +596,8 @@ impl Algebra for MilnorAlgebra {
                 };
                 elt.p_part[t - 1] = entry as PPartEntry;
                 self.compute_basis(degree);
-                (degree, self.basis_element_to_index(&elt))
+                self.try_basis_element_to_index(&elt)
+                    .map(|idx| (degree, idx))
             }),
             map(
                 (
@@ -616,13 +617,14 @@ impl Algebra for MilnorAlgebra {
                     elt.compute_degree(p);
                     self.compute_basis(elt.degree);
 
-                    (elt.degree, self.basis_element_to_index(&elt))
+                    self.try_basis_element_to_index(&elt)
+                        .map(|idx| (elt.degree, idx))
                 },
             ),
         ));
 
         if let Ok(("", res)) = parser.parse(elt) {
-            Some(res)
+            res
         } else {
             None
         }
@@ -1903,6 +1905,48 @@ mod tests {
         assert_eq!(a2.try_beps_pn(0, 7), Some(a2.beps_pn(0, 7)));
         // Invalid input: excluded by the profile, so `None` instead of a panic.
         assert_eq!(a2.try_beps_pn(0, 8), None);
+    }
+
+    #[test]
+    fn basis_element_from_string_total_milnor() {
+        let p = ValidPrime::new(2);
+        let algebra = MilnorAlgebra::new(p, false);
+        algebra.compute_basis(8);
+
+        // Sanity: valid names round-trip through the canonical string form.
+        for name in ["P(1)", "P(2)", "P(0, 1)"] {
+            let (d, i) = algebra
+                .basis_element_from_string(name)
+                .unwrap_or_else(|| panic!("expected Some for {name}"));
+            assert_eq!(algebra.basis_element_to_string(d, i), name);
+        }
+
+        // Syntactically-valid names that name no basis element must return `None`
+        // (they previously panicked in `basis_element_to_index`).
+        //
+        // "P0"/"Sq0" parse via `try_beps_pn(0, 0)`, building the element
+        // {q_part: 0, p_part: [0]} in degree 0, which is not a basis element.
+        assert_eq!(algebra.basis_element_from_string("P0"), None);
+        assert_eq!(algebra.basis_element_from_string("Sq0"), None);
+        // "Q_5" parses via the Q/P branch into a candidate element (degree 63)
+        // whose basis lookup finds nothing at p = 2.
+        assert_eq!(algebra.basis_element_from_string("Q_5"), None);
+
+        // On A(2) (profile [3, 2, 1], truncated) the first xi exponent is bounded
+        // by 2^3 - 1 = 7. "P7" exists; the out-of-profile "P8" parses to a valid
+        // candidate that is excluded by the profile, so it must return `None`.
+        let a2 = MilnorAlgebra::new_with_profile(
+            p,
+            MilnorProfile {
+                q_part: !0,
+                p_part: vec![3, 2, 1],
+                truncated: true,
+            },
+            false,
+        );
+        a2.compute_basis(16);
+        assert!(a2.basis_element_from_string("P7").is_some());
+        assert_eq!(a2.basis_element_from_string("P8"), None);
     }
 
     use crate::module::ModuleFailedRelationError;

--- a/ext/crates/algebra/src/algebra/milnor_algebra.rs
+++ b/ext/crates/algebra/src/algebra/milnor_algebra.rs
@@ -967,7 +967,9 @@ impl MilnorAlgebra {
 
 // Multiplication logic
 impl MilnorAlgebra {
-    fn try_beps_pn(&self, e: u32, x: PPartEntry) -> Option<(i32, usize)> {
+    /// Return the degree and index of $Q_1^e P(x)$, or `None` if the element is not present
+    /// (e.g. out of range or excluded by the profile).
+    pub fn try_beps_pn(&self, e: u32, x: PPartEntry) -> Option<(i32, usize)> {
         let q = self.q() as u32;
         let degree = (q * x + e) as i32;
         self.compute_basis(degree);
@@ -1872,6 +1874,35 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn try_beps_pn_milnor() {
+        let p = ValidPrime::new(2);
+
+        // On the full algebra, `try_beps_pn` agrees with the panicking `beps_pn`
+        // for valid inputs and never returns `None` (every P(x), x >= 1, exists).
+        let algebra = MilnorAlgebra::new(p, false);
+        for x in 1..16 {
+            assert_eq!(algebra.try_beps_pn(0, x), Some(algebra.beps_pn(0, x)));
+            assert!(algebra.try_beps_pn(0, x).is_some());
+        }
+
+        // On A(2) (profile [3, 2, 1], truncated), the first xi exponent is bounded
+        // by 2^3 - 1 = 7, so P(7) is present but P(8) is excluded by the profile.
+        let a2 = MilnorAlgebra::new_with_profile(
+            p,
+            MilnorProfile {
+                q_part: !0,
+                p_part: vec![3, 2, 1],
+                truncated: true,
+            },
+            false,
+        );
+        // Valid input: agrees with `beps_pn`.
+        assert_eq!(a2.try_beps_pn(0, 7), Some(a2.beps_pn(0, 7)));
+        // Invalid input: excluded by the profile, so `None` instead of a panic.
+        assert_eq!(a2.try_beps_pn(0, 8), None);
     }
 
     use crate::module::ModuleFailedRelationError;

--- a/ext/crates/algebra/src/module/finite_dimensional_module.rs
+++ b/ext/crates/algebra/src/module/finite_dimensional_module.rs
@@ -679,7 +679,7 @@ impl<A: GeneratedAlgebra> FiniteDimensionalModule<A> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::algebra::AdemAlgebra;
+    use crate::{algebra::AdemAlgebra, module::ActError};
 
     #[test]
     fn test_module_check_validity() {
@@ -700,5 +700,107 @@ mod tests {
         adem_module.set_action(1, 0, 1, 1, &[1]);
         adem_module.set_action(2, 0, 0, 0, &[1]);
         adem_module.check_validity(0, 2).unwrap();
+    }
+
+    fn make_test_module() -> FiniteDimensionalModule<AdemAlgebra> {
+        let p = fp::prime::ValidPrime::new(2);
+        let adem_algebra = Arc::new(AdemAlgebra::new(p, false));
+        adem_algebra.compute_basis(10);
+        let json = serde_json::json!({
+            "gens": {"x0": 0, "x10": 1, "x11": 1, "x2": 2},
+            "actions": [
+                "Sq1 x0 = x10 + x11",
+                "Sq1 x10 = x2",
+                "Sq1 x11 = x2",
+                "Sq2 x0 = x2",
+            ],
+        });
+        FiniteDimensionalModule::from_json(adem_algebra, &json).unwrap()
+    }
+
+    #[test]
+    fn try_act_on_basis_fd() {
+        let module = make_test_module();
+        let p = module.prime();
+
+        // Valid call: Sq1 acting on the generator x0 lands in degree 1 (dim 2).
+        // The non-panicking variant must succeed and agree with `act_on_basis`.
+        let out_dim = module.dimension(1);
+        let mut result_try = FpVector::new(p, out_dim);
+        let mut result_direct = FpVector::new(p, out_dim);
+        assert!(
+            module
+                .try_act_on_basis(result_try.as_slice_mut(), 1, 1, 0, 0, 0)
+                .is_ok()
+        );
+        module.act_on_basis(result_direct.as_slice_mut(), 1, 1, 0, 0, 0);
+        assert_eq!(result_try, result_direct);
+
+        // Out-of-range op_index is an IndexOutOfRange error (no panic). Degree 1 of the
+        // algebra has dimension 1, so op_index 999 is out of range.
+        let mut result = FpVector::new(p, out_dim);
+        assert!(matches!(
+            module.try_act_on_basis(result.as_slice_mut(), 1, 1, 999, 0, 0),
+            Err(ActError::IndexOutOfRange(_))
+        ));
+
+        // Out-of-range mod_index is an IndexOutOfRange error (no panic). Degree 0 of the
+        // module has dimension 1, so mod_index 999 is out of range.
+        let mut result = FpVector::new(p, out_dim);
+        assert!(matches!(
+            module.try_act_on_basis(result.as_slice_mut(), 1, 1, 0, 0, 999),
+            Err(ActError::IndexOutOfRange(_))
+        ));
+
+        // Negative op_degree is an IndexOutOfRange error.
+        let mut result = FpVector::new(p, out_dim);
+        assert!(matches!(
+            module.try_act_on_basis(result.as_slice_mut(), 1, -1, 0, 0, 0),
+            Err(ActError::IndexOutOfRange(_))
+        ));
+
+        // A mod_degree below the module's min degree is rejected before reaching
+        // compute_basis/the implementor (which could panic on a negative degree).
+        let mut result = FpVector::new(p, out_dim);
+        assert!(matches!(
+            module.try_act_on_basis(result.as_slice_mut(), 1, 1, 0, -1, 0),
+            Err(ActError::IndexOutOfRange(_))
+        ));
+    }
+
+    #[test]
+    fn try_act_fd() {
+        let module = make_test_module();
+        let p = module.prime();
+
+        // Valid call: Sq1 acting on x0 (input degree 0, the single generator).
+        let out_dim = module.dimension(1);
+        let mut input = FpVector::new(p, module.dimension(0));
+        input.set_entry(0, 1);
+        let mut result_try = FpVector::new(p, out_dim);
+        let mut result_direct = FpVector::new(p, out_dim);
+        assert!(
+            module
+                .try_act(result_try.as_slice_mut(), 1, 1, 0, 0, input.as_slice())
+                .is_ok()
+        );
+        module.act(result_direct.as_slice_mut(), 1, 1, 0, 0, input.as_slice());
+        assert_eq!(result_try, result_direct);
+
+        // Out-of-range op_index is an IndexOutOfRange error (no panic).
+        let mut result = FpVector::new(p, out_dim);
+        assert!(matches!(
+            module.try_act(result.as_slice_mut(), 1, 1, 999, 0, input.as_slice()),
+            Err(ActError::IndexOutOfRange(_))
+        ));
+
+        // Input longer than the module dimension is an InvalidInput error (distinct variant,
+        // so the bindings can map it to a different exception type than the index errors).
+        let long_input = FpVector::new(p, module.dimension(0) + 5);
+        let mut result = FpVector::new(p, out_dim);
+        assert!(matches!(
+            module.try_act(result.as_slice_mut(), 1, 1, 0, 0, long_input.as_slice()),
+            Err(ActError::InvalidInput(_))
+        ));
     }
 }

--- a/ext/crates/algebra/src/module/mod.rs
+++ b/ext/crates/algebra/src/module/mod.rs
@@ -21,7 +21,7 @@ pub use free_module::{
     FreeModule, GeneratorData, MuFreeModule, OperationGeneratorPair, UnstableFreeModule,
 };
 pub use hom_module::HomModule;
-pub use module_trait::{Module, ModuleFailedRelationError};
+pub use module_trait::{ActError, Module, ModuleFailedRelationError};
 pub use quotient_module::QuotientModule;
 pub use rpn::RealProjectiveSpace;
 pub use steenrod_module::SteenrodModule;

--- a/ext/crates/algebra/src/module/module_trait.rs
+++ b/ext/crates/algebra/src/module/module_trait.rs
@@ -60,6 +60,92 @@ pub trait Module: std::fmt::Display + std::any::Any + Send + Sync {
         mod_index: usize,
     );
 
+    /// Non-panicking variant of [`Module::act_on_basis`]. Validates the operation and
+    /// module degrees/indices and returns an [`ActError`] describing the problem instead of
+    /// panicking. On success it delegates to [`Module::act_on_basis`] and returns `Ok(())`.
+    fn try_act_on_basis(
+        &self,
+        result: FpSliceMut,
+        coeff: u32,
+        op_degree: i32,
+        op_index: usize,
+        mod_degree: i32,
+        mod_index: usize,
+    ) -> Result<(), ActError> {
+        if op_degree < 0 {
+            return Err(ActError::IndexOutOfRange(format!(
+                "op_degree {op_degree} is negative"
+            )));
+        }
+        self.algebra().compute_basis(op_degree);
+        let op_dim = self.algebra().dimension(op_degree);
+        if op_index >= op_dim {
+            return Err(ActError::IndexOutOfRange(format!(
+                "op_index {op_index} out of range for algebra dimension {op_dim} in degree \
+                 {op_degree}"
+            )));
+        }
+        let min_degree = self.min_degree();
+        if mod_degree < min_degree {
+            return Err(ActError::IndexOutOfRange(format!(
+                "mod_degree {mod_degree} is below the module's min degree {min_degree}"
+            )));
+        }
+        self.compute_basis(mod_degree);
+        let mod_dim = self.dimension(mod_degree);
+        if mod_index >= mod_dim {
+            return Err(ActError::IndexOutOfRange(format!(
+                "mod_index {mod_index} out of range for module dimension {mod_dim} in degree \
+                 {mod_degree}"
+            )));
+        }
+        self.act_on_basis(result, coeff, op_degree, op_index, mod_degree, mod_index);
+        Ok(())
+    }
+
+    /// Non-panicking variant of [`Module::act`]. Validates the operation degree/index and
+    /// the input degree/length and returns an [`ActError`] describing the problem instead of
+    /// panicking. On success it delegates to [`Module::act`] and returns `Ok(())`.
+    fn try_act(
+        &self,
+        result: FpSliceMut,
+        coeff: u32,
+        op_degree: i32,
+        op_index: usize,
+        input_degree: i32,
+        input: FpSlice,
+    ) -> Result<(), ActError> {
+        if op_degree < 0 {
+            return Err(ActError::IndexOutOfRange(format!(
+                "op_degree {op_degree} is negative"
+            )));
+        }
+        self.algebra().compute_basis(op_degree);
+        let op_dim = self.algebra().dimension(op_degree);
+        if op_index >= op_dim {
+            return Err(ActError::IndexOutOfRange(format!(
+                "op_index {op_index} out of range for algebra dimension {op_dim} in degree \
+                 {op_degree}"
+            )));
+        }
+        let min_degree = self.min_degree();
+        if input_degree < min_degree {
+            return Err(ActError::IndexOutOfRange(format!(
+                "input_degree {input_degree} is below the module's min degree {min_degree}"
+            )));
+        }
+        self.compute_basis(input_degree);
+        let input_dim = self.dimension(input_degree);
+        if input.len() > input_dim {
+            return Err(ActError::InvalidInput(format!(
+                "input length {} exceeds module dimension {input_dim} in degree {input_degree}",
+                input.len()
+            )));
+        }
+        self.act(result, coeff, op_degree, op_index, input_degree, input);
+        Ok(())
+    }
+
     /// The name of a basis element. This is useful for debugging and printing results.
     fn basis_element_to_string(&self, degree: i32, idx: usize) -> String;
 
@@ -210,3 +296,25 @@ impl std::fmt::Display for ModuleFailedRelationError {
 }
 
 impl std::error::Error for ModuleFailedRelationError {}
+
+/// Error returned by [`Module::try_act`] and [`Module::try_act_on_basis`].
+///
+/// The variants separate the distinct failure categories so callers (e.g. the
+/// Python bindings) can map them to different error types.
+#[derive(Debug)]
+pub enum ActError {
+    /// A degree is negative, or an operation/module index is beyond the dimension in its degree.
+    IndexOutOfRange(String),
+    /// The input vector is longer than the module dimension in its degree.
+    InvalidInput(String),
+}
+
+impl std::fmt::Display for ActError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::IndexOutOfRange(m) | Self::InvalidInput(m) => f.write_str(m),
+        }
+    }
+}
+
+impl std::error::Error for ActError {}

--- a/ext/crates/sseq/src/sseq.rs
+++ b/ext/crates/sseq/src/sseq.rs
@@ -463,99 +463,126 @@ impl<const N: usize, P: SseqProfile<N>> Sseq<N, P> {
 /// Bigraded-specific methods (charting support).
 impl<P: SseqProfile<2>> Sseq<2, P> {
     /// This shifts the sseq horizontally so that the minimum x is 0.
-    pub fn write_to_graph<'a, T: crate::charting::Backend>(
+    /// Fallible variant of [`Self::write_to_graph`]: this holds the actual drawing logic.
+    ///
+    /// [`Self::write_to_graph`] requires the spectral sequence to have already been shifted so that
+    /// its minimum `y`-coordinate is `0`. This variant checks that precondition up front and
+    /// returns `Err(String)` instead of panicking; when it holds, the inner `Result<(), T::Error>`
+    /// carries any backend error. [`Self::write_to_graph`] is `try_write_to_graph(..).unwrap()`.
+    #[allow(clippy::type_complexity)]
+    pub fn try_write_to_graph<'a, T: crate::charting::Backend>(
         &self,
         mut g: T,
         r: i32,
         differentials: bool,
         products: impl Iterator<Item = &'a (String, Product<2>)> + Clone,
         header: impl FnOnce(&mut T) -> Result<(), T::Error>,
-    ) -> Result<(), T::Error> {
+    ) -> Result<Result<(), T::Error>, String> {
         let min = self.min();
-        assert_eq!(min.y(), 0);
+        if min.y() != 0 {
+            return Err(format!(
+                "write_to_graph requires the minimum y-coordinate to be 0, found {}; shift the \
+                 spectral sequence first",
+                min.y()
+            ));
+        }
 
-        let max = self.max();
+        Ok((move || {
+            let max = self.max();
 
-        g.init(max - min)?;
-        header(&mut g)?;
+            g.init(max - min)?;
+            header(&mut g)?;
 
-        for b in self.iter_degrees() {
-            let shifted_b = b - min;
+            for b in self.iter_degrees() {
+                let shifted_b = b - min;
 
-            let bd = self.page_data(b).get_max(r);
-            if bd.is_empty() {
-                continue;
-            }
-
-            g.node(shifted_b, bd.dimension())?;
-
-            // Now add the products hitting this bidegree
-            for (name, prod) in products.clone() {
-                let source_b = b - prod.b;
-                let shifted_source = source_b - min;
-
-                if !self.defined(source_b) {
+                let bd = self.page_data(b).get_max(r);
+                if bd.is_empty() {
                     continue;
                 }
 
-                let source_data = self.page_data(source_b).get_max(r);
-                if source_data.is_empty() {
-                    continue;
+                g.node(shifted_b, bd.dimension())?;
+
+                // Now add the products hitting this bidegree
+                for (name, prod) in products.clone() {
+                    let source_b = b - prod.b;
+                    let shifted_source = source_b - min;
+
+                    if !self.defined(source_b) {
+                        continue;
+                    }
+
+                    let source_data = self.page_data(source_b).get_max(r);
+                    if source_data.is_empty() {
+                        continue;
+                    }
+
+                    // For unstable charts this is None in low degrees.
+                    if let Some(matrix) = prod.matrices.get(source_b) {
+                        let matrix = Subquotient::reduce_matrix(matrix, source_data, bd);
+                        g.structline_matrix(shifted_source, shifted_b, matrix, Some(name))?;
+                    }
                 }
 
-                // For unstable charts this is None in low degrees.
-                if let Some(matrix) = prod.matrices.get(source_b) {
-                    let matrix = Subquotient::reduce_matrix(matrix, source_data, bd);
-                    g.structline_matrix(shifted_source, shifted_b, matrix, Some(name))?;
-                }
-            }
+                // Finally add the differentials
+                if differentials {
+                    let target_b = P::profile(r, b);
+                    let shifted_target = target_b - min;
 
-            // Finally add the differentials
-            if differentials {
-                let target_b = P::profile(r, b);
-                let shifted_target = target_b - min;
+                    if target_b.x() < 0 {
+                        continue;
+                    }
+                    let d = self.differentials(b);
+                    if d.len() <= r {
+                        continue;
+                    }
+                    let d = &d[r];
+                    let target_data = self.page_data(target_b).get_max(r);
 
-                if target_b.x() < 0 {
-                    continue;
-                }
-                let d = self.differentials(b);
-                if d.len() <= r {
-                    continue;
-                }
-                let d = &d[r];
-                let target_data = self.page_data(target_b).get_max(r);
+                    let pairs = d
+                        .get_source_target_pairs()
+                        .into_iter()
+                        .map(|(mut s, mut t)| {
+                            (
+                                bd.reduce(s.as_slice_mut()),
+                                target_data.reduce(t.as_slice_mut()),
+                            )
+                        });
 
-                let pairs = d
-                    .get_source_target_pairs()
-                    .into_iter()
-                    .map(|(mut s, mut t)| {
-                        (
-                            bd.reduce(s.as_slice_mut()),
-                            target_data.reduce(t.as_slice_mut()),
-                        )
-                    });
-
-                for (source, target) in pairs {
-                    for (i, v) in source.into_iter().enumerate() {
-                        if v == 0 {
-                            continue;
-                        }
-                        for (j, &v) in target.iter().enumerate() {
+                    for (source, target) in pairs {
+                        for (i, v) in source.into_iter().enumerate() {
                             if v == 0 {
                                 continue;
                             }
-                            g.structline(
-                                BidegreeGenerator::new(shifted_b, i),
-                                BidegreeGenerator::new(shifted_target, j),
-                                Some(&format!("d{r}")),
-                            )?;
+                            for (j, &v) in target.iter().enumerate() {
+                                if v == 0 {
+                                    continue;
+                                }
+                                g.structline(
+                                    BidegreeGenerator::new(shifted_b, i),
+                                    BidegreeGenerator::new(shifted_target, j),
+                                    Some(&format!("d{r}")),
+                                )?;
+                            }
                         }
                     }
                 }
             }
-        }
 
-        Ok(())
+            Ok(())
+        })())
+    }
+
+    pub fn write_to_graph<'a, T: crate::charting::Backend>(
+        &self,
+        g: T,
+        r: i32,
+        differentials: bool,
+        products: impl Iterator<Item = &'a (String, Product<2>)> + Clone,
+        header: impl FnOnce(&mut T) -> Result<(), T::Error>,
+    ) -> Result<(), T::Error> {
+        self.try_write_to_graph(g, r, differentials, products, header)
+            .expect("write_to_graph requires the minimum y-coordinate to be 0")
     }
 }
 
@@ -908,5 +935,46 @@ mod tests {
 
         "#]],
         );
+    }
+
+    #[test]
+    fn test_try_write_to_graph_precondition() {
+        use crate::charting::TikzBackend;
+
+        let p = ValidPrime::new(2);
+        let no_products = std::iter::empty::<&(String, Product<2>)>();
+
+        // VALID case: a sseq whose minimum y-coordinate is 0 satisfies the precondition,
+        // so `try_write_to_graph` returns `Ok(..)` and delegates to `write_to_graph`.
+        let mut good = Sseq::<2, Adams>::new(p);
+        good.set_dimension(Bidegree::x_y(0, 0), 1);
+        good.set_dimension(Bidegree::x_y(1, 0), 1);
+        assert_eq!(good.min().y(), 0);
+        let result = good.try_write_to_graph(
+            TikzBackend::new(Vec::<u8>::new()),
+            Adams::MIN_R,
+            true,
+            no_products.clone(),
+            |_| Ok(()),
+        );
+        assert!(result.is_ok(), "min y == 0 should not error");
+        // The inner backend result should also be Ok for this simple chart.
+        assert!(result.unwrap().is_ok());
+
+        // INVALID case: a sseq whose minimum y-coordinate is nonzero violates the
+        // precondition. The original `write_to_graph` would panic via `assert_eq!`; the
+        // fallible variant must instead return `Err(String)`.
+        let mut bad = Sseq::<2, Adams>::new(p);
+        bad.set_dimension(Bidegree::x_y(0, 1), 1);
+        assert_ne!(bad.min().y(), 0);
+        let err = bad.try_write_to_graph(
+            TikzBackend::new(Vec::<u8>::new()),
+            Adams::MIN_R,
+            true,
+            no_products,
+            |_| Ok(()),
+        );
+        assert!(err.is_err(), "nonzero min y should error, not panic");
+        assert!(err.unwrap_err().contains("minimum y-coordinate"));
     }
 }

--- a/ext/src/chain_complex/mod.rs
+++ b/ext/src/chain_complex/mod.rs
@@ -90,25 +90,56 @@ where
     /// Computes the filtration one product.
     ///
     /// # Returns
-    /// If the chain complex is stable, this always returns `Some`. If it is unstable, this returns
-    /// `None` if the product is not defined.
+    /// `Some` when the product is defined (the target bidegree is computed and `op_idx` is in
+    /// range), and `None` otherwise. This is
+    /// [`try_filtration_one_product`](Self::try_filtration_one_product) with the error discarded;
+    /// use that variant to learn why the product is unavailable.
     fn filtration_one_product(
         &self,
         op_deg: i32,
         op_idx: usize,
         source: Bidegree,
     ) -> Option<Vec<Vec<u32>>> {
+        self.try_filtration_one_product(op_deg, op_idx, source).ok()
+    }
+
+    /// Computes the filtration one product, returning an error explaining why the product is
+    /// unavailable instead of swallowing it as `None`.
+    ///
+    /// # Returns
+    /// - `Err(..)` if the target bidegree has not been computed, or if `op_idx` is out of range for
+    ///   the operation degree (in the unstable case this means the product is genuinely not
+    ///   defined; in the stable case it is a caller error);
+    /// - `Ok(products)` with the computed products otherwise.
+    fn try_filtration_one_product(
+        &self,
+        op_deg: i32,
+        op_idx: usize,
+        source: Bidegree,
+    ) -> anyhow::Result<Vec<Vec<u32>>> {
+        anyhow::ensure!(
+            op_deg >= 0,
+            "filtration one product unavailable: op_deg {op_deg} is negative"
+        );
+        anyhow::ensure!(
+            source.s() >= 0 && source.t() >= 0,
+            "filtration one product unavailable: source bidegree {source} has negative coordinates"
+        );
+
         let target = source + Bidegree::s_t(1, op_deg);
-        if !self.has_computed_bidegree(target) {
-            return None;
-        }
+        anyhow::ensure!(
+            self.has_computed_bidegree(target),
+            "filtration one product unavailable: target bidegree {target} has not been computed"
+        );
 
         let source_mod = self.module(target.s() - 1);
         let target_mod = self.module(target.s());
 
-        if U && op_idx >= self.algebra().dimension_unstable(op_deg, source.t()) {
-            return None;
-        }
+        let dim = self.algebra().dimension_unstable(op_deg, source.t());
+        anyhow::ensure!(
+            op_idx < dim,
+            "op_idx {op_idx} out of range for operation degree {op_deg} (algebra dimension {dim})"
+        );
 
         let source_dim = source_mod.number_of_gens_in_degree(source.t());
         let target_dim = target_mod.number_of_gens_in_degree(target.t());
@@ -125,7 +156,7 @@ where
             }
         }
 
-        Some(products)
+        Ok(products)
     }
 
     fn number_of_gens_in_bidegree(&self, b: Bidegree) -> usize {

--- a/ext/src/secondary.rs
+++ b/ext/src/secondary.rs
@@ -516,11 +516,20 @@ pub trait SecondaryLift: Sync + Sized {
             })
     }
 
-    #[tracing::instrument(skip(self), fields(%b))]
     fn compute_homotopy_step(&self, b: Bidegree) -> std::ops::Range<i32> {
+        self.try_compute_homotopy_step(b).unwrap()
+    }
+
+    /// Fallible version of [`compute_homotopy_step`](Self::compute_homotopy_step).
+    ///
+    /// Returns `Err` when the input does not lift to a secondary homotopy, i.e. when the input
+    /// is invalid. [`compute_homotopy_step`](Self::compute_homotopy_step) is simply
+    /// `self.try_compute_homotopy_step(b).unwrap()`.
+    #[tracing::instrument(skip(self), fields(%b))]
+    fn try_compute_homotopy_step(&self, b: Bidegree) -> anyhow::Result<std::ops::Range<i32>> {
         let homotopy = &self.homotopies()[b.s()];
         if homotopy.homotopies.next_degree() > b.t() {
-            return b.t()..b.t() + 1;
+            return Ok(b.t()..b.t() + 1);
         }
         let p = self.prime();
         let shift = self.shift();
@@ -545,9 +554,9 @@ pub trait SecondaryLift: Sync + Sized {
                 for _ in 0..num_gens {
                     results.push(FpVector::from_bytes(p, target_dim, &mut f).unwrap());
                 }
-                return self.homotopies()[b.s()]
+                return Ok(self.homotopies()[b.s()]
                     .homotopies
-                    .add_generators_from_rows_ooo(b.t(), results);
+                    .add_generators_from_rows_ooo(b.t(), results));
             }
         }
 
@@ -575,14 +584,17 @@ pub trait SecondaryLift: Sync + Sized {
 
         let mut results = vec![FpVector::new(p, target_dim); num_gens];
 
-        assert!(target.apply_quasi_inverse(&mut results, target_b, &intermediates,));
+        anyhow::ensure!(
+            target.apply_quasi_inverse(&mut results, target_b, &intermediates,),
+            "secondary: failed to apply quasi-inverse at {b}; the input likely does not lift"
+        );
 
         if b.s() == shift.s() + 1 {
             // Check that we indeed had a lift
             let d = target.differential(target_b.s());
             for (src, tgt) in std::iter::zip(&results, &mut intermediates) {
                 d.apply(tgt.as_slice_mut(), p - 1, target_b.t(), src.as_slice());
-                assert!(
+                anyhow::ensure!(
                     tgt.is_zero(),
                     "secondary: Failed to lift at {b}. This likely indicates an invalid input."
                 );
@@ -616,9 +628,9 @@ pub trait SecondaryLift: Sync + Sized {
             }
         }
 
-        homotopy
+        Ok(homotopy
             .homotopies
-            .add_generators_from_rows_ooo(b.t(), results)
+            .add_generators_from_rows_ooo(b.t(), results))
     }
 
     #[tracing::instrument(skip(self))]
@@ -1430,5 +1442,59 @@ mod tests {
         resolution.compute_through_stem(Bidegree::n_s(20, 5));
         let lift = SecondaryResolution::new(Arc::new(resolution));
         lift.extend_all();
+    }
+
+    #[test]
+    fn cofib_h4_try_returns_err() {
+        let module = json!({
+            "type": "finite dimensional module",
+            "p": 2,
+            "gens": {
+                "x0": 0,
+                "x16": 16,
+            },
+            "actions": ["Sq16 x0 = x16"]
+        });
+        let resolution = utils::construct((module, algebra::AlgebraType::Milnor), None).unwrap();
+        resolution.compute_through_stem(Bidegree::n_s(20, 5));
+        let lift = SecondaryResolution::new(Arc::new(resolution));
+
+        // The failing bidegree is (n, s) = (14, 3), i.e. s = 3, t = 17.
+        let failing = Bidegree::n_s(14, 3);
+
+        // Compute all prerequisite data, then drive the homotopy steps exactly as
+        // `compute_homotopies` does, but skip the failing step (and everything that comes
+        // after it) by returning a dummy "already computed" range. This computes all the
+        // predecessors of `failing` without panicking, leaving `failing` to be computed
+        // explicitly via the fallible path below.
+        lift.initialize_homotopies();
+        lift.compute_composites();
+        lift.compute_intermediates();
+
+        let shift = lift.shift();
+        {
+            let h = &lift.homotopies()[shift.s()];
+            h.homotopies.extend_by_zero(h.composites.max_degree());
+        }
+        let min_t = lift.homotopies()[shift.s()].homotopies.min_degree();
+        let s_range = lift.homotopies().range();
+        let min = Bidegree::s_t(s_range.start + 1, min_t);
+        let max = lift.max().restrict(s_range.end);
+        sseq::coordinates::iter_s_t(
+            &|b| {
+                if b.s() > failing.s() || (b.s() == failing.s() && b.t() >= failing.t()) {
+                    // Skip the failing step and everything after it.
+                    return b.t()..b.t() + 1;
+                }
+                lift.compute_homotopy_step(b)
+            },
+            min,
+            max,
+        );
+
+        // The failing step should report an error rather than panicking.
+        let result = lift.try_compute_homotopy_step(failing);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("Failed to lift"));
     }
 }

--- a/ext/src/utils.rs
+++ b/ext/src/utils.rs
@@ -53,7 +53,10 @@ pub fn parse_module_name(module_name: &str) -> anyhow::Result<Value> {
                 .with_context(|| format!("Cannot parse shift value ({x}) as an integer"))?,
         };
         if let Some(spec_shift) = module.get_mut("shift") {
-            *spec_shift = Value::from(spec_shift.as_i64().unwrap() + shift);
+            let existing = spec_shift
+                .as_i64()
+                .with_context(|| format!("Module shift field is not an integer: {spec_shift}"))?;
+            *spec_shift = Value::from(existing + shift);
         } else {
             module["shift"] = Value::from(shift);
         }
@@ -274,8 +277,34 @@ where
 /// Given the name of a module file (without the `.json` extension), find a json file with this
 /// name, and return the parsed json object. The search path for this json file is described
 /// [here](../index.html#module-specification).
-pub fn load_module_json(name: &str) -> anyhow::Result<Value> {
-    let current_dir = std::env::current_dir().context("Failed to read current directory")?;
+/// Error returned by [`load_module_json`].
+///
+/// Separates a missing module file from one that is present but cannot be read or parsed, so
+/// callers (e.g. the Python bindings) can map `NotFound` to `FileNotFoundError` and `Read` to a
+/// generic runtime error.
+#[derive(Debug)]
+pub enum LoadModuleError {
+    /// No module file with this name exists in any search path.
+    NotFound(String),
+    /// A module file was found but could not be read or parsed.
+    Read(anyhow::Error),
+}
+
+impl std::fmt::Display for LoadModuleError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NotFound(name) => write!(f, "Module file '{name}' not found"),
+            Self::Read(e) => write!(f, "{e}"),
+        }
+    }
+}
+
+impl std::error::Error for LoadModuleError {}
+
+pub fn load_module_json(name: &str) -> Result<Value, LoadModuleError> {
+    let current_dir = std::env::current_dir().map_err(|e| {
+        LoadModuleError::Read(anyhow::Error::new(e).context("Failed to read current directory"))
+    })?;
     let relative_dir = current_dir.join("steenrod_modules");
 
     for path in &[
@@ -287,11 +316,15 @@ pub fn load_module_json(name: &str) -> anyhow::Result<Value> {
         path.push(name);
         path.set_extension("json");
         if let Ok(s) = std::fs::read_to_string(&path) {
-            return serde_json::from_str(&s)
-                .with_context(|| format!("Failed to load module json at {path:?}"));
+            return serde_json::from_str(&s).map_err(|e| {
+                LoadModuleError::Read(
+                    anyhow::Error::new(e)
+                        .context(format!("Failed to load module json at {path:?}")),
+                )
+            });
         }
     }
-    Err(anyhow!("Module file '{}' not found", name))
+    Err(LoadModuleError::NotFound(name.to_string()))
 }
 
 /// Given an `n: usize`, return a UTF-8 character that best depicts this number. If `n < 9`, then

--- a/ext/src/utils.rs
+++ b/ext/src/utils.rs
@@ -218,7 +218,9 @@ where
 
     let cofiber = &json["cofiber"];
     if !cofiber.is_null() {
-        assert!(!U, "Cofiber not supported for unstable resolution");
+        if U {
+            return Err(anyhow!("Cofiber not supported for unstable resolution"));
+        }
         use algebra::module::homomorphism::FreeModuleHomomorphism;
 
         use crate::{chain_complex::ChainMap, yoneda::yoneda_representative};
@@ -226,15 +228,22 @@ where
         let shift = json["shift"].as_i64().unwrap_or(0) as i32;
 
         let cofiber = BidegreeGenerator::s_t(
-            cofiber["s"].as_i64().unwrap() as i32,
-            cofiber["t"].as_i64().unwrap() as i32 + shift,
-            cofiber["idx"].as_u64().unwrap() as usize,
+            cofiber["s"]
+                .as_i64()
+                .context("Cofiber spec is missing an integer `s` field")? as i32,
+            cofiber["t"]
+                .as_i64()
+                .context("Cofiber spec is missing an integer `t` field")? as i32
+                + shift,
+            cofiber["idx"]
+                .as_u64()
+                .context("Cofiber spec is missing an integer `idx` field")? as usize,
         );
 
         let max_degree = Bidegree::n_s(
             module
                 .max_degree()
-                .expect("Can only take cofiber when module is bounded"),
+                .context("Can only take cofiber when module is bounded")?,
             0,
         );
 
@@ -246,13 +255,16 @@ where
             Arc::clone(&module),
             cofiber.t(),
         );
-        let mut new_output = fp::matrix::Matrix::new(
-            module.prime(),
-            resolution
-                .module(cofiber.s())
-                .number_of_gens_in_degree(cofiber.t()),
-            1,
+        let num_gens = resolution
+            .module(cofiber.s())
+            .number_of_gens_in_degree(cofiber.t());
+        anyhow::ensure!(
+            cofiber.idx() < num_gens,
+            "Cofiber idx {} out of range: bidegree {} has {num_gens} generators",
+            cofiber.idx(),
+            cofiber.degree()
         );
+        let mut new_output = fp::matrix::Matrix::new(module.prime(), num_gens, 1);
         new_output.row_mut(cofiber.idx()).set_entry(0, 1);
 
         map.add_generators_from_matrix_rows(cofiber.t(), new_output.as_slice_mut());

--- a/ext/src/yoneda.rs
+++ b/ext/src/yoneda.rs
@@ -75,7 +75,21 @@ fn split_mut_borrow<T>(v: &mut [T], i: usize, j: usize) -> (&mut T, &mut T) {
     (&mut first[i], &mut second[0])
 }
 
-pub fn yoneda_representative_element<CC>(cc: Arc<CC>, b: Bidegree, class: &[u32]) -> Yoneda<CC>
+/// Fallible variant of [`yoneda_representative_element`]: this holds the actual computation.
+///
+/// It validates the cheaply-checkable preconditions up front and returns an error instead of
+/// panicking when they are violated, namely:
+///  - the bidegree `b` must have been computed in `cc`, and
+///  - the length of `class` must match the number of generators of `cc` in bidegree `b`.
+///
+/// The internal Euler-characteristic / lift sanity checks (mathematical invariants that can only be
+/// verified after replaying the computation) are likewise surfaced as errors rather than panicking.
+/// [`yoneda_representative_element`] is `try_yoneda_representative_element(..).unwrap()`.
+pub fn try_yoneda_representative_element<CC>(
+    cc: Arc<CC>,
+    b: Bidegree,
+    class: &[u32],
+) -> anyhow::Result<Yoneda<CC>>
 where
     CC: FreeChainComplex
         + AugmentedChainComplex<
@@ -86,6 +100,19 @@ where
     CC::TargetComplex: BoundedChainComplex,
     CC::Algebra: GeneratedAlgebra,
 {
+    if !cc.has_computed_bidegree(b) {
+        return Err(anyhow::anyhow!(
+            "cannot compute Yoneda representative: bidegree {b} has not been computed"
+        ));
+    }
+    let num_gens = cc.number_of_gens_in_bidegree(b);
+    if class.len() != num_gens {
+        return Err(anyhow::anyhow!(
+            "class length {} does not match the number of generators {num_gens} in bidegree {b}",
+            class.len()
+        ));
+    }
+
     let p = cc.prime();
 
     let target = FDModule::new(cc.algebra(), "".to_string(), BiVec::from_vec(0, vec![1]));
@@ -107,11 +134,11 @@ where
     let module = cc.target().module(0);
 
     for t in cc.min_degree()..=b.t() {
-        assert_eq!(
-            yoneda.euler_characteristic(t),
-            module.dimension(t) as isize,
-            "Incorrect Euler characteristic at t = {t}",
-        );
+        let euler = yoneda.euler_characteristic(t);
+        let dim = module.dimension(t) as isize;
+        if euler != dim {
+            anyhow::bail!("Incorrect Euler characteristic at t = {t}: {euler} != {dim}");
+        }
     }
 
     let f = ResolutionHomomorphism::from_module_homomorphism(
@@ -124,12 +151,38 @@ where
     f.extend_through_stem(b);
     let final_map = f.get_map(b.s());
     for (i, &v) in class.iter().enumerate() {
-        assert_eq!(final_map.output(b.t(), i).len(), 1);
-        assert_eq!(final_map.output(b.t(), i).entry(0), v);
+        let out = final_map.output(b.t(), i);
+        if out.len() != 1 {
+            anyhow::bail!(
+                "lift verification failed: output at index {i} has length {}, expected 1",
+                out.len()
+            );
+        }
+        if out.entry(0) != v {
+            anyhow::bail!(
+                "lift verification failed: output at index {i} is {}, expected {v}",
+                out.entry(0)
+            );
+        }
     }
 
     drop(f);
-    Arc::try_unwrap(yoneda).unwrap_or_else(|_| unreachable!())
+    Ok(Arc::try_unwrap(yoneda).unwrap_or_else(|_| unreachable!()))
+}
+
+pub fn yoneda_representative_element<CC>(cc: Arc<CC>, b: Bidegree, class: &[u32]) -> Yoneda<CC>
+where
+    CC: FreeChainComplex
+        + AugmentedChainComplex<
+            ChainMap = FreeModuleHomomorphism<
+                <<CC as AugmentedChainComplex>::TargetComplex as ChainComplex>::Module,
+            >,
+        >,
+    CC::TargetComplex: BoundedChainComplex,
+    CC::Algebra: GeneratedAlgebra,
+{
+    try_yoneda_representative_element(cc, b, class)
+        .expect("yoneda_representative_element: invalid bidegree or class length")
 }
 
 /// This function produces a quasi-isomorphic quotient of `cc` (as an augmented chain complex) that `map` factors through

--- a/ext/tests/construct_cofiber_error.rs
+++ b/ext/tests/construct_cofiber_error.rs
@@ -1,0 +1,55 @@
+use ext::utils::{construct, construct_standard};
+use serde_json::json;
+
+/// A cofiber spec with a non-integer `s` (`t`, `idx`) field must surface an
+/// `Err` from `construct` rather than panicking on `.unwrap()`.
+#[test]
+fn cofiber_non_integer_field() {
+    // S^0 over A_2: a valid, bounded base module so we reach the cofiber block.
+    let base = json!({
+        "p": 2,
+        "type": "finite dimensional module",
+        "gens": { "x0": 0 },
+        "actions": [],
+    });
+
+    // Non-integer `s` -> `cofiber["s"].as_i64()` is None -> Err (was `.unwrap()`).
+    let mut bad_s = base.clone();
+    bad_s["cofiber"] = json!({ "s": "x", "t": 0, "idx": 0 });
+    assert!(construct((bad_s.clone(), "adem"), None).is_err());
+    assert!(construct((bad_s, "milnor"), None).is_err());
+
+    // Non-integer `t` -> Err (was `.unwrap()`).
+    let mut bad_t = base.clone();
+    bad_t["cofiber"] = json!({ "s": 0, "t": "x", "idx": 0 });
+    assert!(construct((bad_t.clone(), "adem"), None).is_err());
+    assert!(construct((bad_t, "milnor"), None).is_err());
+
+    // Non-integer `idx` -> `cofiber["idx"].as_u64()` is None -> Err (was `.unwrap()`).
+    let mut bad_idx = base.clone();
+    bad_idx["cofiber"] = json!({ "s": 0, "t": 0, "idx": "x" });
+    assert!(construct((bad_idx.clone(), "adem"), None).is_err());
+    assert!(construct((bad_idx, "milnor"), None).is_err());
+
+    // An in-range integer `idx` that exceeds the number of generators must be an Err
+    // (rather than panicking in `Matrix::row_mut`).
+    let mut oor_idx = base.clone();
+    oor_idx["cofiber"] = json!({ "s": 0, "t": 0, "idx": 999 });
+    assert!(construct((oor_idx.clone(), "adem"), None).is_err());
+    assert!(construct((oor_idx, "milnor"), None).is_err());
+}
+
+/// An unstable resolution does not support cofibers: reaching
+/// `construct_standard::<true>` with a cofiber spec must return `Err`
+/// (was `assert!(!U, ...)`).
+#[test]
+fn cofiber_unstable_unsupported() {
+    let mut json = json!({
+        "p": 2,
+        "type": "finite dimensional module",
+        "gens": { "x0": 0 },
+        "actions": [],
+    });
+    json["cofiber"] = json!({ "s": 0, "t": 0, "idx": 0 });
+    assert!(construct_standard::<true, _, _>((json, "adem"), None).is_err());
+}

--- a/ext/tests/filtration_one_product.rs
+++ b/ext/tests/filtration_one_product.rs
@@ -1,0 +1,51 @@
+use ext::{
+    chain_complex::{ChainComplex, FreeChainComplex},
+    utils::construct,
+};
+use sseq::coordinates::Bidegree;
+
+#[test]
+fn filtration_one_product() {
+    let resolution = construct(("S_2", "milnor"), None).unwrap();
+    resolution.compute_through_bidegree(Bidegree::s_t(8, 8));
+
+    // op_deg 1 is Sq^1 at p=2; the algebra dimension in degree 1 is 1, so op_idx 0 is
+    // valid and op_idx 999 is far out of range.
+
+    // Stable out-of-range op_idx on a computed source is a caller error -> Err.
+    let source = Bidegree::s_t(0, 0);
+    assert!(resolution.has_computed_bidegree(source + Bidegree::s_t(1, 1)));
+    assert!(
+        resolution
+            .try_filtration_one_product(1, 999, source)
+            .is_err()
+    );
+
+    // A valid call succeeds.
+    assert!(resolution.try_filtration_one_product(1, 0, source).is_ok());
+
+    // Negative op_deg or source coordinates are rejected (rather than indexing modules/algebra
+    // with a negative degree and panicking).
+    assert!(
+        resolution
+            .try_filtration_one_product(-1, 0, source)
+            .is_err()
+    );
+    assert!(
+        resolution
+            .try_filtration_one_product(1, 0, Bidegree::s_t(-1, 0))
+            .is_err()
+    );
+
+    // The not-computed branch: a source whose target bidegree is far beyond what was
+    // resolved is unavailable -> Err.
+    let far = Bidegree::s_t(100, 100);
+    assert!(!resolution.has_computed_bidegree(far + Bidegree::s_t(1, 1)));
+    assert!(resolution.try_filtration_one_product(1, 0, far).is_err());
+
+    // filtration_one_product discards the error: out-of-range and not-computed both give
+    // None, while a valid call gives Some.
+    assert_eq!(resolution.filtration_one_product(1, 999, source), None);
+    assert_eq!(resolution.filtration_one_product(1, 0, far), None);
+    assert!(resolution.filtration_one_product(1, 0, source).is_some());
+}

--- a/ext/tests/parse_module_name.rs
+++ b/ext/tests/parse_module_name.rs
@@ -1,0 +1,30 @@
+use ext::utils::{LoadModuleError, load_module_json, parse_module_name};
+
+#[test]
+fn valid_module_name_parses_ok() {
+    // "S_2" is a bundled module (see ext/steenrod_modules/S_2.json).
+    assert!(parse_module_name("S_2").is_ok());
+}
+
+#[test]
+fn nonexistent_module_name_is_err_not_panic() {
+    // A name with no corresponding json file must surface an error rather than panic.
+    // load_module_json reports it as the distinct NotFound variant (so a caller can map it
+    // to FileNotFoundError, separately from read/parse failures).
+    assert!(parse_module_name("this_module_does_not_exist_xyz").is_err());
+    assert!(matches!(
+        load_module_json("this_module_does_not_exist_xyz"),
+        Err(LoadModuleError::NotFound(_))
+    ));
+}
+
+#[test]
+fn non_integer_shift_suffix_is_err_not_panic() {
+    // The `[shift]` suffix must parse as an integer; a non-integer suffix returns Err.
+    assert!(parse_module_name("S_2[not_an_integer]").is_err());
+}
+
+#[test]
+fn unterminated_shift_bracket_is_err() {
+    assert!(parse_module_name("S_2[5").is_err());
+}

--- a/ext/tests/try_yoneda.rs
+++ b/ext/tests/try_yoneda.rs
@@ -1,0 +1,46 @@
+use std::sync::Arc;
+
+use ext::{
+    chain_complex::{ChainComplex, FreeChainComplex},
+    utils::construct,
+    yoneda::try_yoneda_representative_element,
+};
+use sseq::coordinates::Bidegree;
+
+#[test]
+fn try_yoneda_representative_element_validates_input() {
+    let resolution = Arc::new(construct(("S_2", "milnor"), None).unwrap());
+    resolution.compute_through_bidegree(Bidegree::s_t(4, 4));
+
+    // VALID case: the bottom class (0, 0) is a computed bidegree with exactly one
+    // generator, so a class vector of length 1 is well-formed.
+    let bottom = Bidegree::s_t(0, 0);
+    assert!(resolution.has_computed_bidegree(bottom));
+    assert_eq!(resolution.number_of_gens_in_bidegree(bottom), 1);
+    assert!(try_yoneda_representative_element(Arc::clone(&resolution), bottom, &[1]).is_ok());
+
+    // VALID case: the h_0 class lives at (s, t) = (1, 1), a computed nonzero bidegree.
+    let h0 = Bidegree::s_t(1, 1);
+    assert!(resolution.has_computed_bidegree(h0));
+    let h0_gens = resolution.number_of_gens_in_bidegree(h0);
+    assert_eq!(h0_gens, 1);
+    let class: Vec<u32> = vec![1; h0_gens];
+    assert!(try_yoneda_representative_element(Arc::clone(&resolution), h0, &class).is_ok());
+
+    // INVALID case: an uncomputed bidegree (far beyond the resolved range) must return
+    // Err instead of panicking.
+    let uncomputed = Bidegree::s_t(100, 100);
+    assert!(!resolution.has_computed_bidegree(uncomputed));
+    assert!(
+        try_yoneda_representative_element(Arc::clone(&resolution), uncomputed, &[]).is_err(),
+        "uncomputed bidegree should error, not panic"
+    );
+
+    // INVALID case: a class vector whose length does not match the generator count at a
+    // computed bidegree must return Err instead of panicking.
+    let wrong_len = vec![0; resolution.number_of_gens_in_bidegree(bottom) + 3];
+    assert!(
+        try_yoneda_representative_element(Arc::clone(&resolution), bottom, &wrong_len).is_err(),
+        "class of wrong length should error, not panic"
+    );
+}


### PR DESCRIPTION
To help with Python bindings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added several fallible APIs that return errors or `None` instead of panicking in common edge cases.
  * Improved module loading and parsing with clearer error messages for missing files, invalid shifts, and malformed cofiber inputs.
  * Added safer helpers for algebra basis lookup, module actions, graph output, filtration products, and Yoneda representatives.

* **Bug Fixes**
  * Invalid or out-of-range inputs now fail gracefully across algebra, module, chain-complex, and spectral-sequence workflows.
  * Preserved existing behavior for valid inputs while reducing unexpected crashes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->