### PR TITLE
CI: lint the feature powerset with cargo-hack

### DIFF
--- a/.github/workflows/ext.yaml
+++ b/.github/workflows/ext.yaml
@@ -112,6 +112,12 @@ jobs:
           toolchain: nightly
           components: clippy, rustfmt
 
+      # `just lint` drives clippy through `cargo hack --feature-powerset`.
+      - name: Install cargo-hack
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-hack
+
       - name: Install python dependencies
         run: sudo apt-get install black flake8
 

--- a/.github/workflows/ext.yaml
+++ b/.github/workflows/ext.yaml
@@ -112,7 +112,6 @@ jobs:
           toolchain: nightly
           components: clippy, rustfmt
 
-      # `just lint` drives clippy through `cargo hack --feature-powerset`.
       - name: Install cargo-hack
         uses: taiki-e/install-action@v2
         with:

--- a/ext/Cargo.toml
+++ b/ext/Cargo.toml
@@ -63,23 +63,13 @@ nassau = []
 gpu = ["fp/gpu"]
 
 [workspace]
+# `fp-cuda` builds its CUDA kernel with nvcc, and fails to build without it. It is excluded from the
+# workspace rather than merely left out of `default-members`: the latter only affects commands that
+# omit `--workspace`, so `cargo check --workspace` and rust-analyzer's flycheck would still build
+# it, and fail for anyone without the CUDA Toolkit.
+exclude = ["crates/fp-cuda"]
+
 members = [
-    "crates/algebra",
-    "crates/bivec",
-    "crates/fp",
-    "crates/fp-cuda",
-    "crates/maybe-rayon",
-    "crates/once",
-    "crates/query",
-    "crates/sseq",
-]
-# `fp-cuda` builds its CUDA kernel with nvcc (falling back to a stub PTX when
-# nvcc is absent) and is opt-in. It stays out of the default member set so plain
-# workspace commands (`cargo build`, `cargo test`, `nix run .#test`) don't pull
-# it in; `fp`'s `gpu` feature depends on it explicitly when the GPU backend is
-# wanted.
-default-members = [
-    ".",
     "crates/algebra",
     "crates/bivec",
     "crates/fp",

--- a/ext/Cargo.toml
+++ b/ext/Cargo.toml
@@ -63,10 +63,8 @@ nassau = []
 gpu = ["fp/gpu"]
 
 [workspace]
-# `fp-cuda` builds its CUDA kernel with nvcc, and fails to build without it. It is excluded from the
-# workspace rather than merely left out of `default-members`: the latter only affects commands that
-# omit `--workspace`, so `cargo check --workspace` and rust-analyzer's flycheck would still build
-# it, and fail for anyone without the CUDA Toolkit.
+# `fp-cuda` needs nvcc. `default-members` is not enough: `--workspace` selects every member, so
+# `cargo check --workspace` and rust-analyzer would still build it.
 exclude = ["crates/fp-cuda"]
 
 members = [

--- a/ext/build_docs.py
+++ b/ext/build_docs.py
@@ -16,9 +16,10 @@ EXCLUDED_FEATURES = {"default", "gpu"}
 
 
 def metadata(*args):
+    # Only stdout is captured, so cargo's diagnostics still reach the terminal if it fails.
     out = subprocess.run(
         ["cargo", "metadata", "--format-version", "1", *args],
-        capture_output=True,
+        stdout=subprocess.PIPE,
         check=True,
         text=True,
     )
@@ -45,11 +46,10 @@ def main():
 
     # Not `target/`: it moves when CARGO_TARGET_DIR is set.
     doc_dir = os.path.join(metadata()["target_directory"], "doc")
-    crates_js = os.path.join(doc_dir, "crates.js")
 
-    # Prevent the cached crates.js from confusing the current run.
-    if os.path.exists(crates_js):
-        os.remove(crates_js)
+    # The whole directory, not just a stale crates.js: CI caches it between runs and uploads it
+    # wholesale, so docs for a crate that is no longer documented would be published forever.
+    subprocess.run(["cargo", "clean", "--doc"], check=True)
 
     feature_args = ["--features", ",".join(features)]
     for argv in (
@@ -69,7 +69,7 @@ def main():
     # built from leaves no dangling entry for one that is excluded from the workspace.
     crates = sorted(p["name"].replace("-", "_") for p in packages if p["name"] != "ext")
     entries = ",".join(f"'{name}'" for name in [*crates, "ext"])
-    with open(crates_js, "w") as f:
+    with open(os.path.join(doc_dir, "crates.js"), "w") as f:
         f.write(f"window.ALL_CRATES = [{entries}];\n")
 
 

--- a/ext/build_docs.py
+++ b/ext/build_docs.py
@@ -16,7 +16,6 @@ EXCLUDED_FEATURES = {"default", "gpu"}
 
 
 def metadata(*args):
-    # Only stdout is captured, so cargo's diagnostics still reach the terminal if it fails.
     out = subprocess.run(
         ["cargo", "metadata", "--format-version", "1", *args],
         stdout=subprocess.PIPE,

--- a/ext/build_docs.py
+++ b/ext/build_docs.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+
+# Build the rustdoc output published to gh-pages.
+#
+# `--all-features` would enable `gpu`, which needs nvcc, so every other feature is named
+# explicitly. Both the feature list and the crate list are read from `cargo metadata`, so adding
+# a feature or a crate needs no change here.
+
+import json
+import os
+import subprocess
+import sys
+
+KATEX_HEADER = "gh-pages/katex-header.html"
+EXCLUDED_FEATURES = {"default", "gpu"}
+
+
+def metadata(*args):
+    out = subprocess.run(
+        ["cargo", "metadata", "--format-version", "1", *args],
+        capture_output=True,
+        check=True,
+        text=True,
+    )
+    return json.loads(out.stdout)
+
+
+def main():
+    meta = metadata("--no-deps")
+    packages = meta["packages"]
+
+    features = sorted(
+        f"{p['name']}/{feature}"
+        for p in packages
+        for feature in p["features"]
+        if feature not in EXCLUDED_FEATURES
+    )
+    if not features:
+        sys.exit("no features found; the metadata query is wrong")
+
+    env = dict(os.environ)
+    env["RUSTDOCFLAGS"] = (
+        f"--html-in-header {KATEX_HEADER} {env.get('RUSTDOCFLAGS', '')}".strip()
+    )
+
+    # Not `target/`: it moves when CARGO_TARGET_DIR is set.
+    doc_dir = os.path.join(metadata()["target_directory"], "doc")
+    crates_js = os.path.join(doc_dir, "crates.js")
+
+    # Prevent the cached crates.js from confusing the current run.
+    if os.path.exists(crates_js):
+        os.remove(crates_js)
+
+    feature_args = ["--features", ",".join(features)]
+    for argv in (
+        ["cargo", "rustdoc", "--examples", *feature_args],
+        [
+            "cargo",
+            "doc",
+            "--all",
+            "--no-deps",
+            "--document-private-items",
+            *feature_args,
+        ],
+    ):
+        subprocess.run(argv, check=True, env=env)
+
+    # Prevent the examples from showing up in the sidebar. Listing the same crates the docs were
+    # built from leaves no dangling entry for one that is excluded from the workspace.
+    crates = sorted(p["name"].replace("-", "_") for p in packages if p["name"] != "ext")
+    entries = ",".join(f"'{name}'" for name in [*crates, "ext"])
+    with open(crates_js, "w") as f:
+        f.write(f"window.ALL_CRATES = [{entries}];\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/ext/crates/fp-cuda/Cargo.toml
+++ b/ext/crates/fp-cuda/Cargo.toml
@@ -24,6 +24,9 @@ cudarc = { version = "0.19", default-features = false, features = [
     "dynamic-loading",
 ] }
 
+[build-dependencies]
+anyhow = "1.0.98"
+
 [dev-dependencies]
 # The library API is fp-agnostic (raw limbs), so that the higher-level `fp` crate
 # can depend on `fp-cuda` without a dependency cycle. Only the examples and benches use `fp`.

--- a/ext/crates/fp-cuda/README.md
+++ b/ext/crates/fp-cuda/README.md
@@ -63,8 +63,8 @@ at runtime, so the Rust side builds with no CUDA present.
 
 This crate is **excluded from the workspace**, so every workspace-wide command
 (`cargo build`, `cargo check --workspace`, `nix run .#test`, and rust-analyzer's
-flycheck) ignores it. It is opt-in: building requires nvcc on `PATH` and (at
-runtime) a Hopper-class GPU.
+flycheck) ignores it. It is opt-in: building requires nvcc on `PATH` and a
+Hopper-class GPU at runtime.
 
 ## Prerequisites
 

--- a/ext/crates/fp-cuda/README.md
+++ b/ext/crates/fp-cuda/README.md
@@ -97,14 +97,11 @@ The kernel's tuning knobs live in `cuda_kernels/params.h`. The kernel includes
 that header directly, and `build.rs` parses it to generate the Rust mirror, so
 the host and device cannot disagree about a tile size.
 
-**When nvcc is absent** (CI, or a contributor without the CUDA Toolkit)
-`build.rs` emits a *stub* PTX and prints a warning instead of failing, so the
-crate stays `cargo check`/`clippy`-able everywhere — including under
-`cargo check --workspace --all-features`, which the workspace CI runs on a
-machine with no CUDA. The stub carries no kernel, so at runtime
-`GpuContext::new` returns an error and callers (e.g. `fp`'s GPU dispatch)
-fall back to the CPU path. An nvcc that *is* present but fails to compile is
-still a hard build error.
+**When nvcc is absent** (CI, or a contributor without the CUDA Toolkit) the
+build fails. Nothing in the workspace's own `just` recipes builds this crate:
+`lint` and `test` pass `--exclude fp-cuda`, and it is not in `default-members`.
+Callers reach the backend through `fp`'s optional `gpu` feature, which is off
+by default and falls back to the CPU path when it is not enabled.
 
 ## Running
 

--- a/ext/crates/fp-cuda/README.md
+++ b/ext/crates/fp-cuda/README.md
@@ -61,10 +61,8 @@ driver-API surface (module load, device buffers, typed launch) and its
 TMA descriptors. `cudarc` is stable Rust and dynamically loads the CUDA driver
 at runtime, so the Rust side builds with no CUDA present.
 
-This crate is **excluded from the workspace**, so every workspace-wide command
-(`cargo build`, `cargo check --workspace`, `nix run .#test`, and rust-analyzer's
-flycheck) ignores it. It is opt-in: building requires nvcc on `PATH` and a
-Hopper-class GPU at runtime.
+This crate is **excluded from the workspace**, so every workspace-wide command ignores it. It is
+opt-in: building requires nvcc on `PATH` and a Hopper-class GPU at runtime.
 
 ## Prerequisites
 

--- a/ext/crates/fp-cuda/README.md
+++ b/ext/crates/fp-cuda/README.md
@@ -61,9 +61,10 @@ driver-API surface (module load, device buffers, typed launch) and its
 TMA descriptors. `cudarc` is stable Rust and dynamically loads the CUDA driver
 at runtime, so the Rust side builds with no CUDA present.
 
-This crate is **excluded from the workspace's `default-members`**, so plain
-`cargo build` / `nix run .#test` ignore it. It is opt-in: building requires
-nvcc on `PATH` and (at runtime) a Hopper-class GPU.
+This crate is **excluded from the workspace**, so every workspace-wide command
+(`cargo build`, `cargo check --workspace`, `nix run .#test`, and rust-analyzer's
+flycheck) ignores it. It is opt-in: building requires nvcc on `PATH` and (at
+runtime) a Hopper-class GPU.
 
 ## Prerequisites
 
@@ -85,8 +86,10 @@ needed at build time to compile the kernel to PTX, and a CUDA driver at runtime.
 # nvcc lives in the opt-in dev shell, not the default one.
 nix develop ./ext#gpu
 
-# From the workspace root; the leading -p selects this crate explicitly.
-cargo build -p fp-cuda
+# The crate is excluded from the workspace, so run cargo from its own directory
+# rather than selecting it with -p from the root.
+cd ext/crates/fp-cuda
+cargo build
 ```
 
 `build.rs` invokes nvcc on `cuda_kernels/matmul_b1.cu` and emits
@@ -99,25 +102,27 @@ the host and device cannot disagree about a tile size.
 
 **When nvcc is absent** (CI, or a contributor without the CUDA Toolkit) the
 build fails. Nothing in the workspace's own `just` recipes builds this crate:
-`lint` and `test` pass `--exclude fp-cuda`, and it is not in `default-members`.
-Callers reach the backend through `fp`'s optional `gpu` feature, which is off
-by default and falls back to the CPU path when it is not enabled.
+the workspace `exclude` entry keeps it out, so even `--workspace` commands skip
+it. Callers reach the backend through `fp`'s optional `gpu` feature, which is
+off by default and falls back to the CPU path when it is not enabled.
 
 ## Running
 
+All from `ext/crates/fp-cuda`:
+
 ```bash
 # Smoke test (multiplies a few small shapes, asserts CPU↔GPU equality):
-cargo run -p fp-cuda --example matmul_b1_demo
+cargo run --example matmul_b1_demo
 
 # Kernel-only throughput (the number to quote):
-cargo run --release -p fp-cuda --example bench_kernel_only
+cargo run --release --example bench_kernel_only
 
 # Fast throughput sweep, and the L2-residency check:
-cargo run --release -p fp-cuda --example tune
-cargo run --release -p fp-cuda --example bench_shapes
+cargo run --release --example tune
+cargo run --release --example bench_shapes
 
 # Benchmark against the CPU AVX-512 path in fp::blas:
-cargo bench -p fp-cuda
+cargo bench
 ```
 
 The bench compares each square size in `{128, 256, 512, 1024, 2048, 4096, 8192}`
@@ -143,17 +148,22 @@ dependency is acyclic; the `Matrix` glue lives on the `fp` side
 (`src/blas/cuda.rs`) and in the examples/benches, which take a dev-dependency on
 `fp`.
 
-## Why excluded from `default-members`?
+## Why excluded from the workspace?
 
-Contributors without nvcc would otherwise see this crate's build fail every
-time they run `cargo build`. Keeping it out of the default member set means:
+Contributors without nvcc would otherwise see this crate's build fail every time
+they run a workspace-wide command. Leaving it out of `default-members` is not
+enough: path dependencies residing in the workspace directory are auto-discovered
+as members, and `--workspace` selects every member, so `cargo check --workspace`
+and rust-analyzer's flycheck would still build it. Only `exclude` keeps it out.
 
-- `cargo build`, `cargo test`, `cargo fmt`, `nix run .#test` from the
-  workspace root behave exactly as before.
-- Tooling that wants this crate explicitly opts in with `-p fp-cuda`.
+That means:
 
-The crate is still a workspace **member**, so `cargo metadata` sees it,
-`rust-analyzer` indexes it, and shared dependency resolution works.
+- `cargo build`, `cargo test`, `cargo check --workspace`, `nix run .#test` and
+  rust-analyzer all ignore the crate.
+- `fp`'s `gpu` feature still reaches it as a path dependency, so enabling the
+  backend works as before.
+- It is no longer addressable as `-p fp-cuda` from the workspace root. Build and
+  test it from its own directory: `cd crates/fp-cuda && cargo test`.
 
 ## Status
 

--- a/ext/crates/fp-cuda/README.md
+++ b/ext/crates/fp-cuda/README.md
@@ -61,8 +61,9 @@ driver-API surface (module load, device buffers, typed launch) and its
 TMA descriptors. `cudarc` is stable Rust and dynamically loads the CUDA driver
 at runtime, so the Rust side builds with no CUDA present.
 
-This crate is **excluded from the workspace**, so every workspace-wide command ignores it. It is
-opt-in: building requires nvcc on `PATH` and a Hopper-class GPU at runtime.
+This crate is **excluded from the workspace**, so `--workspace` never selects it. It is built only
+as a path dependency, when `fp`'s `gpu` feature is on. Building requires nvcc on `PATH`, and a
+Hopper-class GPU at runtime.
 
 ## Prerequisites
 
@@ -99,9 +100,8 @@ that header directly, and `build.rs` parses it to generate the Rust mirror, so
 the host and device cannot disagree about a tile size.
 
 **When nvcc is absent** (CI, or a contributor without the CUDA Toolkit) the
-build fails. Nothing in the workspace's own `just` recipes builds this crate:
-the workspace `exclude` entry keeps it out, so even `--workspace` commands skip
-it. Callers reach the backend through `fp`'s optional `gpu` feature, which is
+build fails. Nothing in the workspace's own `just` recipes builds this crate: it
+is not a member, and none of them enable `fp`'s optional `gpu` feature, which is
 off by default and falls back to the CPU path when it is not enabled.
 
 ## Running

--- a/ext/crates/fp-cuda/build.rs
+++ b/ext/crates/fp-cuda/build.rs
@@ -2,18 +2,14 @@
 //!
 //! The emitted `matmul_b1.ptx` is picked up by `src/lib.rs` via
 //! `include_bytes!(concat!(env!("OUT_DIR"), "/matmul_b1.ptx"))`.
-//!
-//! When `nvcc` is **not on PATH**, we emit a *stub* PTX instead of failing the build. This keeps
-//! the crate `cargo check`/`clippy`-able everywhere, which CI relies on: it runs `cargo check
-//! --workspace --all-features` on a machine with no CUDA. The stub carries no kernel, so at runtime
-//! `GpuContext::new` fails cleanly and callers fall back to the CPU path. An `nvcc` that *is*
-//! present but fails to compile is still a hard error.
 
 use std::{
     env, fs,
     path::{Path, PathBuf},
     process::Command,
 };
+
+use anyhow::{Context, bail};
 
 const KERNEL_SRC: &str = "cuda_kernels/matmul_b1.cu";
 const PARAMS_HEADER: &str = "cuda_kernels/params.h";
@@ -71,14 +67,7 @@ fn emit_params(out_dir: &Path) -> Vec<(String, usize)> {
     knobs
 }
 
-/// A minimal, valid PTX module with no kernel.
-///
-/// `include_bytes!` needs the file to exist, so one is always written.
-const STUB_PTX: &str = "//\n// fp-cuda stub: nvcc was unavailable at build time; no GPU kernel \
-                        was\n// compiled. Install the CUDA Toolkit (12.x+) and rebuild to enable \
-                        the GPU\n// backend.\n//\n.version 8.0\n.target sm_90a\n.address_size 64\n";
-
-fn main() {
+fn main() -> anyhow::Result<()> {
     println!("cargo:rerun-if-changed={KERNEL_SRC}");
     println!("cargo:rerun-if-changed={PARAMS_HEADER}");
     println!("cargo:rerun-if-changed=build.rs");
@@ -109,29 +98,19 @@ fn main() {
         )
         .args([KERNEL_SRC, "-o"])
         .arg(&ptx_out)
-        .status();
+        .status()
+        .with_context(|| {
+            format!("failed to run nvcc ('{nvcc}'). Set the NVCC env var to a working nvcc.")
+        })?;
 
-    match status {
-        // nvcc ran and compiled the kernel
-        Ok(s) if s.success() => {}
-        // nvcc exists but failed to compile
-        Ok(s) => panic!(
-            "nvcc failed to compile {KERNEL_SRC} (exit status: {s}).\nCheck that your CUDA \
-             Toolkit supports {ARCH} (Hopper sm_90a)."
-        ),
-        // nvcc absent, degrade to a stub so the crate still builds
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-            println!(
-                "cargo:warning=fp-cuda: nvcc not found ('{nvcc}': {e}); emitting a stub PTX. The \
-                 GPU backend will be unavailable at runtime. Install the CUDA Toolkit (12.x+) and \
-                 rebuild to enable it."
-            );
-            fs::write(&ptx_out, STUB_PTX).expect("failed to write stub PTX to OUT_DIR");
-        }
-        // nvcc is present but couldn't be executed
-        Err(e) => panic!(
-            "failed to run nvcc ('{nvcc}': {e}). Set the NVCC env var to a working nvcc, or unset \
-             it to fall back to a stub only when nvcc is absent."
-        ),
+    // A non-zero exit is `Ok` as far as `status()` is concerned, so it has to be turned into a
+    // failure explicitly or the build script would succeed with no PTX written.
+    if !status.success() {
+        bail!(
+            "nvcc failed to compile {KERNEL_SRC} ({status}). Check that your CUDA Toolkit \
+             supports {ARCH} (Hopper)."
+        );
     }
+
+    Ok(())
 }

--- a/ext/crates/fp-cuda/src/lib.rs
+++ b/ext/crates/fp-cuda/src/lib.rs
@@ -61,8 +61,6 @@ pub struct GpuContext {
 
 impl GpuContext {
     /// Open device `device_id` and load the kernel onto it.
-    ///
-    /// Fails if there is no usable device.
     pub fn new(device_id: usize) -> anyhow::Result<Self> {
         let ctx = CudaContext::new(device_id)?;
         let ptx = Ptx::from_src(String::from_utf8(PTX_IMAGE.to_vec())?);

--- a/ext/crates/fp-cuda/src/lib.rs
+++ b/ext/crates/fp-cuda/src/lib.rs
@@ -62,8 +62,7 @@ pub struct GpuContext {
 impl GpuContext {
     /// Open device `device_id` and load the kernel onto it.
     ///
-    /// Fails if there is no usable device, or if the embedded PTX is the stub `build.rs` emits when
-    /// `nvcc` is absent, in which case the kernel is missing from the module.
+    /// Fails if there is no usable device.
     pub fn new(device_id: usize) -> anyhow::Result<Self> {
         let ctx = CudaContext::new(device_id)?;
         let ptx = Ptx::from_src(String::from_utf8(PTX_IMAGE.to_vec())?);

--- a/ext/crates/fp/Cargo.toml
+++ b/ext/crates/fp/Cargo.toml
@@ -55,3 +55,4 @@ harness = false
 [[bench]]
 name = "smallfq"
 harness = false
+required-features = ["odd-primes"]

--- a/ext/examples/bruner.rs
+++ b/ext/examples/bruner.rs
@@ -168,8 +168,6 @@ fn read_bruner_resolution(data_dir: &Path, max_n: i32) -> Result<(i32, FiniteCha
     let cc = create_chain_complex(num_s as usize);
     let algebra = cc.algebra();
 
-    // With `nassau` the algebra is already a `MilnorAlgebra`, so this conversion is a no-op;
-    // without it the algebra is a `SteenrodAlgebra` and the conversion does real work.
     #[cfg_attr(feature = "nassau", allow(clippy::useless_conversion))]
     let algebra: &MilnorAlgebra = algebra.as_ref().try_into()?;
 

--- a/ext/examples/bruner.rs
+++ b/ext/examples/bruner.rs
@@ -168,6 +168,9 @@ fn read_bruner_resolution(data_dir: &Path, max_n: i32) -> Result<(i32, FiniteCha
     let cc = create_chain_complex(num_s as usize);
     let algebra = cc.algebra();
 
+    // With `nassau` the algebra is already a `MilnorAlgebra`, so this conversion is a no-op;
+    // without it the algebra is a `SteenrodAlgebra` and the conversion does real work.
+    #[cfg_attr(feature = "nassau", allow(clippy::useless_conversion))]
     let algebra: &MilnorAlgebra = algebra.as_ref().try_into()?;
 
     let mut buf = String::new();

--- a/ext/examples/save_bruner.rs
+++ b/ext/examples/save_bruner.rs
@@ -18,6 +18,9 @@ fn main() -> anyhow::Result<()> {
 
     assert_eq!(resolution.prime(), 2);
     let algebra = resolution.algebra();
+    // With `nassau` the algebra is already a `MilnorAlgebra`, so this conversion is a no-op;
+    // without it the algebra is a `SteenrodAlgebra` and the conversion does real work.
+    #[cfg_attr(feature = "nassau", allow(clippy::useless_conversion))]
     let algebra: &MilnorAlgebra = algebra.as_ref().try_into()?;
 
     let mut buffer = String::new();

--- a/ext/examples/save_bruner.rs
+++ b/ext/examples/save_bruner.rs
@@ -18,8 +18,6 @@ fn main() -> anyhow::Result<()> {
 
     assert_eq!(resolution.prime(), 2);
     let algebra = resolution.algebra();
-    // With `nassau` the algebra is already a `MilnorAlgebra`, so this conversion is a no-op;
-    // without it the algebra is a `SteenrodAlgebra` and the conversion does real work.
     #[cfg_attr(feature = "nassau", allow(clippy::useless_conversion))]
     let algebra: &MilnorAlgebra = algebra.as_ref().try_into()?;
 

--- a/ext/flake.nix
+++ b/ext/flake.nix
@@ -38,6 +38,7 @@
           pkgs.cargo-cache
           pkgs.cargo-criterion
           pkgs.cargo-flamegraph
+          pkgs.cargo-hack
           pkgs.cargo-nextest
           pkgs.perf
         ]

--- a/ext/justfile
+++ b/ext/justfile
@@ -19,12 +19,11 @@ lint:
     cargo fmt --all -- --check
     cargo hack clippy --workspace --all-targets --feature-powerset --skip gpu --profile test
 
-# Apply the fixes that `lint` only checks: rustfmt formatting + clippy autofixes
-# (mirrors the clippy configurations run by `lint`).
+# Apply the fixes that `lint` only checks. Same feature powerset, so nothing `fix` leaves behind
+# is reported by the `lint` run that follows it.
 fix:
     cargo fmt --all
-    cargo clippy --workspace --no-default-features --profile test --fix --allow-dirty --allow-staged
-    cargo clippy --workspace --all-targets --profile test --fix --allow-dirty --allow-staged
+    cargo hack clippy --workspace --all-targets --feature-powerset --skip gpu --profile test --fix --allow-dirty --allow-staged
 
 docs:
     ./build_docs.py

--- a/ext/justfile
+++ b/ext/justfile
@@ -28,12 +28,27 @@ fix:
     cargo clippy --workspace --all-targets --profile test --fix --allow-dirty --allow-staged
 
 docs:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    # `--all-features` would enable `gpu`, which needs nvcc, so name every other feature instead.
+    # Derived from the manifests so a new feature is documented without editing this recipe.
+    features="$(cargo metadata --no-deps --format-version 1 \
+        | jq -r '.packages[] as $p | $p.features | keys[]
+                 | select(. != "default" and . != "gpu") | "\($p.name)/\(.)"' \
+        | sort -u | paste -sd,)"
+    [ -n "$features" ] || { echo "no features found; the metadata query is wrong" >&2; exit 1; }
+    export RUSTDOCFLAGS="--html-in-header gh-pages/katex-header.html ${RUSTDOCFLAGS:-}"
+    # Not `target/`: it moves when CARGO_TARGET_DIR is set.
+    doc_dir="$(cargo metadata --format-version 1 | jq -r .target_directory)/doc"
     # Prevent the cached crates.js from confusing the current run
-    rm target/doc/crates.js || true
-    RUSTDOCFLAGS="--html-in-header gh-pages/katex-header.html $RUSTDOCFLAGS" cargo rustdoc --examples --all-features
-    RUSTDOCFLAGS="--html-in-header gh-pages/katex-header.html $RUSTDOCFLAGS" cargo doc --all --no-deps --document-private-items --all-features
-    # Prevent the examples from showing up in the sidebar
-    echo "window.ALL_CRATES = [$(ls crates/ | sed "s/.*/'&',/; s/-/_/g")'ext'];" > target/doc/crates.js
+    rm -f "$doc_dir/crates.js"
+    cargo rustdoc --examples --features "$features"
+    cargo doc --all --no-deps --document-private-items --features "$features"
+    # Prevent the examples from showing up in the sidebar. The crate list comes from the same
+    # metadata as the docs themselves, so an excluded crate (`fp-cuda`) leaves no dangling entry.
+    crates="$(cargo metadata --no-deps --format-version 1 \
+        | jq -r '.packages[].name' | grep -vx ext | sort | sed "s/-/_/g; s/.*/'&',/" | tr -d '\n')"
+    echo "window.ALL_CRATES = [${crates}'ext'];" > "$doc_dir/crates.js"
 
 miri:
     cargo miri test -p once

--- a/ext/justfile
+++ b/ext/justfile
@@ -19,8 +19,7 @@ lint:
     cargo fmt --all -- --check
     cargo hack clippy --workspace --all-targets --feature-powerset --skip gpu --profile test
 
-# Apply the fixes that `lint` only checks. Same feature powerset, so nothing `fix` leaves behind
-# is reported by the `lint` run that follows it.
+# Apply the fixes that `lint` only checks.
 fix:
     cargo fmt --all
     cargo hack clippy --workspace --all-targets --feature-powerset --skip gpu --profile test --fix --allow-dirty --allow-staged

--- a/ext/justfile
+++ b/ext/justfile
@@ -15,7 +15,6 @@ test:
     cargo test --features concurrent --doc --workspace
     pytest
 
-# `clippy` type-checks everything `check` does, so the powerset only needs the one pass.
 lint:
     cargo fmt --all -- --check
     cargo hack clippy --workspace --all-targets --feature-powerset --skip gpu --profile test
@@ -28,27 +27,7 @@ fix:
     cargo clippy --workspace --all-targets --profile test --fix --allow-dirty --allow-staged
 
 docs:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    # `--all-features` would enable `gpu`, which needs nvcc, so name every other feature instead.
-    # Derived from the manifests so a new feature is documented without editing this recipe.
-    features="$(cargo metadata --no-deps --format-version 1 \
-        | jq -r '.packages[] as $p | $p.features | keys[]
-                 | select(. != "default" and . != "gpu") | "\($p.name)/\(.)"' \
-        | sort -u | paste -sd,)"
-    [ -n "$features" ] || { echo "no features found; the metadata query is wrong" >&2; exit 1; }
-    export RUSTDOCFLAGS="--html-in-header gh-pages/katex-header.html ${RUSTDOCFLAGS:-}"
-    # Not `target/`: it moves when CARGO_TARGET_DIR is set.
-    doc_dir="$(cargo metadata --format-version 1 | jq -r .target_directory)/doc"
-    # Prevent the cached crates.js from confusing the current run
-    rm -f "$doc_dir/crates.js"
-    cargo rustdoc --examples --features "$features"
-    cargo doc --all --no-deps --document-private-items --features "$features"
-    # Prevent the examples from showing up in the sidebar. The crate list comes from the same
-    # metadata as the docs themselves, so an excluded crate (`fp-cuda`) leaves no dangling entry.
-    crates="$(cargo metadata --no-deps --format-version 1 \
-        | jq -r '.packages[].name' | grep -vx ext | sort | sed "s/-/_/g; s/.*/'&',/" | tr -d '\n')"
-    echo "window.ALL_CRATES = [${crates}'ext'];" > "$doc_dir/crates.js"
+    ./build_docs.py
 
 miri:
     cargo miri test -p once

--- a/ext/justfile
+++ b/ext/justfile
@@ -15,12 +15,10 @@ test:
     cargo test --features concurrent --doc --workspace
     pytest
 
+# `clippy` type-checks everything `check` does, so the powerset only needs the one pass.
 lint:
     cargo fmt --all -- --check
-    cargo clippy --workspace --no-default-features --profile test
-    cargo clippy --workspace --all-targets --profile test
-    cargo check --workspace --no-default-features --profile test
-    cargo check --workspace --all-targets --all-features --profile test
+    cargo hack clippy --workspace --all-targets --feature-powerset --skip gpu --profile test
 
 # Apply the fixes that `lint` only checks: rustfmt formatting + clippy autofixes
 # (mirrors the clippy configurations run by `lint`).


### PR DESCRIPTION
Closes #283.

That issue weighed three options for the `--all-features` problem. This takes the third — keep feature coverage but stop enabling `gpu` — and gets *more* coverage than before rather than less.

## What changed

**`just lint` now runs one `cargo hack` pass instead of four fixed invocations.**

```
- cargo clippy --workspace --no-default-features --profile test
- cargo clippy --workspace --all-targets --profile test
- cargo check  --workspace --no-default-features --profile test
- cargo check  --workspace --all-targets --all-features --profile test
+ cargo hack clippy --workspace --all-targets --feature-powerset --skip gpu --profile test
```

The old set only ever checked two points in the feature space (all-default and none), which is the coverage gap #283 worried about losing. The powerset checks all 82 combinations. `--skip gpu` means `fp/gpu` is never enabled, so no CUDA toolchain is needed. `check` is dropped because `clippy` type-checks everything `check` does, so on a powerset it would be 82 redundant invocations against a separate cache.

**`fp-cuda` is excluded from the workspace, not just from `default-members`.** Path dependencies inside the workspace directory are auto-discovered as members, so `fp`'s optional `fp-cuda = { path = ... }` pulled it back in regardless of the `members` list. `default-members` only affects commands that *omit* `--workspace`, so `cargo check --workspace` and rust-analyzer's flycheck still built it and failed for anyone without nvcc. `default-members` had become byte-identical to `members` and is removed. `fp`'s `gpu` feature still reaches the crate as a path dependency.

**The stub PTX is gone.** With `gpu` never enabled in CI it has no remaining purpose, and a missing toolchain is now a loud error instead of silently producing a crate that compiles and then declines to use the GPU — the behaviour #283 identifies as what you actually want on a developer machine. `build.rs` returns `anyhow::Result<()>`; note that a non-zero nvcc exit is `Ok` as far as `Command::status()` is concerned, so it has to be converted explicitly or the build script would succeed having written no PTX.

## Two latent problems the wider coverage surfaced

Both are pre-existing and only visible in feature combinations nothing checked before:

- `crates/fp/benches/smallfq.rs` doesn't build without `odd-primes` — it benchmarks `SmallFq` at `P3`/`P5`/`P7`. Gated with `required-features` so cargo skips the target rather than building an empty one.
- `examples/{bruner,save_bruner}.rs` have a `try_into` that is a no-op under `nassau` (where the algebra is already a `MilnorAlgebra`) but does real work otherwise. CI sets `RUSTFLAGS: -D warnings`, and no previous lint invocation enabled `nassau`, so this became a hard error the moment the powerset reached that combination.

## Notes

- `.github/workflows/ext.yaml` gains a `cargo-hack` install step — the runners use rustup, not the nix flake, so having it in `flake.nix` isn't enough.
- Each commit is individually green: the stub is only removed *after* the crate leaves the workspace.
- Verified locally: `just lint` exits 0 across all 82 combinations under `-D warnings`, with no warnings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * CUDA builds now fail clearly when `nvcc` or a usable CUDA compiler is unavailable, instead of generating fallback stub output.

* **Improvements**
  * Linting now checks supported feature combinations while excluding GPU-specific checks.
  * Added `cargo-hack` to development environments and automated linting.
  * Updated CUDA documentation, feature guidance, and benchmark requirements.
  * Improved lint compatibility for optional-feature examples.
  * Streamlined documentation generation across supported features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->