### PR TITLE
Add hash-free seqno index tables to the Milnor algebra

### DIFF
--- a/ext/crates/algebra/Cargo.toml
+++ b/ext/crates/algebra/Cargo.toml
@@ -17,6 +17,7 @@ maybe-rayon = { path = "../maybe-rayon" }
 once = { path = "../once" }
 
 anyhow = "1.0.98"
+arc-swap = "1.7.1"
 auto_impl = "1.3.0"
 hashbrown = "0.15.4"
 itertools = { version = "0.14.0", default-features = false, features = [
@@ -54,4 +55,8 @@ harness = false
 
 [[bench]]
 name = "nassau_milnor"
+harness = false
+
+[[bench]]
+name = "seqno"
 harness = false

--- a/ext/crates/algebra/Cargo.toml
+++ b/ext/crates/algebra/Cargo.toml
@@ -17,6 +17,7 @@ maybe-rayon = { path = "../maybe-rayon" }
 once = { path = "../once" }
 
 anyhow = "1.0.98"
+arc-swap = "1.7.1"
 auto_impl = "1.3.0"
 hashbrown = "0.15.4"
 itertools = { version = "0.14.0", default-features = false, features = [
@@ -58,4 +59,8 @@ harness = false
 
 [[bench]]
 name = "motivic"
+harness = false
+
+[[bench]]
+name = "seqno"
 harness = false

--- a/ext/crates/algebra/benches/seqno.rs
+++ b/ext/crates/algebra/benches/seqno.rs
@@ -1,0 +1,70 @@
+//! A/B benchmark: the hash-free table-based Milnor index ([`MilnorAlgebra::seqno`]) versus the
+//! `FxHashMap`-backed [`MilnorAlgebra::basis_element_to_index`], over the exact operation of
+//! turning a basis element back into its index.
+//!
+//! This is the lookup that a resolution performs on *every* output term of a multiply — Nassau's
+//! `S_2` @ p=2 run issues ~1.3B of them — so a lookup that is even a little cheaper is worth having,
+//! and a GPU kernel (which cannot carry a hashmap) *needs* the table-based form regardless.
+//!
+//! The `seqno` group here reads the flat [`arc_swap`]-backed table; compare its `basis_to_index/*`
+//! ids against the `hashmap/*` ids at the same degree to see which wins on the CPU.
+
+use std::hint::black_box;
+
+use algebra::{Algebra, MilnorAlgebra};
+use criterion::{Criterion, Throughput, criterion_group, criterion_main};
+use fp::prime::TWO;
+use pprof::criterion::{Output, PProfProfiler};
+
+/// Degrees to sweep. Chosen to bracket the range a real `S_2` resolution reaches, from the cheap
+/// low-dimensional end up to degrees whose basis has thousands of elements.
+const DEGREES: &[i32] = &[16, 24, 32, 40, 48, 56, 64];
+
+fn seqno(c: &mut Criterion) {
+    let algebra = MilnorAlgebra::new(TWO, false);
+    let max_degree = *DEGREES.iter().max().unwrap();
+    algebra.compute_basis(max_degree);
+    algebra.compute_seqno_tables(max_degree);
+
+    let mut g = c.benchmark_group("seqno");
+
+    for &degree in DEGREES {
+        let dim = algebra.dimension(degree);
+        if dim == 0 {
+            continue;
+        }
+        // Snapshot the basis so neither method pays to walk the algebra's storage during timing.
+        let basis: Vec<_> = (0..dim)
+            .map(|i| algebra.basis_element_from_index(degree, i).clone())
+            .collect();
+
+        g.throughput(Throughput::Elements(dim as u64));
+
+        g.bench_function(format!("hashmap/deg{degree}"), |b| {
+            b.iter(|| {
+                for elt in &basis {
+                    black_box(algebra.basis_element_to_index(elt));
+                }
+            });
+        });
+
+        g.bench_function(format!("basis_to_index/deg{degree}"), |b| {
+            b.iter(|| {
+                for elt in &basis {
+                    black_box(algebra.seqno(&elt.p_part));
+                }
+            });
+        });
+    }
+
+    g.finish();
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default()
+        .measurement_time(std::time::Duration::from_secs(3))
+        .with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
+    targets = seqno
+}
+criterion_main!(benches);

--- a/ext/crates/algebra/benches/seqno.rs
+++ b/ext/crates/algebra/benches/seqno.rs
@@ -1,0 +1,70 @@
+//! A/B benchmark: the hash-free table-based Milnor index ([`MilnorAlgebra::seqno`]) versus the
+//! `FxHashMap`-backed [`MilnorAlgebra::basis_element_to_index`], over the exact operation of
+//! turning a basis element back into its index.
+//!
+//! This is the lookup that a resolution performs on *every* output term of a multiply — Nassau's
+//! `S_2` @ p=2 run issues ~1.3B of them — so a lookup that is even a little cheaper is worth having,
+//! and a GPU kernel (which cannot carry a hashmap) *needs* the table-based form regardless.
+//!
+//! The `seqno` group here reads the flat [`arc_swap`]-backed table; compare its `basis_to_index/*`
+//! ids against the `hashmap/*` ids at the same degree to see which wins on the CPU.
+
+use std::hint::black_box;
+
+use algebra::{Algebra, MilnorAlgebra};
+use criterion::{Criterion, Throughput, criterion_group, criterion_main};
+use fp::prime::TWO;
+use pprof::criterion::{Output, PProfProfiler};
+
+/// Degrees to sweep. Chosen to bracket the range a real `S_2` resolution reaches, from the cheap
+/// low-dimensional end up to degrees whose basis has thousands of elements.
+const DEGREES: &[i32] = &[16, 24, 32, 40, 48, 56, 64];
+
+fn seqno(c: &mut Criterion) {
+    let algebra = MilnorAlgebra::new(TWO, false);
+    let max_degree = *DEGREES.iter().max().unwrap();
+    algebra.compute_basis(max_degree);
+    algebra.compute_seqno_tables(max_degree);
+
+    let mut g = c.benchmark_group("seqno");
+
+    for &degree in DEGREES {
+        let dim = algebra.dimension(degree);
+        if dim == 0 {
+            continue;
+        }
+        // Snapshot the basis so neither method pays to walk the algebra's storage during timing.
+        let basis: Vec<_> = (0..dim)
+            .map(|i| algebra.basis_element_from_index(degree, i))
+            .collect();
+
+        g.throughput(Throughput::Elements(dim as u64));
+
+        g.bench_function(format!("hashmap/deg{degree}"), |b| {
+            b.iter(|| {
+                for elt in &basis {
+                    black_box(algebra.basis_element_to_index(elt));
+                }
+            });
+        });
+
+        g.bench_function(format!("basis_to_index/deg{degree}"), |b| {
+            b.iter(|| {
+                for elt in &basis {
+                    black_box(algebra.seqno(elt.p_part));
+                }
+            });
+        });
+    }
+
+    g.finish();
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default()
+        .measurement_time(std::time::Duration::from_secs(3))
+        .with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
+    targets = seqno
+}
+criterion_main!(benches);

--- a/ext/crates/algebra/benches/seqno.rs
+++ b/ext/crates/algebra/benches/seqno.rs
@@ -1,25 +1,21 @@
-//! A/B benchmark: the hash-free table-based Milnor index ([`MilnorAlgebra::seqno`]) versus the
-//! `FxHashMap`-backed [`MilnorAlgebra::basis_element_to_index`], over the exact operation of
-//! turning a basis element back into its index.
-//!
-//! This is the lookup that a resolution performs on *every* output term of a multiply — Nassau's
-//! `S_2` @ p=2 run issues ~1.3B of them — so a lookup that is even a little cheaper is worth having,
-//! and a GPU kernel (which cannot carry a hashmap) *needs* the table-based form regardless.
-//!
-//! The `seqno` group here reads the flat [`arc_swap`]-backed table; compare its `basis_to_index/*`
-//! ids against the `hashmap/*` ids at the same degree to see which wins on the CPU.
-
-use std::hint::black_box;
+//! A/B benchmark: the hash-free table index against the basis hashmap.
 
 use algebra::{Algebra, MilnorAlgebra};
-use criterion::{Criterion, Throughput, criterion_group, criterion_main};
+use criterion::{Criterion, Throughput, black_box, criterion_group, criterion_main};
 use fp::prime::TWO;
-use pprof::criterion::{Output, PProfProfiler};
 
-/// Degrees to sweep. Chosen to bracket the range a real `S_2` resolution reaches, from the cheap
-/// low-dimensional end up to degrees whose basis has thousands of elements.
-const DEGREES: &[i32] = &[16, 24, 32, 40, 48, 56, 64];
+/// Degrees to sample.
+///
+/// The two indices scale differently, which is why this sweeps a range instead of sampling one
+/// size. The hashmap is per-degree, so its working set grows with the dimension of that degree and
+/// eventually falls out of cache; the `g` table is shared across degrees and grows only linearly in
+/// the degree, so it stays resident. The range is chosen to span the point where that crosses over.
+///
+/// `compute_basis` builds every degree below the maximum, so raising the top of this range costs
+/// memory as well as time.
+const DEGREES: &[i32] = &[32, 64, 128, 192, 256, 300, 340];
 
+/// Time both indices over every basis element of each degree in [`DEGREES`].
 fn seqno(c: &mut Criterion) {
     let algebra = MilnorAlgebra::new(TWO, false);
     let max_degree = *DEGREES.iter().max().unwrap();
@@ -33,13 +29,15 @@ fn seqno(c: &mut Criterion) {
         if dim == 0 {
             continue;
         }
-        // Snapshot the basis so neither method pays to walk the algebra's storage during timing.
+        // Snapshot the basis so neither index pays to walk the algebra's storage during timing.
         let basis: Vec<_> = (0..dim)
             .map(|i| algebra.basis_element_from_index(degree, i))
             .collect();
 
         g.throughput(Throughput::Elements(dim as u64));
 
+        // Reads the degree straight off the basis element, then one hash and probe of the packed
+        // key.
         g.bench_function(format!("hashmap/deg{degree}"), |b| {
             b.iter(|| {
                 for elt in &basis {
@@ -48,10 +46,22 @@ fn seqno(c: &mut Criterion) {
             });
         });
 
-        g.bench_function(format!("basis_to_index/deg{degree}"), |b| {
+        // The tables acquired once, the degree supplied by the caller — what a hot loop would do.
+        g.bench_function(format!("seqno/deg{degree}"), |b| {
+            let ranker = algebra.seqno_ranker();
             b.iter(|| {
                 for elt in &basis {
-                    black_box(algebra.seqno(elt.p_part));
+                    black_box(ranker.rank(elt.p_part, degree));
+                }
+            });
+        });
+
+        // The convenience API, which re-acquires the tables on every call. The gap between this and
+        // `seqno` is what hoisting the guard is worth.
+        g.bench_function(format!("seqno_naive/deg{degree}"), |b| {
+            b.iter(|| {
+                for elt in &basis {
+                    black_box(algebra.seqno(elt.p_part, degree));
                 }
             });
         });
@@ -62,9 +72,7 @@ fn seqno(c: &mut Criterion) {
 
 criterion_group! {
     name = benches;
-    config = Criterion::default()
-        .measurement_time(std::time::Duration::from_secs(3))
-        .with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
+    config = Criterion::default();
     targets = seqno
 }
 criterion_main!(benches);

--- a/ext/crates/algebra/src/algebra/milnor_algebra.rs
+++ b/ext/crates/algebra/src/algebra/milnor_algebra.rs
@@ -421,6 +421,61 @@ struct SeqnoTables {
     g: Vec<usize>,
 }
 
+/// A borrowed view of the seqno tables, acquired once for a batch of lookups.
+///
+/// See [`MilnorAlgebra::seqno_ranker`]. Holding this pins one revision of the tables, so the
+/// per-lookup cost is the rank itself with no atomic and no table re-acquisition.
+pub struct SeqnoRanker {
+    tables: std::sync::Arc<SeqnoTables>,
+    xi: &'static [i32],
+}
+
+impl SeqnoRanker {
+    /// The index of `P(p_part)`, which must have degree `degree`, in the Milnor basis of that
+    /// degree.
+    ///
+    /// The basis is enumerated by increasing highest ξ-index, so the rank of `P` accumulates, for
+    /// each populated position `h`, the number of basis elements whose highest index is `< h`
+    /// together with `h` — which is exactly the `g` difference across the degree consumed at that
+    /// position. `degree` is taken from the caller rather than re-derived as `Σ rᵢ·ξᵢ`: every
+    /// caller already knows it, and the hashmap it competes with reads it straight off the basis
+    /// element.
+    #[inline]
+    pub fn rank(&self, p_part: PPart, degree: i32) -> usize {
+        let t = &*self.tables;
+        let w = t.width;
+        debug_assert_eq!(
+            degree,
+            p_part
+                .iter()
+                .zip(self.xi)
+                .map(|(r, &x)| r as i32 * x)
+                .sum::<i32>(),
+            "degree {degree} does not match the p-part {p_part:?}"
+        );
+        // `cur_d` only decreases in the loop below, so this bounds every `t.g` index. A raw
+        // out-of-bounds panic here means the tables were not built far enough for this element.
+        debug_assert!(
+            degree <= t.max_degree,
+            "degree {degree} exceeds seqno tables built to {}; call compute_seqno_tables first",
+            t.max_degree
+        );
+        let mut cur_d = degree;
+        let mut rank = 0;
+        // Consume positions from the highest down; position 0 contributes nothing.
+        for h in (1..p_part.len()).rev() {
+            let r = p_part.get(h) as i32;
+            if r == 0 {
+                continue;
+            }
+            let below = cur_d - r * self.xi[h];
+            rank += t.g[cur_d as usize * w + h] - t.g[below as usize * w + h];
+            cur_d = below;
+        }
+        rank
+    }
+}
+
 pub struct MilnorAlgebra {
     profile: MilnorProfile,
     p: ValidPrime,
@@ -531,11 +586,13 @@ impl MilnorAlgebra {
     }
 
     pub fn try_basis_element_to_index(&self, elt: &MilnorBasisElement) -> Option<usize> {
-        // NB: the table-based `Self::seqno` computes this same index without a hash, but computing
-        // the rank (a degree sum plus two indexed table reads per populated ξ-position) is more work
-        // than one hash and probe, so it loses to this hashmap on the CPU. `seqno` is kept as the
-        // GPU-oriented index (a GPU kernel cannot carry a hashmap, and the flat table uploads
-        // directly), not for the CPU hot path.
+        // NB: [`Self::seqno`] computes this same index without a hash, and which one is faster
+        // depends on the degree. This map holds one entry per basis element of `elt.degree`, so its
+        // working set grows with that dimension and leaves cache; the `g` table behind `seqno` is
+        // shared across degrees and grows only linearly in the degree, so its cost is flat. The
+        // hashmap wins while it is cache-resident and loses once it is not — see `benches/seqno.rs`
+        // for the curve. This path stays on the hashmap because `compute_basis` does not build the
+        // seqno tables, so they are not guaranteed to exist here.
         self.basis_element_to_index_map[elt.degree as usize]
             .get(elt)
             .copied()
@@ -640,9 +697,10 @@ impl Algebra for MilnorAlgebra {
             self.generate_basis_2(max_degree);
         }
 
-        // The `seqno` tables are *not* built here: `seqno` lost to the hashmap on the CPU (see
-        // `try_basis_element_to_index`), so a normal resolution should not pay to build tables it
-        // won't use. A GPU backend that needs the hash-free index calls `compute_seqno_tables`.
+        // The `seqno` tables are *not* built here: they are useful only above the degree where
+        // they overtake the hashmap (see `try_basis_element_to_index`), and a resolution that never
+        // gets there should not pay to build them. Callers that want the hash-free index — a GPU
+        // backend, or a high-degree CPU run — call `compute_seqno_tables` themselves.
 
         // Populate hash map
         self.basis_element_to_index_map
@@ -1134,6 +1192,13 @@ impl MilnorAlgebra {
     /// step `ξ_{h+1}`, letting `seqno` rank a `p_part` without a hash lookup.
     pub fn compute_seqno_tables(&self, max_degree: i32) {
         assert!(self.seqno_applicable());
+        // Mirrors the gate in `compute_basis`: a negative degree would wrap `rows` to a huge
+        // `usize`, and one past the bound would build rows for elements the packing cannot hold.
+        assert!(
+            (0..=PPart::MAX_DEGREE).contains(&max_degree),
+            "seqno tables are only supported for degrees 0..={}, got {max_degree}",
+            PPart::MAX_DEGREE,
+        );
         if let Some(t) = &*self.seqno_tables.load()
             && t.max_degree >= max_degree
         {
@@ -1196,42 +1261,34 @@ impl MilnorAlgebra {
         });
     }
 
-    /// The index ("sequence number") of `P(p_part)` in the Milnor basis of its degree, computed in
-    /// O(number of `p_part` entries) from the precomputed tables — no hash lookup. Assumes
-    /// `seqno_applicable` and that `p_part` is a genuine basis element (trimmed, in range).
+    /// A handle that borrows the seqno tables once for a batch of lookups.
     ///
-    /// The basis is enumerated by increasing highest ξ-index, so the rank of `P` accumulates, for
-    /// each populated position `h`, the number of basis elements whose highest index is `< h`
-    /// together with `h` — which is exactly the `g_table` difference across the degree consumed at
-    /// that position.
-    pub fn seqno(&self, p_part: PPart) -> usize {
-        let xi = combinatorics::xi_degrees(self.prime());
-        let guard = self.seqno_tables.load();
-        let t = guard
-            .as_ref()
-            .expect("seqno tables not built; call compute_seqno_tables first");
-        let w = t.width;
-        let mut cur_d: i32 = p_part.iter().zip(xi).map(|(r, &x)| r as i32 * x).sum();
-        // `cur_d` only decreases in the loop below, so this bounds every `t.g` index. A raw
-        // out-of-bounds panic here means the tables were not built far enough for this element.
-        debug_assert!(
-            cur_d <= t.max_degree,
-            "p_part degree {cur_d} exceeds seqno tables built to {}; call compute_seqno_tables \
-             first",
-            t.max_degree
-        );
-        let mut rank = 0;
-        // Consume positions from the highest down; position 0 contributes nothing.
-        for h in (1..p_part.len()).rev() {
-            let r = p_part.get(h) as i32;
-            if r == 0 {
-                continue;
-            }
-            let below = cur_d - r * xi[h];
-            rank += t.g[cur_d as usize * w + h] - t.g[below as usize * w + h];
-            cur_d = below;
+    /// [`Self::seqno`] acquires the [`arc_swap`] guard on every call. That is one atomic per
+    /// lookup, which is pure overhead in a loop that ranks many elements — the tables cannot
+    /// change underneath it in any way that matters, since the publish is monotonic. A hot loop
+    /// should hoist the acquisition with this instead.
+    ///
+    /// # Panics
+    ///
+    /// If the tables have not been built; call [`Self::compute_seqno_tables`] first.
+    pub fn seqno_ranker(&self) -> SeqnoRanker {
+        SeqnoRanker {
+            tables: self
+                .seqno_tables
+                .load_full()
+                .expect("seqno tables not built; call compute_seqno_tables first"),
+            xi: combinatorics::xi_degrees(self.prime()),
         }
-        rank
+    }
+
+    /// The index ("sequence number") of `P(p_part)`, of degree `degree`, in the Milnor basis of
+    /// that degree — computed in O(number of `p_part` entries) from the precomputed tables, with
+    /// no hash lookup. Assumes `seqno_applicable` and that `p_part` is a genuine basis element
+    /// (trimmed, in range) of `degree`.
+    ///
+    /// Ranking many elements? Use [`Self::seqno_ranker`] to acquire the tables once.
+    pub fn seqno(&self, p_part: PPart, degree: i32) -> usize {
+        self.seqno_ranker().rank(p_part, degree)
     }
 
     fn generate_basis_generic(&self, max_degree: i32) {
@@ -2169,7 +2226,7 @@ mod tests {
                 for i in 0..dim {
                     let elt = algebra.basis_element_from_index(d, i);
                     assert_eq!(
-                        algebra.seqno(elt.p_part),
+                        algebra.seqno(elt.p_part, d),
                         i,
                         "seqno mismatch at degree {d}, index {i}: {elt:?}"
                     );

--- a/ext/crates/algebra/src/algebra/milnor_algebra.rs
+++ b/ext/crates/algebra/src/algebra/milnor_algebra.rs
@@ -411,6 +411,16 @@ impl std::fmt::Display for MilnorBasisElement {
     }
 }
 
+/// Flat, contiguous storage for the "seqno" (hash-free index) computation. See
+/// [`MilnorAlgebra::compute_seqno_tables`] for how `g` is derived and [`MilnorAlgebra::seqno`] for
+/// how it is read. Row-major with a fixed `width` (the number of ξ-degrees), so entry `(e, h)` lives
+/// at `g[e * width + h]`; degrees `0..=max_degree` are populated.
+struct SeqnoTables {
+    max_degree: i32,
+    width: usize,
+    g: Vec<usize>,
+}
+
 pub struct MilnorAlgebra {
     profile: MilnorProfile,
     p: ValidPrime,
@@ -434,6 +444,15 @@ pub struct MilnorAlgebra {
 
     /// degree -> MilnorBasisElement -> index
     basis_element_to_index_map: OnceVec<HashMap<MilnorBasisElement, usize>>,
+
+    /// Table backing the "seqno" (hash-free index) computation, populated only when
+    /// [`Self::seqno_applicable`] holds (p = 2, trivial profile, stable). It holds the flat,
+    /// row-major `g` array described in [`Self::compute_seqno_tables`]; [`Self::seqno`] ranks a
+    /// `p_part` from it with plain array indexing and no hash lookup. Stored behind an
+    /// [`arc_swap::ArcSwapOption`] rather than a [`OnceVec`] so that reads on the hot path are a
+    /// single guard load followed by direct indexing — the earlier `OnceVec<Vec<_>>` layout paid two
+    /// atomics *per table access*, which is what made the table lose to the hashmap.
+    seqno_tables: arc_swap::ArcSwapOption<SeqnoTables>,
 
     #[cfg(feature = "cache-multiplication")]
     /// source_deg -> target_deg -> source_op -> target_op
@@ -463,6 +482,7 @@ impl MilnorAlgebra {
             basis_table: OnceVec::new(),
             excess_table: OnceVec::new(),
             basis_element_to_index_map: OnceVec::new(),
+            seqno_tables: arc_swap::ArcSwapOption::empty(),
             #[cfg(feature = "cache-multiplication")]
             multiplication_table: OnceVec::new(),
         }
@@ -511,6 +531,11 @@ impl MilnorAlgebra {
     }
 
     pub fn try_basis_element_to_index(&self, elt: &MilnorBasisElement) -> Option<usize> {
+        // NB: the table-based `Self::seqno` computes this same index without a hash, but computing
+        // the rank (a degree sum plus two indexed table reads per populated ξ-position) is more work
+        // than one hash and probe, so it loses to this hashmap on the CPU. `seqno` is kept as the
+        // GPU-oriented index (a GPU kernel cannot carry a hashmap, and the flat table uploads
+        // directly), not for the CPU hot path.
         self.basis_element_to_index_map[elt.degree as usize]
             .get(elt)
             .copied()
@@ -614,6 +639,10 @@ impl Algebra for MilnorAlgebra {
         } else {
             self.generate_basis_2(max_degree);
         }
+
+        // The `seqno` tables are *not* built here: `seqno` lost to the hashmap on the CPU (see
+        // `try_basis_element_to_index`), so a normal resolution should not pay to build tables it
+        // won't use. A GPU backend that needs the hash-free index calls `compute_seqno_tables`.
 
         // Populate hash map
         self.basis_element_to_index_map
@@ -1083,6 +1112,118 @@ impl MilnorAlgebra {
             }
             new_row
         });
+    }
+
+    /// Whether the fast table-based [`Self::seqno`] can be used instead of the hashmap. It requires
+    /// `p = 2` (single-generator Milnor basis), a trivial profile (so *every* `P(R)` of a degree is
+    /// a basis element, matching the partition counts), and the stable ordering (unstable sorts the
+    /// basis by excess, breaking the enumeration-order = index correspondence).
+    fn seqno_applicable(&self) -> bool {
+        !self.generic() && !self.unstable_enabled && self.profile.is_trivial()
+    }
+
+    /// Build the flat `SeqnoTables` up to `max_degree`, so that [`Self::seqno`] can be used.
+    /// Requires `seqno_applicable`. Idempotent: if the stored tables already reach
+    /// `max_degree` this returns immediately; otherwise it rebuilds the whole (cheap,
+    /// `O(max_degree · width)`) table from scratch and atomically swaps it in, so readers always see
+    /// either the old complete table or the new one.
+    ///
+    /// The `n[e][m]` intermediate — the number of `P(R)` of degree `e` using only `ξ₁ … ξ_{m+1}` —
+    /// is built locally and discarded; only the `g` row-progression it feeds is stored, since that
+    /// is all [`Self::seqno`] reads. `g[e][h]` sums `n[·][h−1]` along the arithmetic progression of
+    /// step `ξ_{h+1}`, letting `seqno` rank a `p_part` without a hash lookup.
+    pub fn compute_seqno_tables(&self, max_degree: i32) {
+        assert!(self.seqno_applicable());
+        if let Some(t) = &*self.seqno_tables.load()
+            && t.max_degree >= max_degree
+        {
+            return;
+        }
+
+        let xi = combinatorics::xi_degrees(self.prime());
+        let width = xi.len();
+        let rows = max_degree as usize + 1;
+
+        // n[e * width + m] = #{ P(R) of degree e using only ξ₁ … ξ_{m+1} }
+        //                  = n[e][m-1] + [ξ_{m+1} ≤ e] · n[e − ξ_{m+1}][m]
+        let mut n = vec![0usize; rows * width];
+        for e in 0..=max_degree {
+            let base = e as usize * width;
+            for m in 0..width {
+                // m = 0: partitions into {1} — always exactly one, P(e), for e ≥ 0.
+                let without = if m == 0 {
+                    (e == 0) as usize
+                } else {
+                    n[base + m - 1]
+                };
+                let with = if xi[m] <= e {
+                    n[(e - xi[m]) as usize * width + m]
+                } else {
+                    0
+                };
+                n[base + m] = without + with;
+            }
+        }
+
+        // g[e * width + h] = Σ_{j ≥ 0} n[e − j·ξ_{h+1}][h−1]   (h ≥ 1; g[·][0] unused)
+        //                  = n[e][h−1] + [ξ_{h+1} ≤ e] · g[e − ξ_{h+1}][h]
+        let mut g = vec![0usize; rows * width];
+        for e in 0..=max_degree {
+            let base = e as usize * width;
+            for h in 1..width {
+                let head = n[base + h - 1];
+                let tail = if xi[h] <= e {
+                    g[(e - xi[h]) as usize * width + h]
+                } else {
+                    0
+                };
+                g[base + h] = head + tail;
+            }
+        }
+
+        // Guard the publish: under `concurrent`, parallel `get_partial_matrix` builds can race here,
+        // and an unconditional store would let a smaller table clobber a larger one already in place
+        // — after which `seqno` would index past the shrunken `g` and panic. Only replace when ours
+        // reaches at least as far, so the cached `max_degree` is monotonic.
+        let new_tables = std::sync::Arc::new(SeqnoTables {
+            max_degree,
+            width,
+            g,
+        });
+        self.seqno_tables.rcu(|current| match current.as_deref() {
+            Some(t) if t.max_degree >= max_degree => current.clone(),
+            _ => Some(new_tables.clone()),
+        });
+    }
+
+    /// The index ("sequence number") of `P(p_part)` in the Milnor basis of its degree, computed in
+    /// O(number of `p_part` entries) from the precomputed tables — no hash lookup. Assumes
+    /// `seqno_applicable` and that `p_part` is a genuine basis element (trimmed, in range).
+    ///
+    /// The basis is enumerated by increasing highest ξ-index, so the rank of `P` accumulates, for
+    /// each populated position `h`, the number of basis elements whose highest index is `< h`
+    /// together with `h` — which is exactly the `g_table` difference across the degree consumed at
+    /// that position.
+    pub fn seqno(&self, p_part: PPart) -> usize {
+        let xi = combinatorics::xi_degrees(self.prime());
+        let guard = self.seqno_tables.load();
+        let t = guard
+            .as_ref()
+            .expect("seqno tables not built; call compute_seqno_tables first");
+        let w = t.width;
+        let mut cur_d: i32 = p_part.iter().zip(xi).map(|(r, &x)| r as i32 * x).sum();
+        let mut rank = 0;
+        // Consume positions from the highest down; position 0 contributes nothing.
+        for h in (1..p_part.len()).rev() {
+            let r = p_part.get(h) as i32;
+            if r == 0 {
+                continue;
+            }
+            let below = cur_d - r * xi[h];
+            rank += t.g[cur_d as usize * w + h] - t.g[below as usize * w + h];
+            cur_d = below;
+        }
+        rank
     }
 
     fn generate_basis_generic(&self, max_degree: i32) {
@@ -2002,6 +2143,29 @@ mod tests {
     use rstest::rstest;
 
     use super::*;
+
+    /// The table-based [`MilnorAlgebra::seqno`] must return the position of every basis element in
+    /// its degree — i.e. agree with the enumeration order that defines the index — for the stable
+    /// `p = 2` full algebra, and reject non-basis elements via `try_`.
+    #[test]
+    fn seqno_matches_enumeration_order() {
+        let algebra = MilnorAlgebra::new(ValidPrime::new(2), false);
+        assert!(algebra.seqno_applicable());
+        let max_degree = 100;
+        algebra.compute_basis(max_degree);
+        algebra.compute_seqno_tables(max_degree);
+        for d in 0..=max_degree {
+            let dim = algebra.dimension(d);
+            for i in 0..dim {
+                let elt = algebra.basis_element_from_index(d, i);
+                assert_eq!(
+                    algebra.seqno(elt.p_part),
+                    i,
+                    "seqno mismatch at degree {d}, index {i}: {elt:?}"
+                );
+            }
+        }
+    }
 
     #[rstest]
     #[trace]

--- a/ext/crates/algebra/src/algebra/milnor_algebra.rs
+++ b/ext/crates/algebra/src/algebra/milnor_algebra.rs
@@ -1212,6 +1212,14 @@ impl MilnorAlgebra {
             .expect("seqno tables not built; call compute_seqno_tables first");
         let w = t.width;
         let mut cur_d: i32 = p_part.iter().zip(xi).map(|(r, &x)| r as i32 * x).sum();
+        // `cur_d` only decreases in the loop below, so this bounds every `t.g` index. A raw
+        // out-of-bounds panic here means the tables were not built far enough for this element.
+        debug_assert!(
+            cur_d <= t.max_degree,
+            "p_part degree {cur_d} exceeds seqno tables built to {}; call compute_seqno_tables \
+             first",
+            t.max_degree
+        );
         let mut rank = 0;
         // Consume positions from the highest down; position 0 contributes nothing.
         for h in (1..p_part.len()).rev() {
@@ -2153,18 +2161,33 @@ mod tests {
         assert!(algebra.seqno_applicable());
         let max_degree = 100;
         algebra.compute_basis(max_degree);
-        algebra.compute_seqno_tables(max_degree);
-        for d in 0..=max_degree {
-            let dim = algebra.dimension(d);
-            for i in 0..dim {
-                let elt = algebra.basis_element_from_index(d, i);
-                assert_eq!(
-                    algebra.seqno(elt.p_part),
-                    i,
-                    "seqno mismatch at degree {d}, index {i}: {elt:?}"
-                );
+
+        // `seqno` must return the enumeration index of every basis element in `0..=upto`.
+        let check = |upto: i32| {
+            for d in 0..=upto {
+                let dim = algebra.dimension(d);
+                for i in 0..dim {
+                    let elt = algebra.basis_element_from_index(d, i);
+                    assert_eq!(
+                        algebra.seqno(elt.p_part),
+                        i,
+                        "seqno mismatch at degree {d}, index {i}: {elt:?}"
+                    );
+                }
             }
-        }
+        };
+
+        // Exercise the idempotent, monotonic (non-shrinking) publish documented on
+        // `compute_seqno_tables`: build partially, rebuild identically (no-op), grow, then request
+        // a smaller degree (must not shrink the cached table).
+        algebra.compute_seqno_tables(50);
+        check(50);
+        algebra.compute_seqno_tables(50);
+        check(50);
+        algebra.compute_seqno_tables(max_degree);
+        check(max_degree);
+        algebra.compute_seqno_tables(50);
+        check(max_degree);
     }
 
     #[rstest]

--- a/ext/crates/algebra/src/algebra/milnor_algebra.rs
+++ b/ext/crates/algebra/src/algebra/milnor_algebra.rs
@@ -245,6 +245,16 @@ impl<V> MilnorHashMap<V> {
     }
 }
 
+/// Flat, contiguous storage for the "seqno" (hash-free index) computation. See
+/// [`MilnorAlgebra::compute_seqno_tables`] for how `g` is derived and [`MilnorAlgebra::seqno`] for
+/// how it is read. Row-major with a fixed `width` (the number of ξ-degrees), so entry `(e, h)` lives
+/// at `g[e * width + h]`; degrees `0..=max_degree` are populated.
+struct SeqnoTables {
+    max_degree: i32,
+    width: usize,
+    g: Vec<usize>,
+}
+
 pub struct MilnorAlgebra {
     profile: MilnorProfile,
     p: ValidPrime,
@@ -264,6 +274,15 @@ pub struct MilnorAlgebra {
 
     /// degree -> MilnorBasisElement -> index
     basis_element_to_index_map: OnceVec<MilnorHashMap<usize>>,
+
+    /// Table backing the "seqno" (hash-free index) computation, populated only when
+    /// [`Self::seqno_applicable`] holds (p = 2, trivial profile, stable). It holds the flat,
+    /// row-major `g` array described in [`Self::compute_seqno_tables`]; [`Self::seqno`] ranks a
+    /// `p_part` from it with plain array indexing and no hash lookup. Stored behind an
+    /// [`arc_swap::ArcSwapOption`] rather than a [`OnceVec`] so that reads on the hot path are a
+    /// single guard load followed by direct indexing — the earlier `OnceVec<Vec<_>>` layout paid two
+    /// atomics *per table access*, which is what made the table lose to the hashmap.
+    seqno_tables: arc_swap::ArcSwapOption<SeqnoTables>,
 
     #[cfg(feature = "cache-multiplication")]
     /// source_deg -> target_deg -> source_op -> target_op
@@ -293,6 +312,7 @@ impl MilnorAlgebra {
             basis_table: OnceVec::new(),
             excess_table: OnceVec::new(),
             basis_element_to_index_map: OnceVec::new(),
+            seqno_tables: arc_swap::ArcSwapOption::empty(),
             #[cfg(feature = "cache-multiplication")]
             multiplication_table: OnceVec::new(),
         }
@@ -328,6 +348,11 @@ impl MilnorAlgebra {
     }
 
     pub fn try_basis_element_to_index(&self, elt: &MilnorBasisElement) -> Option<usize> {
+        // NB: the table-based `Self::seqno` computes this same index without a hash, but computing
+        // the rank (a degree sum plus two indexed table reads per populated ξ-position) is more work
+        // than one hash and probe, so it loses to this hashmap on the CPU. `seqno` is kept as the
+        // GPU-oriented index (a GPU kernel cannot carry a hashmap, and the flat table uploads
+        // directly), not for the CPU hot path.
         self.basis_element_to_index_map[elt.degree as usize]
             .get(elt)
             .copied()
@@ -424,6 +449,10 @@ impl Algebra for MilnorAlgebra {
         } else {
             self.generate_basis_2(max_degree);
         }
+
+        // The `seqno` tables are *not* built here: `seqno` lost to the hashmap on the CPU (see
+        // `try_basis_element_to_index`), so a normal resolution should not pay to build tables it
+        // won't use. A GPU backend that needs the hash-free index calls `compute_seqno_tables`.
 
         // Populate hash map
         self.basis_element_to_index_map
@@ -882,6 +911,118 @@ impl MilnorAlgebra {
             }
             new_row
         });
+    }
+
+    /// Whether the fast table-based [`Self::seqno`] can be used instead of the hashmap. It requires
+    /// `p = 2` (single-generator Milnor basis), a trivial profile (so *every* `P(R)` of a degree is
+    /// a basis element, matching the partition counts), and the stable ordering (unstable sorts the
+    /// basis by excess, breaking the enumeration-order = index correspondence).
+    fn seqno_applicable(&self) -> bool {
+        !self.generic() && !self.unstable_enabled && self.profile.is_trivial()
+    }
+
+    /// Build the flat `SeqnoTables` up to `max_degree`, so that [`Self::seqno`] can be used.
+    /// Requires `seqno_applicable`. Idempotent: if the stored tables already reach
+    /// `max_degree` this returns immediately; otherwise it rebuilds the whole (cheap,
+    /// `O(max_degree · width)`) table from scratch and atomically swaps it in, so readers always see
+    /// either the old complete table or the new one.
+    ///
+    /// The `n[e][m]` intermediate — the number of `P(R)` of degree `e` using only `ξ₁ … ξ_{m+1}` —
+    /// is built locally and discarded; only the `g` row-progression it feeds is stored, since that
+    /// is all [`Self::seqno`] reads. `g[e][h]` sums `n[·][h−1]` along the arithmetic progression of
+    /// step `ξ_{h+1}`, letting `seqno` rank a `p_part` without a hash lookup.
+    pub fn compute_seqno_tables(&self, max_degree: i32) {
+        assert!(self.seqno_applicable());
+        if let Some(t) = &*self.seqno_tables.load()
+            && t.max_degree >= max_degree
+        {
+            return;
+        }
+
+        let xi = combinatorics::xi_degrees(self.prime());
+        let width = xi.len();
+        let rows = max_degree as usize + 1;
+
+        // n[e * width + m] = #{ P(R) of degree e using only ξ₁ … ξ_{m+1} }
+        //                  = n[e][m-1] + [ξ_{m+1} ≤ e] · n[e − ξ_{m+1}][m]
+        let mut n = vec![0usize; rows * width];
+        for e in 0..=max_degree {
+            let base = e as usize * width;
+            for m in 0..width {
+                // m = 0: partitions into {1} — always exactly one, P(e), for e ≥ 0.
+                let without = if m == 0 {
+                    (e == 0) as usize
+                } else {
+                    n[base + m - 1]
+                };
+                let with = if xi[m] <= e {
+                    n[(e - xi[m]) as usize * width + m]
+                } else {
+                    0
+                };
+                n[base + m] = without + with;
+            }
+        }
+
+        // g[e * width + h] = Σ_{j ≥ 0} n[e − j·ξ_{h+1}][h−1]   (h ≥ 1; g[·][0] unused)
+        //                  = n[e][h−1] + [ξ_{h+1} ≤ e] · g[e − ξ_{h+1}][h]
+        let mut g = vec![0usize; rows * width];
+        for e in 0..=max_degree {
+            let base = e as usize * width;
+            for h in 1..width {
+                let head = n[base + h - 1];
+                let tail = if xi[h] <= e {
+                    g[(e - xi[h]) as usize * width + h]
+                } else {
+                    0
+                };
+                g[base + h] = head + tail;
+            }
+        }
+
+        // Guard the publish: under `concurrent`, parallel `get_partial_matrix` builds can race here,
+        // and an unconditional store would let a smaller table clobber a larger one already in place
+        // — after which `seqno` would index past the shrunken `g` and panic. Only replace when ours
+        // reaches at least as far, so the cached `max_degree` is monotonic.
+        let new_tables = std::sync::Arc::new(SeqnoTables {
+            max_degree,
+            width,
+            g,
+        });
+        self.seqno_tables.rcu(|current| match current.as_deref() {
+            Some(t) if t.max_degree >= max_degree => current.clone(),
+            _ => Some(new_tables.clone()),
+        });
+    }
+
+    /// The index ("sequence number") of `P(p_part)` in the Milnor basis of its degree, computed in
+    /// O(number of `p_part` entries) from the precomputed tables — no hash lookup. Assumes
+    /// `seqno_applicable` and that `p_part` is a genuine basis element (trimmed, in range).
+    ///
+    /// The basis is enumerated by increasing highest ξ-index, so the rank of `P` accumulates, for
+    /// each populated position `h`, the number of basis elements whose highest index is `< h`
+    /// together with `h` — which is exactly the `g_table` difference across the degree consumed at
+    /// that position.
+    pub fn seqno(&self, p_part: &[PPartEntry]) -> usize {
+        let xi = combinatorics::xi_degrees(self.prime());
+        let guard = self.seqno_tables.load();
+        let t = guard
+            .as_ref()
+            .expect("seqno tables not built; call compute_seqno_tables first");
+        let w = t.width;
+        let mut cur_d: i32 = p_part.iter().zip(xi).map(|(&r, &x)| r as i32 * x).sum();
+        let mut rank = 0;
+        // Consume positions from the highest down; position 0 contributes nothing.
+        for h in (1..p_part.len()).rev() {
+            let r = p_part[h] as i32;
+            if r == 0 {
+                continue;
+            }
+            let below = cur_d - r * xi[h];
+            rank += t.g[cur_d as usize * w + h] - t.g[below as usize * w + h];
+            cur_d = below;
+        }
+        rank
     }
 
     fn generate_basis_generic(&self, max_degree: i32) {
@@ -1792,6 +1933,29 @@ mod tests {
     use rstest::rstest;
 
     use super::*;
+
+    /// The table-based [`MilnorAlgebra::seqno`] must return the position of every basis element in
+    /// its degree — i.e. agree with the enumeration order that defines the index — for the stable
+    /// `p = 2` full algebra, and reject non-basis elements via `try_`.
+    #[test]
+    fn seqno_matches_enumeration_order() {
+        let algebra = MilnorAlgebra::new(ValidPrime::new(2), false);
+        assert!(algebra.seqno_applicable());
+        let max_degree = 100;
+        algebra.compute_basis(max_degree);
+        algebra.compute_seqno_tables(max_degree);
+        for d in 0..=max_degree {
+            let dim = algebra.dimension(d);
+            for i in 0..dim {
+                let elt = algebra.basis_element_from_index(d, i);
+                assert_eq!(
+                    algebra.seqno(&elt.p_part),
+                    i,
+                    "seqno mismatch at degree {d}, index {i}: {elt:?}"
+                );
+            }
+        }
+    }
 
     #[rstest]
     #[trace]

--- a/ext/crates/algebra/src/algebra/milnor_algebra.rs
+++ b/ext/crates/algebra/src/algebra/milnor_algebra.rs
@@ -1011,6 +1011,14 @@ impl MilnorAlgebra {
             .expect("seqno tables not built; call compute_seqno_tables first");
         let w = t.width;
         let mut cur_d: i32 = p_part.iter().zip(xi).map(|(&r, &x)| r as i32 * x).sum();
+        // `cur_d` only decreases in the loop below, so this bounds every `t.g` index. A raw
+        // out-of-bounds panic here means the tables were not built far enough for this element.
+        debug_assert!(
+            cur_d <= t.max_degree,
+            "p_part degree {cur_d} exceeds seqno tables built to {}; call compute_seqno_tables \
+             first",
+            t.max_degree
+        );
         let mut rank = 0;
         // Consume positions from the highest down; position 0 contributes nothing.
         for h in (1..p_part.len()).rev() {
@@ -1943,18 +1951,33 @@ mod tests {
         assert!(algebra.seqno_applicable());
         let max_degree = 100;
         algebra.compute_basis(max_degree);
-        algebra.compute_seqno_tables(max_degree);
-        for d in 0..=max_degree {
-            let dim = algebra.dimension(d);
-            for i in 0..dim {
-                let elt = algebra.basis_element_from_index(d, i);
-                assert_eq!(
-                    algebra.seqno(&elt.p_part),
-                    i,
-                    "seqno mismatch at degree {d}, index {i}: {elt:?}"
-                );
+
+        // `seqno` must return the enumeration index of every basis element in `0..=upto`.
+        let check = |upto: i32| {
+            for d in 0..=upto {
+                let dim = algebra.dimension(d);
+                for i in 0..dim {
+                    let elt = algebra.basis_element_from_index(d, i);
+                    assert_eq!(
+                        algebra.seqno(&elt.p_part),
+                        i,
+                        "seqno mismatch at degree {d}, index {i}: {elt:?}"
+                    );
+                }
             }
-        }
+        };
+
+        // Exercise the idempotent, monotonic (non-shrinking) publish documented on
+        // `compute_seqno_tables`: build partially, rebuild identically (no-op), grow, then request
+        // a smaller degree (must not shrink the cached table).
+        algebra.compute_seqno_tables(50);
+        check(50);
+        algebra.compute_seqno_tables(50);
+        check(50);
+        algebra.compute_seqno_tables(max_degree);
+        check(max_degree);
+        algebra.compute_seqno_tables(50);
+        check(max_degree);
     }
 
     #[rstest]


### PR DESCRIPTION
Splits the GPU-agnostic `seqno` index out of the Nassau GPU work (#264) so it can land on its own. Second of three; follows the benchmark split (#269).

## What

A flat, arc-swapped hash-free index for the Milnor basis: an O(number of p-part entries) rank computed from a precomputed `g` table, with no hash lookup.

- `SeqnoTables` + `compute_seqno_tables` (idempotent, concurrency-safe via `ArcSwapOption::rcu`) + `seqno`, applicable at `p = 2` with a trivial profile and stable ordering.
- `SeqnoRanker`, which acquires the tables once for a batch of lookups instead of taking an `arc_swap` guard per call.
- `benches/seqno.rs`: an A/B of the table index against the basis hashmap across a range of degrees.

## Why it is worth having

Three reasons, in descending order of how settled they are.

**1. The GPU path requires it.** A kernel cannot carry a hashmap, so an arithmetic rank is the only way to turn a `p_part` into a basis index on-device, and the flat `g` table uploads directly. This is the blocking dependency for #271.

**2. It is dramatically smaller, at every degree.** The basis hashmap holds one entry per basis element and is built for every degree up to the max; the `g` table is shared across all degrees and grows only linearly in the degree:

| max degree | dim at that degree | basis hashmap, all degrees | `g` table |
|---|---|---|---|
| 200 | 15,499 | 19 MB | 16 KB |
| 300 | 87,977 | 144 MB | 24 KB |
| 350 | 178,195 | 329 MB | 27 KB |
| 400 | 335,566 | 688 MB | 31 KB |
| 450 | 596,191 | 1.3 GB | 35 KB |

Four orders of magnitude, and unlike the speed comparison it does not have a crossover — the table is smaller everywhere. This saving is *available* rather than banked: realising it means not building the hashmap at all in the applicable regime, which is the follow-up below, not this PR.

**3. Above a crossover it is also faster.** Per lookup, at `p = 2`:

| degree | dim | hashmap | seqno | |
|---|---|---|---|---|
| 32 | 47 | 7.09 ns | 12.39 ns | |
| 100 | 1,189 | 7.39 ns | 15.59 ns | |
| 180 | 10,155 | 8.53 ns | 17.18 ns | |
| 260 | 46,750 | 13.24 ns | 18.15 ns | |
| 300 | 87,977 | 15.26 ns | 18.07 ns | |
| 320 | 117,834 | 22.27 ns | **18.70 ns** | seqno wins |
| 370 | 231,354 | 46.76 ns | **18.98 ns** | 2.5x |
| 400 | 335,566 | 53.27 ns | **19.56 ns** | 2.7x |

`seqno` is flat — 12 ns to 20 ns while the dimension grows four orders of magnitude — while the hashmap degrades 7.5x as its per-degree map leaves cache. They cross between degree 300 and 320.

This is the behaviour Christian Nassau has reported since 1998, when the comparison was against binary search over a written-out basis. It survives the move to a hashmap keyed on the packed p-part (#280): that changed the constant factor, not the asymptotics.

## Scope: why this PR does not yet dispatch on it

`try_basis_element_to_index` still uses the hashmap unconditionally, and `compute_basis` does not build the tables. Two things have to be true before flipping that, and only one of them is:

- **Where the time goes.** Counting `basis_element_to_index` calls over a real Nassau resolution of `S_2`: 2.46 M calls at t = 60, 1.21 billion at t = 120 — but against ~426 ns of surrounding work per call, so the lookup is only ~1.7% of runtime. The whole prize is under 2%. The looked-up degree tracks about 0.65·t, so at t = 350 roughly 7% of lookups are past the crossover and the weighted average still favours the hashmap; whole-resolution crossover is near t ≈ 420.
- **The benchmark flatters the hashmap.** It hammers one degree's map in a tight loop with nothing competing. A real high-degree run has hundreds of MB of index maps live against a 33 MB L3, so in situ the hashmap is worse than the table above shows and the true crossover is lower than 320 — by how much, a microbenchmark cannot say.

So the dispatch wants an in-situ profile rather than these numbers, and the memory argument (2) may well decide it before the timing one does. That is a separate PR; this one lands the primitive, the benchmark, and the evidence.

## Notes

- `seqno` takes the degree from the caller, which always has it, rather than re-deriving it as `Σ rᵢ·ξᵢ`. With `SeqnoRanker` hoisting the guard, that is worth 2.2x-2.8x — an earlier version of this benchmark was measuring that self-inflicted overhead as though it were inherent.
- `compute_seqno_tables` asserts the degree bound `compute_basis` already enforces. A negative argument wrapped to a huge row count (CodeRabbit).

## Test plan

- [x] `cargo test -p algebra` — incl. `seqno_matches_enumeration_order`, which cross-checks the caller-supplied degree against the p-part in debug builds
- [x] `cargo bench -p algebra --bench seqno` — the timing table above
- [x] Call counts measured with a temporary counter on `basis_element_to_index` over `construct(("S_2", "milnor"))` resolutions; the counting atomic itself cost 0.9% (518.3 s vs 513.7 s at t = 120), so it does not distort the ratio
- [x] `just lint` (nightly fmt + `cargo hack clippy` feature-powerset, `-D warnings`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPYvsLdEfitgCbAiPxxx3U)_