### PR TITLE
Catch wasm worker panics and surface them as error dialogs

### DIFF
--- a/.github/workflows/ext.yaml
+++ b/.github/workflows/ext.yaml
@@ -169,6 +169,9 @@ jobs:
       - name: Lint sseq_gui wasm
         run: make -C web_ext/sseq_gui lint-wasm
 
+      - name: Test worker panic handling
+        run: make -C web_ext/sseq_gui test-wasm-js
+
       - name: Build wasm
         run: make -C web_ext/sseq_gui wasm
 

--- a/web_ext/sseq_gui/Makefile
+++ b/web_ext/sseq_gui/Makefile
@@ -61,7 +61,12 @@ test-wasm-unwind:
 		|| { echo "ERROR: $(WASM_LIB) has no Tag section; panic=unwind is not in effect"; exit 1; }
 	@echo "OK: wasm built with exception-handling (panic=unwind)"
 
-.PHONY: wasm serve-wasm clean-wasm clean dummy test selenium selenium-update test-wasm-unwind FORCE
+# Unit-test the panic-catching logic in the worker JS (wasm/*_worker.js).
+# Runs in plain Node with mocked wasm globals, so no browser/wasm build needed.
+test-wasm-js:
+	node --test wasm/*.test.mjs
+
+.PHONY: wasm serve-wasm clean-wasm clean dummy test selenium selenium-update test-wasm-unwind test-wasm-js FORCE
 
 wasm: $(WASM_FILE) $(wildcard interface/*) $(wildcard wasm/*) $(wildcard $(EXT)/steenrod_modules/*)
 	# Must be done in this order since both contain index.js and we want the wasm version

--- a/web_ext/sseq_gui/wasm/resolution_worker.js
+++ b/web_ext/sseq_gui/wasm/resolution_worker.js
@@ -6,10 +6,26 @@ const promise = wasm_bindgen("./sseq_gui_wasm_bg.wasm").catch(console.error).the
     self.resolution = Resolution.new(m => self.postMessage(m));
 });
 
+function reportPanic(err) {
+    const message =
+        err && err.stack ? err.stack : `${err}`;
+    self.postMessage(
+        JSON.stringify({
+            recipients: [],
+            sseq: 'Main',
+            action: { Error: { message: `Panic in resolution worker:\n${message}` } },
+        }),
+    );
+}
+
 self.onmessage = ev => {
     if (!self.resolution) {
         promise.then(() => self.onmessage(ev));
         return;
     }
-    self.resolution.run(ev.data);
+    try {
+        self.resolution.run(ev.data);
+    } catch (err) {
+        reportPanic(err);
+    }
 }

--- a/web_ext/sseq_gui/wasm/sseq_worker.js
+++ b/web_ext/sseq_gui/wasm/sseq_worker.js
@@ -6,10 +6,26 @@ const promise = wasm_bindgen("./sseq_gui_wasm_bg.wasm").catch(console.error).the
     self.sseq = Sseq.new((m) => self.postMessage(m));
 });
 
+function reportPanic(err) {
+    const message =
+        err && err.stack ? err.stack : `${err}`;
+    self.postMessage(
+        JSON.stringify({
+            recipients: [],
+            sseq: 'Main',
+            action: { Error: { message: `Panic in sseq worker:\n${message}` } },
+        }),
+    );
+}
+
 self.onmessage = ev => {
     if (!self.sseq) {
         promise.then(() => self.onmessage(ev));
         return;
     }
-    self.sseq.run(ev.data);
+    try {
+        self.sseq.run(ev.data);
+    } catch (err) {
+        reportPanic(err);
+    }
 }

--- a/web_ext/sseq_gui/wasm/worker_panic.test.mjs
+++ b/web_ext/sseq_gui/wasm/worker_panic.test.mjs
@@ -1,0 +1,121 @@
+'use strict';
+
+// Unit tests for the panic-catching logic added to the wasm workers.
+//
+// With `panic=unwind`, wasm-bindgen rethrows Rust panics as JS exceptions out
+// of the exported `run()` method. The workers wrap that call in a try/catch
+// and forward the failure as an `Error` action message, which the frontend
+// renders as a dialog (see `interface/index.js`'s `messageHandler.Error`).
+//
+// These tests load the (tiny) worker scripts into a sandbox with mocked
+// browser/wasm globals so we can make `run()` throw and assert on what gets
+// posted back, without needing a browser or a compiled wasm module.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import vm from 'node:vm';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+// Load a worker script into a sandbox with the globals it expects
+// (`self`, `importScripts`, `wasm_bindgen`). Returns handles to drive it:
+// `self` (with the installed `onmessage`), the list of `posted` messages, and
+// the wasm `instance` whose `run` method the test can override.
+async function loadWorker(filename, className) {
+    const source = readFileSync(join(here, filename), 'utf8');
+
+    const posted = [];
+    const instance = {
+        run() {
+            throw new Error('run() should be overridden by the test');
+        },
+    };
+
+    // `wasm_bindgen` is both callable (loads the module, returns a promise)
+    // and carries the exported classes as properties.
+    function wasm_bindgen() {
+        return Promise.resolve();
+    }
+    wasm_bindgen[className] = {
+        new() {
+            return instance;
+        },
+    };
+
+    const self = {
+        postMessage: msg => posted.push(msg),
+        onmessage: null,
+    };
+
+    const sandbox = {
+        self,
+        wasm_bindgen,
+        importScripts() {},
+        console,
+    };
+    vm.createContext(sandbox);
+    vm.runInContext(source, sandbox, { filename });
+
+    // The script sets `self.<instance>` asynchronously once the (mocked) wasm
+    // module "loads". Flush microtasks so it is ready before we return.
+    await new Promise(resolve => setImmediate(resolve));
+
+    return { self, posted, instance };
+}
+
+const cases = [
+    {
+        filename: 'sseq_worker.js',
+        className: 'Sseq',
+        label: 'Panic in sseq worker:',
+    },
+    {
+        filename: 'resolution_worker.js',
+        className: 'Resolution',
+        label: 'Panic in resolution worker:',
+    },
+];
+
+for (const { filename, className, label } of cases) {
+    test(`${filename}: a panic in run() is forwarded as an Error message`, async () => {
+        const { self, posted, instance } = await loadWorker(filename, className);
+
+        instance.run = () => {
+            throw new Error('boom');
+        };
+
+        self.onmessage({ data: '{"some": "message"}' });
+
+        assert.equal(posted.length, 1, 'exactly one message should be posted');
+
+        const msg = JSON.parse(posted[0]);
+        assert.deepEqual(msg.recipients, []);
+        assert.equal(msg.sseq, 'Main');
+        assert.ok(msg.action.Error, 'message should be an Error action');
+        assert.ok(
+            msg.action.Error.message.startsWith(label),
+            `error message should be labelled with "${label}"`,
+        );
+        assert.ok(
+            msg.action.Error.message.includes('boom'),
+            'error message should include the panic text',
+        );
+    });
+
+    test(`${filename}: a successful run() posts nothing`, async () => {
+        const { self, posted, instance } = await loadWorker(filename, className);
+
+        let received;
+        instance.run = data => {
+            received = data;
+        };
+
+        self.onmessage({ data: 'payload' });
+
+        assert.equal(received, 'payload', 'run() should receive the message data');
+        assert.equal(posted.length, 0, 'no error message should be posted');
+    });
+}


### PR DESCRIPTION
With panic=unwind, wasm-bindgen rethrows Rust panics as JS exceptions out of the exported run() method. Previously these escaped uncaught in the worker and were invisible to the user. Wrap the run() calls in the sseq and resolution workers in try/catch and forward the failure as an Error action message, which the frontend already renders as a dialog.

Add a Node unit test (make test-wasm-js) that loads the worker scripts with mocked wasm globals, makes run() throw, and asserts an Error message is posted. Wire it into the webserver CI job.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling in background worker tasks so failures are reported back to the app instead of failing silently.
  * Added clearer error messages when worker execution encounters unexpected issues.

* **Tests**
  * Added automated coverage for worker error handling to verify both successful runs and failure reporting.
  * Included the new test in the existing workflow so it runs during continuous integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->