### PR TITLE
The deformation (algebraic Novikov / τ-Bockstein) spectral sequence

### DIFF
--- a/ext/crates/algebra/src/algebra/milnor_algebra.rs
+++ b/ext/crates/algebra/src/algebra/milnor_algebra.rs
@@ -414,8 +414,6 @@ impl std::fmt::Display for MilnorBasisElement {
 pub struct MilnorAlgebra {
     profile: MilnorProfile,
     p: ValidPrime,
-    #[cfg(feature = "odd-primes")]
-    generic: bool,
 
     unstable_enabled: bool,
 
@@ -455,8 +453,6 @@ impl MilnorAlgebra {
         assert!(profile.is_valid());
         Self {
             p,
-            #[cfg(feature = "odd-primes")]
-            generic: p != 2,
             unstable_enabled,
             profile,
             ppart_table: OnceVec::new(),
@@ -468,17 +464,13 @@ impl MilnorAlgebra {
         }
     }
 
+    /// Whether the algebra has an exterior part, which is the case exactly at odd primes.
+    ///
+    /// Without the `odd-primes` feature [`ValidPrime`] is the zero-sized type $2$, so this folds
+    /// to a constant `false`.
     #[inline]
     pub fn generic(&self) -> bool {
-        #[cfg(feature = "odd-primes")]
-        {
-            self.generic
-        }
-
-        #[cfg(not(feature = "odd-primes"))]
-        {
-            false
-        }
+        self.p != 2
     }
 
     pub fn q(&self) -> i32 {
@@ -1195,62 +1187,6 @@ impl MilnorAlgebra {
         self.try_beps_pn(e, x).unwrap()
     }
 
-    fn multiply_qpart(&self, m1: MilnorBasisElement, f: u32) -> Vec<(u32, MilnorBasisElement)> {
-        let mut new_result: Vec<(u32, MilnorBasisElement)> = vec![(1, m1)];
-        let mut old_result: Vec<(u32, MilnorBasisElement)> = Vec::new();
-
-        for k in BitflagIterator::set_bit_iterator(f as u64) {
-            let k = k as u32;
-            let pk = self.p.pow(k);
-            std::mem::swap(&mut new_result, &mut old_result);
-            new_result.clear();
-
-            // We implement the formula
-            // P(R) Q_k = Q_k P^R + Q_{k+1} P(R - p^k e_1) + Q_{k+2} P(R - p^k e_2) +
-            // ... + Q_{k + i} P(R - p^k e_i) + ...
-            // where e_i is the vector with value 1 in entry i and 0 otherwise (in the above
-            // formula, the first xi is xi_1, hence the offset below). If R - p^k e_i has a
-            // negative entry, the term is 0.
-            //
-            // We also use the fact that Q_k Q_j = -Q_j Q_k
-            for (coef, term) in &old_result {
-                for i in 0..=term.p_part.len() {
-                    // If there is already Q_{k+i} on the other side, the result is 0
-                    if term.q_part & (1 << (k + i as u32)) != 0 {
-                        continue;
-                    }
-                    let mut new_p = term.p_part;
-                    if i > 0 {
-                        // Check if R - p^k e_i < 0. Only do this from the first term onwards.
-                        let entry = new_p.get(i - 1);
-                        if entry < pk {
-                            continue;
-                        }
-                        new_p.set(i - 1, entry - pk);
-                    }
-
-                    // Now calculate the number of Q's we are moving past
-                    let larger_q = (term.q_part >> (k + i as u32 + 1)).count_ones();
-
-                    // Now put everything together
-                    let m = MilnorBasisElement {
-                        p_part: new_p,
-                        q_part: term.q_part | (1 << (k + i as u32)),
-                        degree: 0, // we don't really care about the degree here. The final degree of the whole calculation is known a priori
-                    };
-                    let c = if larger_q.is_multiple_of(2) {
-                        *coef
-                    } else {
-                        *coef * (self.prime() - 1)
-                    };
-
-                    new_result.push((c, m));
-                }
-            }
-        }
-        new_result
-    }
-
     pub fn multiply(
         &self,
         res: FpSliceMut,
@@ -1270,48 +1206,16 @@ impl MilnorAlgebra {
         m1: MilnorBasisElement,
         m2: MilnorBasisElement,
         excess: i32,
-        mut allocation: PPartAllocation,
+        allocation: PPartAllocation,
     ) -> PPartAllocation {
         let target_deg = m1.degree + m2.degree;
-        if self.generic() {
-            let m1f = self.multiply_qpart(m1, m2.q_part);
-            for (cc, basis) in m1f {
-                let mut multiplier = PPartMultiplier::<false>::new_from_allocation(
-                    self.prime(),
-                    basis.p_part,
-                    m2.p_part,
-                    allocation,
-                    basis.q_part,
-                    target_deg,
-                );
-
-                while let Some(c) = multiplier.next() {
-                    let idx = self.basis_element_to_index(&multiplier.ans);
-                    if idx < self.dimension_unstable(target_deg, excess) {
-                        res.add_basis_element(idx, c * cc * coef);
-                    }
-                }
-                allocation = multiplier.into_allocation()
+        let dim = self.dimension_unstable(target_deg, excess);
+        milnor_product(self.prime(), m1, m2, allocation, |c, ans| {
+            let idx = self.basis_element_to_index(ans);
+            if idx < dim {
+                res.add_basis_element(idx, c * coef);
             }
-        } else {
-            let mut multiplier = PPartMultiplier::<false>::new_from_allocation(
-                self.prime(),
-                m1.p_part,
-                m2.p_part,
-                allocation,
-                0,
-                target_deg,
-            );
-
-            while let Some(c) = multiplier.next() {
-                let idx = self.basis_element_to_index(&multiplier.ans);
-                if idx < self.dimension_unstable(target_deg, excess) {
-                    res.add_basis_element(idx, c * coef);
-                }
-            }
-            allocation = multiplier.into_allocation()
-        }
-        allocation
+        })
     }
 
     pub fn multiply_basis_by_element(
@@ -1450,6 +1354,103 @@ impl PPartAllocation {
 pub const fn next_disjoint(sum: PPartEntry, k: PPartEntry) -> PPartEntry {
     debug_assert!(k & sum == 0, "next_disjoint needs k disjoint from sum");
     ((k | sum) + 1) & !sum
+}
+
+fn multiply_qpart(p: ValidPrime, m1: MilnorBasisElement, f: u32) -> Vec<(u32, MilnorBasisElement)> {
+    let mut new_result: Vec<(u32, MilnorBasisElement)> = vec![(1, m1)];
+    let mut old_result: Vec<(u32, MilnorBasisElement)> = Vec::new();
+
+    for k in BitflagIterator::set_bit_iterator(f as u64) {
+        let k = k as u32;
+        let pk = p.pow(k);
+        std::mem::swap(&mut new_result, &mut old_result);
+        new_result.clear();
+
+        // We implement the formula
+        // P(R) Q_k = Q_k P^R + Q_{k+1} P(R - p^k e_1) + Q_{k+2} P(R - p^k e_2) +
+        // ... + Q_{k + i} P(R - p^k e_i) + ...
+        // where e_i is the vector with value 1 in entry i and 0 otherwise (in the above
+        // formula, the first xi is xi_1, hence the offset below). If R - p^k e_i has a
+        // negative entry, the term is 0.
+        //
+        // We also use the fact that Q_k Q_j = -Q_j Q_k
+        for (coef, term) in &old_result {
+            for i in 0..=term.p_part.len() {
+                // If there is already Q_{k+i} on the other side, the result is 0
+                if term.q_part & (1 << (k + i as u32)) != 0 {
+                    continue;
+                }
+                let mut new_p = term.p_part;
+                if i > 0 {
+                    // Check if R - p^k e_i < 0. Only do this from the first term onwards.
+                    let entry = new_p.get(i - 1);
+                    if entry < pk {
+                        continue;
+                    }
+                    new_p.set(i - 1, entry - pk);
+                }
+
+                // Now calculate the number of Q's we are moving past
+                let larger_q = (term.q_part >> (k + i as u32 + 1)).count_ones();
+
+                // Now put everything together
+                let m = MilnorBasisElement {
+                    p_part: new_p,
+                    q_part: term.q_part | (1 << (k + i as u32)),
+                    degree: 0, // we don't really care about the degree here. The final degree of the whole calculation is known a priori
+                };
+                let c = if larger_q.is_multiple_of(2) {
+                    *coef
+                } else {
+                    *coef * (p - 1)
+                };
+
+                new_result.push((c, m));
+            }
+        }
+    }
+    new_result
+}
+
+/// Multiply two Milnor basis elements, reporting each `(coefficient, basis element)` of the result.
+///
+/// The exterior part of `m2` is commuted leftwards past `m1` by `multiply_qpart`, and each
+/// resulting polynomial part is expanded by a single [`PPartMultiplier`] walk. When `m2` has no
+/// exterior part there is nothing to commute, and this is the walk alone: the classical $p = 2$
+/// product.
+pub fn milnor_product(
+    p: ValidPrime,
+    m1: MilnorBasisElement,
+    m2: MilnorBasisElement,
+    mut allocation: PPartAllocation,
+    mut f: impl FnMut(u32, &MilnorBasisElement),
+) -> PPartAllocation {
+    let target_deg = m1.degree + m2.degree;
+    let mut walk = |cc: u32, basis: &MilnorBasisElement, allocation| {
+        let mut multiplier = PPartMultiplier::<false>::new_from_allocation(
+            p,
+            basis.p_part,
+            m2.p_part,
+            allocation,
+            basis.q_part,
+            target_deg,
+        );
+        while let Some(c) = multiplier.next() {
+            f(c * cc, &multiplier.ans);
+        }
+        multiplier.into_allocation()
+    };
+
+    // An empty exterior part commutes past `m1` trivially, so skip the `multiply_qpart` buffer and
+    // its allocation. This is every product at $p = 2$.
+    if m2.q_part == 0 {
+        return walk(1, &m1, allocation);
+    }
+
+    for (cc, basis) in multiply_qpart(p, m1, m2.q_part) {
+        allocation = walk(cc, &basis, allocation);
+    }
+    allocation
 }
 
 #[allow(non_snake_case)]

--- a/ext/crates/algebra/src/algebra/mod.rs
+++ b/ext/crates/algebra/src/algebra/mod.rs
@@ -19,7 +19,7 @@ pub mod milnor_algebra;
 pub use milnor_algebra::MilnorAlgebra;
 
 pub mod motivic;
-pub use motivic::MotivicMilnorAlgebra;
+pub use motivic::{CTauAlgebra, MotivicMilnorAlgebra};
 
 mod steenrod_algebra;
 pub use steenrod_algebra::{AlgebraType, SteenrodAlgebra};

--- a/ext/crates/algebra/src/algebra/motivic/ctau.rs
+++ b/ext/crates/algebra/src/algebra/motivic/ctau.rs
@@ -126,18 +126,24 @@ impl Algebra for CTauAlgebra {
         // part leftwards past it; the engine's `product_indexed` orders its arguments the other
         // way. Passing `s` then `r` keeps this product equal to the engine's τ^0 part, which the
         // cross-check below pins down.
-        milnor_product(
-            TWO,
-            mbe(s_degree, s_idx),
-            mbe(r_degree, r_idx),
-            PPartAllocation::default(),
-            |c, res| {
-                let elt = Dual(Monomial::new(res.q_part, res.p_part));
-                if let Some(idx) = self.ac.index_of(t, &elt) {
+        PPartAllocation::with_local(|allocation| {
+            milnor_product(
+                TWO,
+                mbe(s_degree, s_idx),
+                mbe(r_degree, r_idx),
+                allocation,
+                |c, res| {
+                    let elt = Dual(Monomial::new(res.q_part, res.p_part));
+                    // `enum_basis` holds every monomial of degree `t`, so a miss is a broken
+                    // product invariant rather than a term to drop.
+                    let idx = self
+                        .ac
+                        .index_of(t, &elt)
+                        .expect("A_C/τ product left the degree-t basis");
                     result.add_basis_element(idx, coeff * c);
-                }
-            },
-        );
+                },
+            )
+        });
     }
 
     fn basis_element_to_string(&self, degree: i32, idx: usize) -> String {
@@ -157,7 +163,9 @@ impl Algebra for CTauAlgebra {
             if tok == "1" {
                 continue;
             }
-            q_part |= 1 << tok.strip_prefix("Q_")?.parse::<u32>().ok()?;
+            // The exterior part is a 32-bit mask, so an out-of-range index is malformed
+            // input, not an out-of-range shift.
+            q_part |= 1u32.checked_shl(tok.strip_prefix("Q_")?.parse::<u32>().ok()?)?;
         }
         let r = match p_str {
             Some(s) => {
@@ -294,7 +302,7 @@ impl GeneratedAlgebra for CTauAlgebra {
         target.add_basis_element(idx, 1);
         let mut coeffs = FpVector::new(TWO, n);
         reduce_row(&mut target, &mut coeffs, &rows);
-        debug_assert!(
+        assert!(
             target.is_zero(),
             "A_C/τ basis element ({degree}, {idx}) is not a generator but did not decompose"
         );
@@ -401,6 +409,10 @@ mod tests {
         // Malformed input is rejected, not panicked on.
         assert_eq!(alg.basis_element_from_string("Sq1"), None);
         assert_eq!(alg.basis_element_from_string("Q_"), None);
+        // The exterior mask is 32 bits wide, so `Q_32` is out of range: rejected rather
+        // than shifted out of bounds.
+        assert_eq!(alg.basis_element_from_string("Q_32"), None);
+        assert_eq!(alg.basis_element_from_string("Q_99"), None);
     }
 
     #[test]

--- a/ext/crates/algebra/src/algebra/motivic/ctau.rs
+++ b/ext/crates/algebra/src/algebra/motivic/ctau.rs
@@ -1,0 +1,560 @@
+//! $A_C/\tau$: the mod-$\tau$ reduction of the C-motivic Steenrod algebra,
+//! presented to the resolution engine as an ordinary $\mathbb{F}_2$-algebra.
+//!
+//! Setting $\tau = 0$ in $A_C$ collapses the defining relation $\tau_i^2 =
+//! \tau\xi_{i+1}$ to $\tau_i^2 = 0$, so
+//! $$A_C/\tau \;\cong\; \mathbb{F}_2[\xi_1, \xi_2, \dots] \otimes E(\tau_0, \tau_1, \dots).$$
+//! This is a **connected, finite-type $\mathbb{F}_2$-algebra** — once $\tau$ is
+//! gone every generator has positive stem — and it is *strictly bigger* than the
+//! classical dual Steenrod algebra $\mathbb{F}_2[\xi_i]$ (it carries the extra
+//! exterior generators $\tau_i$). Its cohomology $\mathrm{Ext}_{A_C/\tau}$ is the
+//! **algebraic Novikov $E_2$**, equivalently the motivic Adams $E_2$ of $C\tau$
+//! (Gheorghe–Wang–Xu).
+//!
+//! Because $A_C$ is a free $\mathbb{F}_2[\tau]$-module on the Milnor basis
+//! $\{Q(E)P(R)\}$, the reduction $A_C/\tau = A_C \otimes_{\mathbb{F}_2[\tau]}
+//! \mathbb{F}_2$ has *the same basis*, and its product is the $\tau^0$ part of the
+//! $A_C$ product: reduce each structure constant $\tau^k$ mod $\tau$, keeping only
+//! $k = 0$. So this type is a thin $\mathbb{F}_2$ view over the
+//! [`MotivicMilnorAlgebra`] engine, and the ordinary ($\mathbb{F}_p$-only)
+//! resolution engine can resolve over it unchanged.
+//!
+//! Each basis element additionally carries a **motivic weight** (via
+//! [`CTauAlgebra::weight`]); the algebra is graded by the single topological
+//! degree `t`, with weight a bounded per-basis-element label that the Phase 2
+//! lift consumes.
+
+use fp::{
+    prime::{TWO, ValidPrime},
+    vector::{FpSliceMut, FpVector},
+};
+
+use super::{
+    MotivicMilnorAlgebra,
+    milnor::{Bigraded, Dual, Monomial},
+};
+use crate::algebra::{
+    Algebra, GeneratedAlgebra,
+    milnor_algebra::{MilnorBasisElement, PPartAllocation, milnor_product},
+};
+
+/// $A_C/\tau$, the mod-$\tau$ C-motivic Steenrod algebra as an $\mathbb{F}_2$-algebra.
+///
+/// Wraps the [`MotivicMilnorAlgebra`] $A_C$ engine and presents its $\tau^0$
+/// product to the resolution engine. Resolving the trivial module over this
+/// algebra yields the algebraic Novikov $E_2$.
+#[derive(Default)]
+pub struct CTauAlgebra {
+    ac: MotivicMilnorAlgebra,
+}
+
+impl CTauAlgebra {
+    pub fn new() -> Self {
+        Self {
+            ac: MotivicMilnorAlgebra::new(),
+        }
+    }
+
+    /// The underlying $A_C$ product engine (over $\mathbb{F}_2[\tau]$), shared so
+    /// that the Phase 2 lift can recover the $\tau$-powers this $\mathbb{F}_2$ view
+    /// discards.
+    pub fn engine(&self) -> &MotivicMilnorAlgebra {
+        &self.ac
+    }
+
+    /// The motivic weight of the `idx`-th basis element in topological degree `t`.
+    ///
+    /// $A_C/\tau$ is graded by the single degree `t`; the weight is an extra label
+    /// carried per basis element (inherited from the $A_C$ bigrading, where
+    /// reducing mod $\tau$ does not change weights).
+    pub fn weight(&self, t: i32, idx: usize) -> i32 {
+        self.ac.bidegree(t, idx).1
+    }
+}
+
+impl std::fmt::Display for CTauAlgebra {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "CTauAlgebra(A_C/τ, p=2)")
+    }
+}
+
+impl Algebra for CTauAlgebra {
+    fn prefix(&self) -> &str {
+        "motivic_ctau"
+    }
+
+    fn magic(&self) -> u32 {
+        // Distinct from the classical Milnor/Adem magics so motivic save files can
+        // never be cross-loaded.
+        0x004D_0003
+    }
+
+    fn prime(&self) -> ValidPrime {
+        TWO
+    }
+
+    fn compute_basis(&self, degree: i32) {
+        self.ac.compute_basis(degree);
+    }
+
+    fn dimension(&self, degree: i32) -> usize {
+        self.ac.dimension(degree)
+    }
+
+    fn multiply_basis_elements(
+        &self,
+        mut result: FpSliceMut,
+        coeff: u32,
+        r_degree: i32,
+        r_idx: usize,
+        s_degree: i32,
+        s_idx: usize,
+    ) {
+        let t = r_degree + s_degree;
+        let mbe = |d: i32, idx: usize| {
+            let Dual(m) = *self.ac.basis_element(d, idx);
+            MilnorBasisElement {
+                q_part: m.q_part,
+                p_part: m.p_part,
+                degree: d,
+            }
+        };
+        // $A_C/\tau \cong \mathbb{F}_2[\xi_i] \otimes E(\tau_i)$ is the odd-primary dual's
+        // shape with $2^i$ for $p^i$, so the classical product *is* this product at `p = 2`: the
+        // exterior commutation shifts by $2^k$ and the signs collapse over $\mathbb{F}_2$.
+        // `milnor_product` takes its *left* factor first, commuting the right factor's exterior
+        // part leftwards past it; the engine's `product_indexed` orders its arguments the other
+        // way. Passing `s` then `r` keeps this product equal to the engine's τ^0 part, which the
+        // cross-check below pins down.
+        milnor_product(
+            TWO,
+            mbe(s_degree, s_idx),
+            mbe(r_degree, r_idx),
+            PPartAllocation::default(),
+            |c, res| {
+                let elt = Dual(Monomial::new(res.q_part, res.p_part));
+                if let Some(idx) = self.ac.index_of(t, &elt) {
+                    result.add_basis_element(idx, coeff * c);
+                }
+            },
+        );
+    }
+
+    fn basis_element_to_string(&self, degree: i32, idx: usize) -> String {
+        self.ac.basis_element(degree, idx).to_string()
+    }
+
+    /// Parse `1`, `Q_i`, `P(R)`, or a product `Q_i … P(R)`, inverting the [`Dual<Monomial>`]
+    /// display so `.json` module descriptors can be written over $A_C/\tau$.
+    fn basis_element_from_string(&self, elt: &str) -> Option<(i32, usize)> {
+        let elt = elt.trim();
+        let (q_str, p_str) = match elt.find("P(") {
+            Some(i) => (&elt[..i], Some(&elt[i..])),
+            None => (elt, None),
+        };
+        let mut q_part = 0;
+        for tok in q_str.split_whitespace() {
+            if tok == "1" {
+                continue;
+            }
+            q_part |= 1 << tok.strip_prefix("Q_")?.parse::<u32>().ok()?;
+        }
+        let r = match p_str {
+            Some(s) => {
+                let inner = s.strip_prefix("P(")?.strip_suffix(')')?.trim();
+                if inner.is_empty() {
+                    Vec::new()
+                } else {
+                    inner
+                        .split(',')
+                        .map(|x| x.trim().parse::<u32>().ok())
+                        .collect::<Option<Vec<_>>>()?
+                }
+            }
+            None => Vec::new(),
+        };
+        let elt = Dual(Monomial::from_paper(q_part, &r)?);
+        let degree = elt.bidegree().0;
+        self.ac.compute_basis(degree);
+        Some((degree, self.ac.index_of(degree, &elt)?))
+    }
+}
+
+/// Reduce `v` (with companion coefficient vector `c`) against the echelon `rows`,
+/// clearing every leading entry that a row already pivots. On return `v` is the
+/// residual and `c` records which candidate columns were added — see
+/// [`CTauAlgebra::decompose_basis_element`].
+fn reduce_row(v: &mut FpVector, c: &mut FpVector, rows: &[(usize, FpVector, FpVector)]) {
+    while let Some((pivot, _)) = v.first_nonzero() {
+        match rows.iter().find(|(p, _, _)| *p == pivot) {
+            Some((_, row_v, row_c)) => {
+                v.add(row_v, 1);
+                c.add(row_c, 1);
+            }
+            None => break,
+        }
+    }
+}
+
+impl GeneratedAlgebra for CTauAlgebra {
+    /// The algebra generators of $A_C/\tau$ in `degree`.
+    ///
+    /// The generators of a Hopf algebra are dual to the *primitives* of its dual.
+    /// The dual $A_{**}/\tau = \mathbb{F}_2[\xi_1, \xi_2, \dots] \otimes E(\tau_0,
+    /// \tau_1, \dots)$ has primitives exactly $\xi_1^{2^k}$ (from the polynomial
+    /// part) and $\tau_0$ (the only primitive $\tau$). Dually, $A_C/\tau$ is
+    /// generated by
+    /// - $Q_0$ (dual $\tau_0$), the Bockstein, in degree $1$; and
+    /// - $P(\xi_1^{2^k})$ (dual $\xi_1^{2^k}$), the motivic $\mathrm{Sq}^{2^{k+1}}$,
+    ///   in degree $2^{k+1}$ (since $|\xi_1| = 2$) — i.e. degrees $2, 4, 8, 16,
+    ///   \dots$.
+    ///
+    /// So each degree carries at most one generator. Every other basis element is
+    /// decomposable (see [`Self::decompose_basis_element`]).
+    fn generators(&self, degree: i32) -> Vec<usize> {
+        if degree < 1 {
+            return vec![];
+        }
+        self.ac.compute_basis(degree);
+        if degree == 1 {
+            // Q_0 = Q(E)P(R) with E = {0}, R empty.
+            // Q_0 = Q(E)P(R) with E = {0}, R empty.
+            let q0 = Dual(Monomial::from_paper(1, &[]).expect("Q_0 is a valid monomial"));
+            return self.ac.index_of(1, &q0).into_iter().collect();
+        }
+        if (degree as u32).is_power_of_two() {
+            // degree = 2^{k+1}: the generator P(ξ_1^{2^k}), R = [0, 2^k].
+            let k = degree.trailing_zeros() - 1;
+            let elt = Dual(
+                Monomial::from_paper(0, &[0, 1u32 << k]).expect("P(ξ_1^{2^k}) is a valid monomial"),
+            );
+            return self.ac.index_of(degree, &elt).into_iter().collect();
+        }
+        vec![]
+    }
+
+    /// Decompose a non-generator basis element into products of generators.
+    ///
+    /// Every basis element that is not a generator is *decomposable* — a sum of
+    /// products of positive-degree elements — and expanding each factor into
+    /// generators shows it lies in the span of $\{g \cdot m\}$ where $g$ is a
+    /// generator of strictly smaller degree and $m$ is a basis element filling the
+    /// rest. So we enumerate those products (via the verified $A_C/\tau$ product),
+    /// and solve the resulting $\mathbb{F}_2$-linear system for the target by
+    /// augmented Gaussian elimination. This reuses the product engine as the source
+    /// of truth rather than re-deriving the Milnor-matrix decomposition, and is
+    /// validated by an exhaustive round-trip test (`decompose` then multiply gives
+    /// back the element).
+    fn decompose_basis_element(
+        &self,
+        degree: i32,
+        idx: usize,
+    ) -> Vec<(u32, (i32, usize), (i32, usize))> {
+        self.ac.compute_basis(degree);
+        let dim = self.dimension(degree);
+
+        // Candidate factorizations `g · m` and their product vectors in `degree`.
+        let mut cands: Vec<((i32, usize), (i32, usize))> = Vec::new();
+        let mut prods: Vec<FpVector> = Vec::new();
+        for g_deg in 1..degree {
+            let gens = self.generators(g_deg);
+            if gens.is_empty() {
+                continue;
+            }
+            let m_deg = degree - g_deg;
+            for &g_idx in &gens {
+                for m_idx in 0..self.dimension(m_deg) {
+                    let mut v = FpVector::new(TWO, dim);
+                    self.multiply_basis_elements(v.as_slice_mut(), 1, g_deg, g_idx, m_deg, m_idx);
+                    if v.is_zero() {
+                        continue;
+                    }
+                    cands.push(((g_deg, g_idx), (m_deg, m_idx)));
+                    prods.push(v);
+                }
+            }
+        }
+
+        // Augmented Gaussian elimination over F₂: reduce each product vector,
+        // tracking (in a length-`n` companion vector) which candidates combine to
+        // it, then reduce the target basis element and read off the combination.
+        let n = prods.len();
+        let mut rows: Vec<(usize, FpVector, FpVector)> = Vec::new();
+        for (i, prod) in prods.iter().enumerate() {
+            let mut v = prod.clone();
+            let mut c = FpVector::new(TWO, n);
+            c.add_basis_element(i, 1);
+            reduce_row(&mut v, &mut c, &rows);
+            if let Some((pivot, _)) = v.first_nonzero() {
+                rows.push((pivot, v, c));
+            }
+        }
+
+        let mut target = FpVector::new(TWO, dim);
+        target.add_basis_element(idx, 1);
+        let mut coeffs = FpVector::new(TWO, n);
+        reduce_row(&mut target, &mut coeffs, &rows);
+        debug_assert!(
+            target.is_zero(),
+            "A_C/τ basis element ({degree}, {idx}) is not a generator but did not decompose"
+        );
+
+        coeffs
+            .iter_nonzero()
+            .map(|(i, _)| {
+                let (g, m) = cands[i];
+                (1, g, m)
+            })
+            .collect()
+    }
+
+    /// Relations among the generators, checked to validate module descriptors.
+    ///
+    /// For each pair of generators $g_1, g_2$ with $|g_1| + |g_2| = \text{degree}$,
+    /// the product $g_1 g_2$ (computed by the engine) expands in the basis as
+    /// $\sum_k b_k$, giving the relation $g_1 g_2 + \sum_k b_k = 0$ (over
+    /// $\mathbb{F}_2$). These are the motivic analogue of the Adem relations
+    /// (products of two generators re-expressed), and generate the relation ideal;
+    /// `FiniteDimensionalModule::check_validity` applies them to reject descriptors
+    /// whose generator actions are inconsistent (e.g. $Q_0^2 \ne 0$).
+    fn generating_relations(&self, degree: i32) -> Vec<Vec<(u32, (i32, usize), (i32, usize))>> {
+        self.ac.compute_basis(degree);
+        let dim = self.dimension(degree);
+        let mut out = Vec::new();
+        for d1 in 1..degree {
+            let g1s = self.generators(d1);
+            if g1s.is_empty() {
+                continue;
+            }
+            let d2 = degree - d1;
+            let g2s = self.generators(d2);
+            for &g1 in &g1s {
+                for &g2 in &g2s {
+                    let mut prod = FpVector::new(TWO, dim);
+                    self.multiply_basis_elements(prod.as_slice_mut(), 1, d1, g1, d2, g2);
+                    let mut relation = vec![(1, (d1, g1), (d2, g2))];
+                    for (bk, _) in prod.iter_nonzero() {
+                        relation.push((1, (degree, bk), (0, 0)));
+                    }
+                    out.push(relation);
+                }
+            }
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use fp::vector::FpVector;
+
+    use super::*;
+
+    #[test]
+    fn test_ctau_dimensions_match_ac_basis() {
+        // A_C/τ has the same basis as A_C (same Milnor monomials per degree), so its
+        // F_2-dimensions are the A_C F_2[τ]-ranks. Spot-check low degrees:
+        //   t=0: 1 (unit); t=1: Q_0; t=2: P(ξ_1); t=3: Q_1, Q_0 P(ξ_1) → dim 2.
+        let alg = CTauAlgebra::new();
+        alg.compute_basis(6);
+        assert_eq!(alg.dimension(0), 1);
+        assert_eq!(alg.dimension(1), 1);
+        assert_eq!(alg.dimension(2), 1);
+        assert_eq!(alg.dimension(3), 2);
+    }
+
+    #[test]
+    fn test_ctau_weight_labels() {
+        // The weight label is the A_C bigrading's weight coordinate, carried through the
+        // mod-τ reduction unchanged. In this presentation the algebra weight is the
+        // *negative* of the dual monomial's weight (so products stay homogeneous with τ,
+        // of weight −1): Q_0 = Sq^1 has weight 0; the ξ_1-dual (t = 2) has weight −1.
+        // (The standard-sign motivic weight is recovered by a single global negation when
+        // the Phase 1 chart is compared to published data.)
+        let alg = CTauAlgebra::new();
+        alg.compute_basis(2);
+        assert_eq!(alg.weight(1, 0), alg.engine().bidegree(1, 0).1);
+        assert_eq!(alg.weight(1, 0), 0);
+        assert_eq!(alg.weight(2, 0), -1);
+    }
+
+    #[test]
+    fn test_ctau_basis_element_from_string_round_trips() {
+        // `basis_element_from_string` inverts `basis_element_to_string` on every basis
+        // element in range — so `.json` module descriptors can name motivic operations.
+        let alg = CTauAlgebra::new();
+        alg.compute_basis(12);
+        for degree in 0..=12 {
+            for idx in 0..alg.dimension(degree) {
+                let s = alg.basis_element_to_string(degree, idx);
+                assert_eq!(
+                    alg.basis_element_from_string(&s),
+                    Some((degree, idx)),
+                    "round-trip failed for {s:?} at ({degree}, {idx})"
+                );
+            }
+        }
+        // Spot-check known names, including the P(…) block with spaces.
+        assert_eq!(alg.basis_element_from_string("1"), Some((0, 0)));
+        assert_eq!(alg.basis_element_from_string("Q_0"), Some((1, 0)));
+        assert_eq!(alg.basis_element_from_string("P(0, 1)"), Some((2, 0)));
+        // Malformed input is rejected, not panicked on.
+        assert_eq!(alg.basis_element_from_string("Sq1"), None);
+        assert_eq!(alg.basis_element_from_string("Q_"), None);
+    }
+
+    #[test]
+    fn test_ctau_product_is_tau0_part_of_ac() {
+        // The defining contract, and a cross-check of two independent products: this algebra
+        // multiplies through the classical `milnor_product`, while the engine computes the same
+        // structure constants from the Kong–Lin closed form. The A_C/τ product must be exactly
+        // the τ^0 part of the engine's A_C product. Also confirm some product genuinely drops a
+        // τ-divisible term, so the reduction is doing real work.
+        use std::collections::BTreeSet;
+
+        let alg = CTauAlgebra::new();
+        alg.compute_basis(10);
+        let engine = alg.engine();
+        let mut saw_drop = false;
+        for t1 in 0..=5 {
+            for idx1 in 0..alg.dimension(t1) {
+                for t2 in 0..=(5 - t1) {
+                    for idx2 in 0..alg.dimension(t2) {
+                        let t = t1 + t2;
+                        let raw = engine.product_indexed(t1, idx1, t2, idx2);
+                        let tau_of = |i: usize| engine.tau_exponent(t1, idx1, t2, idx2, i);
+                        let expected: BTreeSet<usize> =
+                            raw.iter().copied().filter(|&i| tau_of(i) == 0).collect();
+                        saw_drop |= raw.iter().any(|&i| tau_of(i) != 0);
+
+                        let mut result = FpVector::new(TWO, alg.dimension(t));
+                        alg.multiply_basis_elements(result.as_slice_mut(), 1, t1, idx1, t2, idx2);
+                        let got: BTreeSet<usize> = result.iter_nonzero().map(|(i, _)| i).collect();
+                        assert_eq!(
+                            got, expected,
+                            "mod-τ product ≠ τ^0 part at ({t1},{idx1})·({t2},{idx2})"
+                        );
+                    }
+                }
+            }
+        }
+        assert!(saw_drop, "no product in range dropped a τ-divisible term");
+    }
+
+    #[test]
+    fn test_ctau_generators_are_q0_and_p_of_xi1_powers() {
+        // The generators are Q_0 (degree 1) and P(ξ_1^{2^k}) (degrees 2, 4, 8, 16),
+        // dual to the primitives ξ_1^{2^k} and τ_0 of A_**/τ. Every other degree has
+        // none — in particular Q_1 (degree 3) and ξ_2-dual P(0, 1) (degree 6) are
+        // decomposable, not generators.
+        let alg = CTauAlgebra::new();
+        alg.compute_basis(16);
+
+        let name_of = |deg: i32, gens: &[usize]| -> Vec<String> {
+            gens.iter()
+                .map(|&i| alg.basis_element_to_string(deg, i))
+                .collect()
+        };
+        assert_eq!(name_of(1, &alg.generators(1)), vec!["Q_0"]);
+        assert_eq!(name_of(2, &alg.generators(2)), vec!["P(0, 1)"]);
+        assert_eq!(name_of(4, &alg.generators(4)), vec!["P(0, 2)"]);
+        assert_eq!(name_of(8, &alg.generators(8)), vec!["P(0, 4)"]);
+        assert_eq!(name_of(16, &alg.generators(16)), vec!["P(0, 8)"]);
+
+        for degree in [3, 5, 6, 7, 9, 10, 12] {
+            assert!(
+                alg.generators(degree).is_empty(),
+                "degree {degree} should have no generators"
+            );
+        }
+    }
+
+    #[test]
+    fn test_ctau_decompose_round_trips() {
+        // The contract for `decompose_basis_element`: every non-generator basis
+        // element, multiplied back out from its decomposition, returns itself — and
+        // every factor has strictly smaller degree. This validates the generic
+        // Gaussian-solve decomposition against the independently-verified product
+        // engine, over the whole basis in a range.
+        let alg = CTauAlgebra::new();
+        alg.compute_basis(16);
+        for degree in 1..=16 {
+            let gens = alg.generators(degree);
+            for idx in 0..alg.dimension(degree) {
+                if gens.contains(&idx) {
+                    continue;
+                }
+                let decomp = alg.decompose_basis_element(degree, idx);
+                assert!(
+                    !decomp.is_empty(),
+                    "no decomposition for ({degree}, {idx}) = {}",
+                    alg.basis_element_to_string(degree, idx)
+                );
+                let mut sum = FpVector::new(TWO, alg.dimension(degree));
+                for (coef, (d1, i1), (d2, i2)) in decomp {
+                    assert!(
+                        d1 > 0 && d1 < degree && d2 > 0 && d2 < degree,
+                        "factor of ({degree}, {idx}) is not strictly smaller: \
+                         ({d1},{i1})·({d2},{i2})"
+                    );
+                    alg.multiply_basis_elements(sum.as_slice_mut(), coef, d1, i1, d2, i2);
+                }
+                let mut want = FpVector::new(TWO, alg.dimension(degree));
+                want.add_basis_element(idx, 1);
+                assert_eq!(
+                    sum,
+                    want,
+                    "decomposition of ({degree}, {idx}) = {} does not reassemble",
+                    alg.basis_element_to_string(degree, idx)
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_ctau_generating_relations_encode_products() {
+        // Each relation is `g1·g2 + Σ b_k = 0`, a true algebra identity: multiplying
+        // it back out is zero. The degree-2 relation is just Q_0² = 0 (empty tail).
+        let alg = CTauAlgebra::new();
+        alg.compute_basis(8);
+
+        let q0 = alg.basis_element_from_string("Q_0").unwrap();
+        let rels2 = alg.generating_relations(2);
+        assert!(
+            rels2.iter().any(|r| r.len() == 1 && r[0] == (1, q0, q0)),
+            "expected the Q_0^2 = 0 relation, got {rels2:?}"
+        );
+
+        for degree in 2..=8 {
+            for relation in alg.generating_relations(degree) {
+                let mut sum = FpVector::new(TWO, alg.dimension(degree));
+                for (coef, (d1, i1), (d2, i2)) in relation {
+                    alg.multiply_basis_elements(sum.as_slice_mut(), coef, d1, i1, d2, i2);
+                }
+                assert!(
+                    sum.is_zero(),
+                    "generating relation in degree {degree} is not zero in the algebra"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_ctau_unit_acts_trivially() {
+        // 1 · x = x for the unit in degree 0.
+        let alg = CTauAlgebra::new();
+        alg.compute_basis(3);
+        for t in 0..=3 {
+            for idx in 0..alg.dimension(t) {
+                let mut result = FpVector::new(TWO, alg.dimension(t));
+                alg.multiply_basis_elements(result.as_slice_mut(), 1, 0, 0, t, idx);
+                let mut expected = FpVector::new(TWO, alg.dimension(t));
+                expected.add_basis_element(idx, 1);
+                assert_eq!(
+                    result, expected,
+                    "unit did not act as identity on ({t}, {idx})"
+                );
+            }
+        }
+    }
+}

--- a/ext/crates/algebra/src/algebra/motivic/mod.rs
+++ b/ext/crates/algebra/src/algebra/motivic/mod.rs
@@ -1,4 +1,7 @@
-//! The C-motivic prime 2 Steenrod algebra.
+//! The C-motivic prime 2 Steenrod algebra and its mod-$\tau$ reduction.
 
 pub mod milnor;
 pub use milnor::MotivicMilnorAlgebra;
+
+pub mod ctau;
+pub use ctau::CTauAlgebra;

--- a/ext/examples/chart_motivic.rs
+++ b/ext/examples/chart_motivic.rs
@@ -1,0 +1,145 @@
+//! Render the deformation (algebraic Novikov / τ-Bockstein) spectral sequence of
+//! $A_C/\tau$ as an $(n, s)$ Adams chart, in SVG on stdout.
+//!
+//! The deformation SS is trigraded — stem $n$, Adams filtration $s$, motivic
+//! weight $w$ — so it cannot go through the bigraded `Sseq::write_to_graph`.
+//! Instead we project onto the $(n, s)$ plane: a node at $(n, s)$ stacks the
+//! classes of every weight there, and the τ-Bockstein differentials
+//! $d_r\colon (n, s, w) \to (n{+}1, s{-}1, w{+}r)$ are drawn between the projected
+//! nodes.
+//!
+//! At page `1` the nodes are $E_1 = \Ext_{A_C/\tau}$ (the algebraic Novikov $E_2$,
+//! equivalently the Adams $E_2$ of $C\tau$) and the structlines are $d_1 = \delta$.
+//! Inverting $\tau$ ($w \to \infty$) leaves $E_\infty = $ the classical Adams
+//! $E_2$; the finite-page deaths are the motivic τ-torsion. Ask for a larger page
+//! to watch the SS converge.
+//!
+//! Prompts for `Max n`, `Max s`, and the `Page` to draw (defaulting to 30 / 17 / 1).
+
+use std::collections::BTreeMap;
+
+use ext::motivic::{Deformation, MotivicResolution};
+use sseq::{
+    SseqProfile,
+    charting::{Backend, SvgBackend},
+    coordinates::{Bidegree, BidegreeGenerator, degree::MultiDegree},
+};
+
+fn main() -> anyhow::Result<()> {
+    ext::utils::init_logging()?;
+
+    let max = Bidegree::n_s(
+        query::with_default("Max n", "30", str::parse),
+        query::with_default("Max s", "17", str::parse),
+    );
+    let page: i32 = query::with_default("Page", "1", str::parse);
+
+    let res = MotivicResolution::new(max);
+    let sseq = res.deformation_sseq();
+
+    // The reported box: stems `0..=max.n()`, filtrations `0..=max.s()-1` (the top
+    // filtration needs the lift one degree higher, so it is not reported).
+    let max_n = res.max().n();
+    let max_s = res.max().s() - 1;
+    let in_box = |n: i32, s: i32| (0..=max_n).contains(&n) && (0..=max_s).contains(&s);
+
+    // Group the degrees of the reported box by (n, s), collecting the weights
+    // present at each — sorted, so the stacking order (and hence the per-weight
+    // offset within a projected node) is deterministic.
+    let mut weights_at: BTreeMap<(i32, i32), Vec<i32>> = BTreeMap::new();
+    for b in sseq.iter_degrees() {
+        let [n, s, w] = b.coords();
+        if in_box(n, s) && sseq.page_data(b).get_max(page).dimension() > 0 {
+            weights_at.entry((n, s)).or_default().push(w);
+        }
+    }
+    for ws in weights_at.values_mut() {
+        ws.sort_unstable();
+    }
+
+    // The Page-`page` dimension of the (n, s, w) slice. The deformation SS is
+    // sparse — an (n, s, w) with no classes was never registered, and `page_data`
+    // panics on an unregistered degree — so an undefined slice is dimension 0.
+    let dim_at = |n: i32, s: i32, w: i32| {
+        let deg = MultiDegree::from([n, s, w]);
+        if sseq.defined(deg) {
+            sseq.page_data(deg).get_max(page).dimension()
+        } else {
+            0
+        }
+    };
+
+    // Flat index of the weight-`w` block within the projected (n, s) node: the
+    // total dimension of all lighter weights present there.
+    let offset_at = |n: i32, s: i32, w: i32| -> usize {
+        weights_at
+            .get(&(n, s))
+            .into_iter()
+            .flatten()
+            .take_while(|&&ww| ww < w)
+            .map(|&ww| dim_at(n, s, ww))
+            .sum()
+    };
+
+    let mut backend = SvgBackend::new(std::io::stdout());
+    backend.init(Bidegree::n_s(max_n, max_s))?;
+
+    // Draw every node first: get_coords (used by structlines) panics unless the
+    // node was registered.
+    for (&(n, s), ws) in &weights_at {
+        let total: usize = ws.iter().map(|&w| dim_at(n, s, w)).sum();
+        backend.node(Bidegree::n_s(n, s), total)?;
+    }
+
+    // Then the page-`page` τ-Bockstein differentials, projected onto (n, s).
+    for b in sseq.iter_degrees() {
+        let [n, s, w] = b.coords();
+        if !in_box(n, s) {
+            continue;
+        }
+        let target = Deformation::profile(page, b);
+        let [tn, ts, tw] = target.coords();
+        if !in_box(tn, ts) {
+            continue;
+        }
+        // `target` cleared the (n, s) *range* check, but the SS is sparse: an
+        // in-range slice with no classes was never registered, and
+        // `page_data`/`differentials` panic on an unregistered degree. A d_page out
+        // of `b` can only land where classes exist, so an unregistered target
+        // carries no structlines — skip it.
+        if !sseq.defined(target) {
+            continue;
+        }
+
+        let diffs = sseq.differentials(b);
+        if page < diffs.min_degree() || page >= diffs.len() {
+            continue;
+        }
+        let source_data = sseq.page_data(b).get_max(page);
+        let target_data = sseq.page_data(target).get_max(page);
+        let off_src = offset_at(n, s, w);
+        let off_tgt = offset_at(tn, ts, tw);
+
+        for (mut src, mut tgt) in diffs[page].get_source_target_pairs() {
+            let src = source_data.reduce(src.as_slice_mut());
+            let tgt = target_data.reduce(tgt.as_slice_mut());
+            for (i, &sv) in src.iter().enumerate() {
+                if sv == 0 {
+                    continue;
+                }
+                for (j, &tv) in tgt.iter().enumerate() {
+                    if tv == 0 {
+                        continue;
+                    }
+                    backend.structline(
+                        BidegreeGenerator::new(Bidegree::n_s(n, s), off_src + i),
+                        BidegreeGenerator::new(Bidegree::n_s(tn, ts), off_tgt + j),
+                        Some(&format!("d{page}")),
+                    )?;
+                }
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/ext/examples/resolve_motivic_ctau.rs
+++ b/ext/examples/resolve_motivic_ctau.rs
@@ -1,0 +1,61 @@
+//! Resolve $A_C/\tau$ over $\mathbb{F}_2$ — the algebraic Novikov $E_2$.
+//!
+//! $A_C/\tau$ is the mod-$\tau$ reduction of the C-motivic Steenrod algebra (over
+//! $\mathbb{C}$, $p = 2$): a connected, finite-type $\mathbb{F}_2$-algebra, and an
+//! ordinary [`algebra::Algebra`] ([`CTauAlgebra`]). We resolve
+//! the trivial module $\mathbb{F}_2$ over it with the **unmodified** production
+//! resolution engine; the generator counts in $\mathrm{Ext}^{s,t}_{A_C/\tau}$ are
+//! the **algebraic Novikov $E_2$** ranks, equivalently the motivic Adams $E_2$ of
+//! $C\tau$ (Gheorghe–Wang–Xu).
+//!
+//! This is Phase 1 of `MOTIVIC_PLAN.md`: the first end-to-end motivic numbers,
+//! carrying essentially zero engine risk (nothing about the engine is motivic —
+//! it just resolves over an $\mathbb{F}_2$-algebra it has never seen), and it
+//! validates the $A_C/\tau$ algebra structure before the harder $\tau$-lift.
+//!
+//! Run with e.g. `cargo run --example resolve_motivic_ctau` (reads `Max n` / `Max
+//! s`, defaulting to 30 / 15).
+
+use std::sync::Arc;
+
+use algebra::{CTauAlgebra, module::FDModule};
+use bivec::BiVec;
+use ext::{
+    chain_complex::{ChainComplex, FiniteChainComplex, FreeChainComplex},
+    resolution::Resolution,
+};
+use sseq::coordinates::Bidegree;
+
+fn main() -> anyhow::Result<()> {
+    ext::utils::init_logging()?;
+
+    let max = Bidegree::n_s(
+        query::with_default("Max n", "30", str::parse),
+        query::with_default("Max s", "15", str::parse),
+    );
+
+    // The trivial module F_2, concentrated in degree 0 (one generator, no
+    // positive-degree action), over A_C/τ.
+    let algebra = Arc::new(CTauAlgebra::new());
+    let trivial = Arc::new(FDModule::new(
+        algebra,
+        "F2".to_string(),
+        BiVec::from_vec(0, vec![1]),
+    ));
+    let cc: Arc<FiniteChainComplex<FDModule<CTauAlgebra>>> =
+        Arc::new(FiniteChainComplex::ccdz(trivial));
+
+    let res = Resolution::new(cc);
+    res.compute_through_stem(max);
+
+    println!("{}", res.graded_dimension_string());
+    println!("n,s,num_gens");
+    for b in res.iter_stem() {
+        let num = res.number_of_gens_in_bidegree(b);
+        if num > 0 {
+            println!("{},{},{}", b.n(), b.s(), num);
+        }
+    }
+
+    Ok(())
+}

--- a/ext/examples/resolve_motivic_ctau.rs
+++ b/ext/examples/resolve_motivic_ctau.rs
@@ -2,7 +2,7 @@
 //!
 //! $A_C/\tau$ is the mod-$\tau$ reduction of the C-motivic Steenrod algebra (over
 //! $\mathbb{C}$, $p = 2$): a connected, finite-type $\mathbb{F}_2$-algebra, and an
-//! ordinary [`algebra::Algebra`] ([`CTauAlgebra`]). We resolve
+//! ordinary [`algebra::Algebra`] (`CTauAlgebra`). We resolve
 //! the trivial module $\mathbb{F}_2$ over it with the **unmodified** production
 //! resolution engine; the generator counts in $\mathrm{Ext}^{s,t}_{A_C/\tau}$ are
 //! the **algebraic Novikov $E_2$** ranks, equivalently the motivic Adams $E_2$ of
@@ -18,10 +18,9 @@
 
 use std::sync::Arc;
 
-use algebra::{CTauAlgebra, module::FDModule};
-use bivec::BiVec;
 use ext::{
     chain_complex::{ChainComplex, FiniteChainComplex, FreeChainComplex},
+    motivic::{CTauResolution, MotivicResolution},
     resolution::Resolution,
 };
 use sseq::coordinates::Bidegree;
@@ -36,16 +35,9 @@ fn main() -> anyhow::Result<()> {
 
     // The trivial module F_2, concentrated in degree 0 (one generator, no
     // positive-degree action), over A_C/τ.
-    let algebra = Arc::new(CTauAlgebra::new());
-    let trivial = Arc::new(FDModule::new(
-        algebra,
-        "F2".to_string(),
-        BiVec::from_vec(0, vec![1]),
-    ));
-    let cc: Arc<FiniteChainComplex<FDModule<CTauAlgebra>>> =
-        Arc::new(FiniteChainComplex::ccdz(trivial));
+    let cc = Arc::new(FiniteChainComplex::ccdz(MotivicResolution::trivial_module()));
 
-    let res = Resolution::new(cc);
+    let res: CTauResolution = Resolution::new(cc);
     res.compute_through_stem(max);
 
     println!("{}", res.graded_dimension_string());

--- a/ext/src/lib.rs
+++ b/ext/src/lib.rs
@@ -180,6 +180,7 @@ use algebra::module::SteenrodModule;
 use crate::chain_complex::FiniteChainComplex;
 pub type CCC = FiniteChainComplex<SteenrodModule>;
 
+pub mod motivic;
 pub mod nassau;
 pub mod secondary;
 pub mod utils;

--- a/ext/src/motivic/deformation.rs
+++ b/ext/src/motivic/deformation.rs
@@ -1,0 +1,265 @@
+//! The deformation (algebraic Novikov / τ-Bockstein) spectral sequence: assemble
+//! the trigraded [`Sseq`] whose $E_1 = \mathrm{Ext}_{A_C/\tau}$ and whose $d_r$ are
+//! the τ-Bockstein differentials read off the lifted δ. Inverting τ gives the
+//! classical Adams $E_2$ ([`MotivicResolution::classical_ext_rank`]); the
+//! finite-page deaths are the motivic τ-torsion.
+
+use std::collections::HashMap;
+
+use fp::{prime::TWO, vector::FpVector};
+use sseq::{
+    Sseq, SseqProfile,
+    coordinates::{degree::MultiDegree, element::MultiDegreeElement},
+};
+
+use super::{Gen, MotivicResolution};
+
+/// The direction of the **deformation spectral sequence** (the algebraic Novikov
+/// / $\tau$-Bockstein SS), trigraded by (stem $n$, Adams filtration $s$, weight
+/// $w$). Each $d_r$ carries δ's fixed $(n, s) \mapsto (n+1, s-1)$ shift — δ lowers
+/// Novikov filtration at fixed internal degree, so the stem rises — and jumps the
+/// weight by $r$ (the $\tau$-power). $E_1 = \Ext_{A_C/\tau}$; inverting $\tau$
+/// ($w \to \infty$) gives $E_\infty = $ classical $\Ext_A$, and finite-page deaths
+/// are the motivic $\tau$-torsion.
+pub struct Deformation;
+
+impl SseqProfile<3> for Deformation {
+    const MIN_R: i32 = 1;
+
+    fn profile(r: i32, b: MultiDegree<3>) -> MultiDegree<3> {
+        b + MultiDegree::from([1, -1, r])
+    }
+
+    fn profile_inverse(r: i32, b: MultiDegree<3>) -> MultiDegree<3> {
+        b + MultiDegree::from([-1, 1, -r])
+    }
+
+    fn differential_length(offset: MultiDegree<3>) -> i32 {
+        offset.coords()[2] // the weight component
+    }
+}
+
+impl MotivicResolution {
+    /// Group generators by their multidegree `(n, s, w)`. Returns the per-multidegree
+    /// generator-index lists (a generator's position in its list is its Sseq
+    /// coordinate) and the reverse map `Gen ↦ (multidegree, position)`.
+    fn sseq_grouping(
+        &self,
+    ) -> (
+        HashMap<[i32; 3], Vec<usize>>,
+        HashMap<Gen, (MultiDegree<3>, usize)>,
+    ) {
+        let mut groups: HashMap<[i32; 3], Vec<usize>> = HashMap::new();
+        let mut pos: HashMap<Gen, (MultiDegree<3>, usize)> = HashMap::new();
+        for s in 0..=self.max_s() {
+            let t_max = self.compute.n() + s;
+            for t in 0..=t_max {
+                for idx in 0..self.num_gens(s, t) {
+                    let g = Gen { s, t, idx };
+                    if let Some(&w) = self.weights.get(&g) {
+                        let key = [t - s, s, w];
+                        let list = groups.entry(key).or_default();
+                        pos.insert(g, (MultiDegree::from(key), list.len()));
+                        list.push(idx);
+                    }
+                }
+            }
+        }
+        (groups, pos)
+    }
+
+    /// The deformation spectral sequence as an [`Sseq`], trigraded by $(n, s, w)$
+    /// ([`Deformation`]). $E_1 = \Ext_{A_C/\tau}$ — the mod-τ generators, grouped
+    /// by weight — with $d_1$ the **weight-1 part of δ** (the induced differential
+    /// on the associated graded, read directly off [`delta`](Self::delta)).
+    /// [`Sseq::update`] then computes $E_2 = H(d_1)$, whose [`page_data`] are the
+    /// `Subquotient`s.
+    ///
+    /// The higher $d_r$ are then computed by the **τ-Bockstein zig-zag** on the full
+    /// $\mathbb{F}_2[\tau]$-linear δ (`slice`/`inject`/`apply_delta` below), pushing
+    /// $\delta(\tilde x)$ up in weight one order at a time — each correction solved by
+    /// $d_1$'s stored quasi-inverse — and reading the weight-$(w+r)$ part, until a
+    /// page adds nothing ($E_\infty$). The products (via [`Sseq::multiply`]) build on
+    /// this.
+    ///
+    /// [`page_data`]: Sseq::page_data
+    pub fn deformation_sseq(&self) -> &Sseq<3, Deformation> {
+        self.deformation
+            .get_or_init(|| self.build_deformation_sseq())
+    }
+
+    #[tracing::instrument(
+        skip(self),
+        fields(max = %self.max, top_page = tracing::field::Empty, num_higher_diffs = tracing::field::Empty)
+    )]
+    fn build_deformation_sseq(&self) -> Sseq<3, Deformation> {
+        let mut sseq = Sseq::<3, Deformation>::new(TWO);
+
+        // Group generators by (n, s, w) — a generator's position within its group
+        // is its coordinate in that multidegree.
+        let (groups, pos) = self.sseq_grouping();
+        for (&key, list) in &groups {
+            sseq.set_dimension(MultiDegree::from(key), list.len());
+        }
+
+        // d₁ = the weight-1 part of δ; a generator with δ = ∅ is a permanent cycle.
+        for (&g, &(deg, p)) in &pos {
+            let mut source = FpVector::new(TWO, sseq.dimension(deg));
+            source.set_entry(p, 1);
+            // s = 0 is the unit: no differential (δ is only defined for s ≥ 1).
+            if g.s == 0 {
+                sseq.add_permanent_class(&MultiDegreeElement::new(deg, source));
+                continue;
+            }
+            let d = self.delta(g);
+            if d.is_empty() {
+                sseq.add_permanent_class(&MultiDegreeElement::new(deg, source));
+                continue;
+            }
+            // d₁ = the weight-1 part of δ. A δ with no weight-1 term makes g a
+            // d₁-cycle (its leading δ term is higher order); it is left to the
+            // τ-Bockstein zig-zag below. Checking this before sizing `target` also
+            // avoids `sseq.dimension(profile(1, deg))` on an empty d₁-target degree:
+            // that degree need not carry any generators (e.g. at the top-stem edge of
+            // the box), and `Sseq::dimension` panics on a degree that was never
+            // `set_dimension`'d. A weight-1 term, by contrast, points to a generator
+            // *at* that degree, so its presence guarantees the degree is populated.
+            if !d.iter().any(|&(_, power)| power == 1) {
+                continue;
+            }
+            let target_deg = Deformation::profile(1, deg);
+            let mut target = FpVector::new(TWO, sseq.dimension(target_deg));
+            for (gj, power) in d {
+                if power == 1 {
+                    target.set_entry(pos[&gj].1, 1);
+                }
+            }
+            sseq.add_differential(1, &MultiDegreeElement::new(deg, source), target.as_slice());
+        }
+        sseq.update();
+
+        // Higher d_r by the τ-Bockstein zig-zag on the full δ. `apply_delta`
+        // evaluates δ on a raw cochain over the generators at (s, t); `slice`
+        // extracts a fixed-weight part into (n,s,w)-group coordinates; `inject` adds
+        // a group-coordinate vector back into a raw cochain.
+        let apply_delta = |xtilde: &FpVector, s: i32, t: i32| -> FpVector {
+            let mut dvec = FpVector::new(TWO, self.num_gens(s - 1, t));
+            for (gi, _) in xtilde.iter_nonzero() {
+                for (gj, _power) in self.delta(Gen { s, t, idx: gi }) {
+                    dvec.add_basis_element(gj.idx, 1);
+                }
+            }
+            dvec
+        };
+        let slice = |dvec: &FpVector, key: [i32; 3]| -> FpVector {
+            let g = groups.get(&key).map(Vec::as_slice).unwrap_or(&[]);
+            let mut y = FpVector::new(TWO, g.len());
+            for (p, &gi) in g.iter().enumerate() {
+                if dvec.entry(gi) != 0 {
+                    y.set_entry(p, 1);
+                }
+            }
+            y
+        };
+        let inject = |xtilde: &mut FpVector, key: [i32; 3], gv: &FpVector| {
+            if let Some(g) = groups.get(&key) {
+                for (p, _) in gv.iter_nonzero() {
+                    xtilde.add_basis_element(g[p], 1);
+                }
+            }
+        };
+
+        let degrees: Vec<MultiDegree<3>> = sseq.iter_degrees().collect();
+        let mut r = 2;
+        let mut num_higher_diffs = 0usize;
+        loop {
+            let mut to_add: Vec<(MultiDegree<3>, FpVector, FpVector)> = Vec::new();
+            for &b in &degrees {
+                let [n, s, w] = b.coords();
+                // Only report-box sources: their δ-targets (stem n+1 ≤ compute.n())
+                // are resolved, and every differential touching a report degree has
+                // a report-box source, so the report E_∞ is unaffected. Margin
+                // sources would reach stem max.n+2 (unresolved).
+                if s < 1 || n > self.max.n() {
+                    continue;
+                }
+                let page = sseq.page_data(b);
+                if page.len() <= r {
+                    continue;
+                }
+                let t = n + s;
+                for rep in page[r].gens() {
+                    // x̃ = the E_r representative, lifted to a raw cochain over (s, t).
+                    let mut xtilde = FpVector::new(TWO, self.num_gens(s, t));
+                    if let Some(g) = groups.get(&[n, s, w]) {
+                        for (p, _) in rep.iter_nonzero() {
+                            xtilde.add_basis_element(g[p], 1);
+                        }
+                    }
+                    // Push δ(x̃) up in weight, correcting each intermediate order.
+                    let mut ok = true;
+                    for k in 1..r {
+                        let y = slice(&apply_delta(&xtilde, s, t), [n + 1, s - 1, w + k]);
+                        if y.is_zero() {
+                            continue;
+                        }
+                        let src = MultiDegree::from([n, s, w + k - 1]);
+                        if !sseq.defined(src) || sseq.differentials(src).len() <= 1 {
+                            ok = false; // no d₁ to invert (should not happen for a genuine cycle)
+                            break;
+                        }
+                        let mut c = FpVector::new(TWO, sseq.dimension(src));
+                        sseq.differentials(src)[1].quasi_inverse(c.as_slice_mut(), y.as_slice());
+                        inject(&mut xtilde, [n, s, w + k - 1], &c);
+                    }
+                    if !ok {
+                        continue;
+                    }
+                    let target = slice(&apply_delta(&xtilde, s, t), [n + 1, s - 1, w + r]);
+                    if !target.is_zero() {
+                        to_add.push((b, rep.to_owned(), target));
+                    }
+                }
+            }
+            let mut added = false;
+            for (b, source, target) in to_add {
+                if sseq.add_differential(r, &MultiDegreeElement::new(b, source), target.as_slice())
+                {
+                    added = true;
+                    num_higher_diffs += 1;
+                }
+            }
+            sseq.update();
+            if !added {
+                break;
+            }
+            r += 1;
+        }
+        let span = tracing::Span::current();
+        span.record("top_page", r);
+        span.record("num_higher_diffs", num_higher_diffs);
+
+        sseq
+    }
+
+    /// The classical Adams $E_2$ rank at `(s, t)` — invert $\tau$: the free rank of
+    /// the motivic $E_2$.
+    ///
+    /// Read off the deformation SS: the $E_\infty$ survivors at `(n, s)` summed over
+    /// weight. Inverting $\tau$ ($w \to \infty$) is exactly the classical Adams
+    /// $E_2$; the τ-torsion classes die on finite pages and drop out.
+    pub fn classical_ext_rank(&self, s: i32, t: i32) -> usize {
+        let n = t - s;
+        let sseq = self.deformation_sseq();
+        sseq.iter_degrees()
+            .filter(|d| {
+                let c = d.coords();
+                c[0] == n && c[1] == s
+            })
+            .map(|d| {
+                let page = sseq.page_data(d);
+                page[page.len() - 1].dimension() // E_∞ at (n, s, w)
+            })
+            .sum()
+    }
+}

--- a/ext/src/motivic/mod.rs
+++ b/ext/src/motivic/mod.rs
@@ -205,7 +205,8 @@ impl MotivicResolution {
         // So `+1` is provably sufficient; `MOT_MARGIN` is only an escape hatch.
         let margin: i32 = std::env::var("MOT_MARGIN")
             .ok()
-            .and_then(|v| v.parse().ok())
+            .and_then(|v| v.parse::<i32>().ok())
+            .map(|m| m.max(1))
             .unwrap_or(1);
         let compute = Bidegree::n_s(max.n() + margin, max.s());
         tracing::Span::current().record("compute", tracing::field::display(compute));
@@ -463,7 +464,20 @@ impl MotivicResolution {
     fn compute_weights(&mut self) {
         // Built locally, then `Arc`-shared into `self.weights` (and the Ext DGA) — no copy.
         let mut weights: HashMap<Gen, i32> = HashMap::new();
-        // s = 0: the single generator is the unit, weight 0.
+        // s = 0: the single generator is the unit, weight 0. Only the generator at
+        // `t = 0` is seeded, so a module needing another one — anything not cyclic on a
+        // degree-0 class — has no weight to propagate from. Reject it here rather than
+        // let an unseeded generator surface as a `HashMap` index panic much later.
+        for t in 0..=self.compute.n() {
+            let expected = usize::from(t == 0);
+            assert_eq!(
+                self.num_gens(0, t),
+                expected,
+                "the motivic lift supports modules cyclic on a degree-0 class; this one needs {} \
+                 generator(s) at (s = 0, t = {t})",
+                self.num_gens(0, t),
+            );
+        }
         weights.insert(Gen { s: 0, t: 0, idx: 0 }, 0);
 
         for s in 1..=self.max_s() {
@@ -529,7 +543,13 @@ impl MotivicResolution {
                     t: og.generator_degree,
                     idx: og.generator_index,
                 };
-                let power = (self.weights[&gj] - w_k) as u32;
+                let diff = self.weights[&gj] - w_k;
+                let power = u32::try_from(diff).unwrap_or_else(|_| {
+                    panic!(
+                        "δ must raise the weight, got τ-power {diff} at (s={}, t={})",
+                        g.s, g.t
+                    )
+                });
                 out.push((gj, power));
             }
         }

--- a/ext/src/motivic/mod.rs
+++ b/ext/src/motivic/mod.rs
@@ -46,8 +46,7 @@
 //! fall out:
 //!
 //! - **invert $\tau$** — the free rank (all generators): the classical Adams $E_2$
-//!   (`classical_ext_rank`, regressed against `Ext_A`; lands with the deformation
-//!   spectral sequence).
+//!   ([`MotivicResolution::classical_ext_rank`], regressed against `Ext_A`).
 //! - **$\tau = 0$** — the generator counts: the algebraic Novikov $E_2$ (Phase 1).
 //! - **keep $\tau$** — free plus $\tau$-torsion: the motivic $E_2$ as a full
 //!   $\mathbb{F}_2[\tau]$-module (`tau_module`, structure
@@ -57,7 +56,7 @@
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap},
     path::PathBuf,
-    sync::Arc,
+    sync::{Arc, OnceLock},
 };
 
 use algebra::{
@@ -68,14 +67,17 @@ use algebra::{
 use bivec::BiVec;
 use fp::{prime::TWO, vector::FpVector};
 use maybe_rayon::prelude::*;
-use sseq::coordinates::Bidegree;
+use sseq::{Sseq, coordinates::Bidegree};
 
 use crate::{
     chain_complex::{ChainComplex, FiniteChainComplex},
     resolution::Resolution,
 };
 
+mod deformation;
 mod persist;
+
+pub use deformation::Deformation;
 
 /// The $A_C/\tau$ resolution type: the trivial module resolved by the ordinary
 /// engine over the mod-$\tau$ Steenrod algebra.
@@ -95,6 +97,10 @@ pub struct Gen {
 pub struct MotivicResolution {
     algebra: Arc<CTauAlgebra>,
     resolution: Arc<CTauResolution>,
+    /// The deformation (algebraic Novikov / τ-Bockstein) spectral sequence, built
+    /// lazily — the source of truth for the free rank and τ-torsion. See
+    /// [`Self::deformation_sseq`].
+    deformation: OnceLock<Sseq<3, Deformation>>,
     /// Motivic weight of each generator. `Arc`-shared with the Ext DGA's
     /// the Ext DGA's coboundary (which slices by it) rather than copied.
     weights: Arc<HashMap<Gen, i32>>,
@@ -220,6 +226,7 @@ impl MotivicResolution {
         let mut this = Self {
             algebra,
             resolution,
+            deformation: OnceLock::new(),
             weights: Arc::new(HashMap::new()),
             lifted: HashMap::new(),
             max,
@@ -792,8 +799,76 @@ impl TauLift for DifferentialCells<'_> {
 
 #[cfg(test)]
 mod tests {
+    use sseq::coordinates::degree::MultiDegree;
 
     use super::*;
+
+    #[test]
+    fn deformation_sseq_foundation() {
+        // The deformation SS stored as an Sseq: E₁ = Ext_{A_C/τ} trigraded by
+        // (n,s,w), d₁ = the weight-1 part of δ.
+        let res = MotivicResolution::new(Bidegree::n_s(8, 5));
+        let sseq = res.deformation_sseq();
+
+        // E₁ grouping: summing the weight slices at (n,s) recovers the algebraic
+        // Novikov rank (the mod-τ generator count).
+        let mut totals: HashMap<(i32, i32), usize> = HashMap::new();
+        for deg in sseq.iter_degrees() {
+            let [n, s, _] = deg.coords();
+            *totals.entry((n, s)).or_default() += sseq.dimension(deg);
+        }
+        for (&(n, s), &total) in &totals {
+            if (0..=8).contains(&n) && (0..=5).contains(&s) {
+                assert_eq!(
+                    total,
+                    res.algebraic_novikov_rank(s, n + s),
+                    "E₁ weight slices at (n={n}, s={s}) should sum to the generator count"
+                );
+            }
+        }
+
+        // h₀ ∈ (n=0, s=1, w=0): δ(h₀) = ∅, so it is a permanent cycle.
+        let h0 = MultiDegree::from([0, 1, 0]);
+        assert_eq!(sseq.get_dimension(h0), Some(1), "h₀ is 1-dimensional");
+        assert_eq!(
+            sseq.permanent_classes(h0).dimension(),
+            1,
+            "h₀ (δ = ∅) should be a permanent cycle"
+        );
+
+        // Every d₁ we added is consistent.
+        for deg in sseq.iter_degrees() {
+            assert!(
+                !sseq.inconsistent(deg),
+                "inconsistent differential at {deg}"
+            );
+        }
+    }
+
+    #[test]
+    fn resolves_a_nontrivial_module_moore_space() {
+        // Resolve S/2 (cofiber of 2 = h₀): cells x₀, x₁ joined by Q₀ = Sq¹. The whole
+        // deformation pipeline runs on a non-trivial module, and because 2 = h₀ is
+        // coned off, the h₀-tower on the bottom cell is truncated — the sphere has
+        // h₀ⁿ ≠ 0 at (0, n) for all n, but S/2 has only the bottom class.
+        // Build S/2 from a .json descriptor (exercising module_from_json /
+        // basis_element_from_string over the motivic Steenrod algebra).
+        let descriptor = serde_json::json!({
+            "gens": { "x0": 0, "x1": 1 },
+            "actions": ["Q_0 x0 = x1"],
+        });
+        let module = MotivicResolution::module_from_json(&descriptor).unwrap();
+        let sphere = MotivicResolution::new(Bidegree::n_s(8, 6));
+        let moore = MotivicResolution::with_module(module, Bidegree::n_s(8, 6), None);
+
+        // The bottom class survives on both.
+        assert_eq!(moore.classical_ext_rank(0, 0), 1, "S/2 bottom cell");
+        // The h₀-tower (stem 0, filtration ≥ 1): present on the sphere, gone on S/2.
+        for s in 1..=4 {
+            assert_eq!(sphere.classical_ext_rank(s, s), 1, "sphere h₀^{s}");
+            assert_eq!(moore.classical_ext_rank(s, s), 0, "S/2 kills h₀^{s}");
+        }
+    }
 
     #[test]
     fn module_descriptor_auto_extends_composite_operations() {
@@ -903,5 +978,37 @@ mod tests {
             delta_entries > 0,
             "the lift produced no δ (augmentation) terms"
         );
+    }
+
+    #[test]
+    fn anchor_invert_tau_is_classical_adams_e2() {
+        // Anchor 1: inverting τ (the free rank of H(δ), all generators) reproduces
+        // the classical Adams E₂ — Ext over the mod-2 Steenrod algebra. We resolve
+        // the classical sphere in-process and compare rank-for-rank. This is where
+        // the τ-torsion (e.g. the h₁-tower classes beyond h₁⁴) is *killed*: the
+        // motivic algebraic-Novikov extras collapse back onto classical Ext.
+        use crate::{chain_complex::FreeChainComplex, utils::construct_standard};
+
+        let max = Bidegree::n_s(8, 5);
+        let res = MotivicResolution::new(max);
+
+        let classical = construct_standard::<false, _, _>("S_2", None).unwrap();
+        classical.compute_through_stem(max);
+
+        // classical_ext_rank(s, t) needs the lift at s+1, so s ≤ max_s − 1.
+        for s in 0..res.max_s() {
+            for t in s..=(max.n() + s) {
+                let n = t - s;
+                if n > max.n() {
+                    continue;
+                }
+                let got = res.classical_ext_rank(s, t);
+                let want = classical.number_of_gens_in_bidegree(Bidegree::n_s(n, s));
+                assert_eq!(
+                    got, want,
+                    "invert-τ mismatch at (n={n}, s={s}): H(δ) free rank {got} ≠ classical {want}"
+                );
+            }
+        }
     }
 }

--- a/ext/src/motivic/mod.rs
+++ b/ext/src/motivic/mod.rs
@@ -1,0 +1,887 @@
+//! The C-motivic Adams $E_2$ by deformation: lift the $A_C/\tau$ resolution to
+//! $A_C$ over $\mathbb{F}_2[\tau]$.
+//!
+//! Phase 1 ([`crate`]'s `resolve_motivic_ctau` example) resolves the trivial
+//! module over $A_C/\tau$ with the ordinary engine. That resolution is *minimal
+//! mod $\tau$*: its differentials $\bar d_s$ have entries in the augmentation
+//! ideal (positive-degree operations). This module performs Phase 2 of
+//! `MOTIVIC_PLAN.md`: it lifts $\bar d_s$ to honest differentials $d_s$ over
+//! $A_C$ (coefficients in $\mathbb{F}_2[\tau]$) with $d_{s-1} d_s = 0$, reducing
+//! to $\bar d_s$ mod $\tau$.
+//!
+//! # Weights and the valuation representation
+//!
+//! $A_C/\tau$ is bigraded by (stem $t$, motivic weight $w$), but we present it to
+//! the engine graded by $t$ alone (it is connected and finite-type there). The
+//! minimal resolution nonetheless comes out **weight-homogeneous**: every
+//! generator has a well-defined weight, computed here by descending the
+//! differential ([`MotivicResolution::generator_weight`]). Homogeneity forces the
+//! $\tau$-power of every differential entry — a term $m \otimes g_j$ (operation
+//! $m$, target generator $g_j$) in $d_s(g_k)$ carries exactly
+//! $\tau^{\,w(g_k) - w(m) - w(g_j)}$ — so a lifted differential is an
+//! $\mathbb{F}_2$ support (which basis elements occur) plus the weights, with the
+//! $\tau$-powers reconstructed on demand. This is the one-integer-per-entry
+//! valuation representation of the plan.
+//!
+//! # The lift
+//!
+//! Initialize $d_s = \bar d_s$ (each mod-$\tau$ operation at $\tau^0$). Over
+//! $A_C$ the composite $d_{s-1} d_s$ is $\equiv 0 \bmod \tau$ (its $\tau^0$ part
+//! is $\bar d_{s-1}\bar d_s = 0$) but not exactly $0$: the $A_C$ products
+//! $m \cdot m'$ generate $\tau$-divisible terms. That remainder is a
+//! $\bar d_{s-2}$-cycle, so the quasi-inverse of $\bar d_{s-1}$ (already computed
+//! by the engine) yields a $\tau$-power correction to $d_s$ that cancels the
+//! lowest-order remainder; iterating to bounded $\tau$-order gives $d_{s-1}d_s=0$.
+//! (Guozhen Wang's Adams–Novikov lift, module side; see `MOTIVIC_PLAN.md` §5.)
+//!
+//! # The cohomology $H(\delta)$ — the motivic Adams $E_2$
+//!
+//! The lift creates $\delta$, the identity-operation (augmentation) part of the
+//! differential ([`MotivicResolution::delta`]): a differential on the free
+//! $\mathbb{F}_2[\tau]$-modules of generators at fixed internal degree $t$. The
+//! motivic Adams $E_2$ is `Ext_{A_C} = H(δ)`, a graded $\mathbb{F}_2[\tau]$-module
+//! — free $\oplus\ \mathbb{F}_2[\tau]/\tau^k$, since $\tau$ is the only homogeneous
+//! prime. Because $\delta$ raises the weight, `{weight ≤ cap}` is a subcomplex and
+//! the whole computation is pure $\mathbb{F}_2$ linear algebra. The three anchors
+//! fall out:
+//!
+//! - **invert $\tau$** — the free rank (all generators): the classical Adams $E_2$
+//!   (`classical_ext_rank`, regressed against `Ext_A`; lands with the deformation
+//!   spectral sequence).
+//! - **$\tau = 0$** — the generator counts: the algebraic Novikov $E_2$ (Phase 1).
+//! - **keep $\tau$** — free plus $\tau$-torsion: the motivic $E_2$ as a full
+//!   $\mathbb{F}_2[\tau]$-module (`tau_module`, structure
+//!   theorem), including the $h_1$-tower classes ($h_1^n$, which are
+//!   $\mathbb{F}_2[\tau]/\tau$-torsion for $n \ge 4$) that the classical page kills.
+
+use std::{
+    collections::{BTreeMap, BTreeSet, HashMap},
+    path::PathBuf,
+    sync::Arc,
+};
+
+use algebra::{
+    Algebra, CTauAlgebra,
+    module::{FDModule, FreeModule, Module, homomorphism::ModuleHomomorphism},
+    motivic::MotivicMilnorAlgebra,
+};
+use bivec::BiVec;
+use fp::{prime::TWO, vector::FpVector};
+use maybe_rayon::prelude::*;
+use sseq::coordinates::Bidegree;
+
+use crate::{
+    chain_complex::{ChainComplex, FiniteChainComplex},
+    resolution::Resolution,
+};
+
+mod persist;
+
+/// The $A_C/\tau$ resolution type: the trivial module resolved by the ordinary
+/// engine over the mod-$\tau$ Steenrod algebra.
+pub type CTauResolution = Resolution<FiniteChainComplex<FDModule<CTauAlgebra>>>;
+
+/// A generator of the resolution, identified by homological degree `s`, internal
+/// degree `t`, and index within that `(s, t)` bidegree.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Gen {
+    pub s: i32,
+    pub t: i32,
+    pub idx: usize,
+}
+
+/// The C-motivic resolution: the mod-$\tau$ model plus the weight assignment and
+/// (Phase 2) the lifted $A_C$ differentials.
+pub struct MotivicResolution {
+    algebra: Arc<CTauAlgebra>,
+    resolution: Arc<CTauResolution>,
+    /// Motivic weight of each generator. `Arc`-shared with the Ext DGA's
+    /// the Ext DGA's coboundary (which slices by it) rather than copied.
+    weights: Arc<HashMap<Gen, i32>>,
+    /// The lifted $A_C$ differential of each generator: the set of $F_{s-1}$ basis
+    /// elements in its image. The coefficient of each is $1 \in \mathbb{F}_2$ and
+    /// its $\tau$-power is forced by the weights, so the support is the whole
+    /// datum (see the module docs).
+    lifted: HashMap<Gen, BTreeSet<usize>>,
+    /// The box the results are trusted/reported in.
+    max: Bidegree,
+    /// The (padded) square actually resolved: `{stem ≤ compute.n(), filt ≤
+    /// compute.s()}`. It is the report box `max` with a small stem margin for the
+    /// lift's δ-reach (see [`Self::new`]).
+    compute: Bidegree,
+}
+
+impl MotivicResolution {
+    /// Resolve the trivial module $k$ over $A_C/\tau$ (the sphere) through the box
+    /// `max`, in memory. Shorthand for [`Self::with_module`] on `k` with no save
+    /// directory.
+    pub fn new(max: Bidegree) -> Self {
+        Self::with_module(Self::trivial_module(), max, None)
+    }
+
+    /// Build a module over $A_C/\tau$ from a `.json` descriptor — the standard module
+    /// format (`gens` naming cells by degree, `actions` naming operations as the
+    /// motivic Steenrod algebra prints them: `Q_i`, `P(R)`, or products `Q_i … P(R)`)
+    /// — ready for [`Self::with_module`]. For example, the Moore space $S/2$ is
+    /// ```json
+    /// { "gens": { "x0": 0, "x1": 1 }, "actions": ["Q_0 x0 = x1"] }
+    /// ```
+    ///
+    /// This is exactly the classical [`FDModule::from_json`] path, made available by
+    /// the [`GeneratedAlgebra`](algebra::GeneratedAlgebra) implementation of
+    /// $A_C/\tau$: only the actions of the *generators* ($Q_0$ and the $P(\xi_1^{2^k})
+    /// = \mathrm{Sq}^{2^{k+1}}$) need be listed, and the action of every composite
+    /// operation is extended from them and cross-checked against the Steenrod
+    /// relations. Inconsistent descriptors are rejected.
+    pub fn module_from_json(
+        json: &serde_json::Value,
+    ) -> anyhow::Result<Arc<FDModule<CTauAlgebra>>> {
+        let algebra = Arc::new(CTauAlgebra::new());
+        // Size the algebra to the top cell so operation names and composite-action
+        // extension resolve; `from_json` drives the rest.
+        let max_d = json["gens"]
+            .as_object()
+            .into_iter()
+            .flat_map(|g| g.values())
+            .filter_map(serde_json::Value::as_i64)
+            .max()
+            .unwrap_or(0);
+        algebra.compute_basis(max_d.max(0) as i32);
+        Ok(Arc::new(FDModule::from_json(algebra, json)?))
+    }
+
+    /// The trivial module $k = \mathbb{F}_2$ (concentrated in degree 0) over
+    /// $A_C/\tau$: the module whose resolution is the sphere.
+    pub fn trivial_module() -> Arc<FDModule<CTauAlgebra>> {
+        let algebra = Arc::new(CTauAlgebra::new());
+        Arc::new(FDModule::new(
+            algebra,
+            "F2".to_string(),
+            BiVec::from_vec(0, vec![1]),
+        ))
+    }
+
+    /// Resolve `module` over $A_C/\tau$ through the box `max`, lift to $A_C$, and
+    /// assign weights, optionally caching to `save_dir` on disk.
+    ///
+    /// If `save_dir` is set, the mod-τ resolution is saved/loaded there (via
+    /// [`Resolution::new_with_save`]) and the weights + lifted differentials are
+    /// cached alongside it (`motivic-lift.bin`), so re-running the same box reloads
+    /// the whole computation instead of recomputing the resolution and the lift.
+    ///
+    /// The generators of `module` must be weight-homogeneous, seeded by
+    /// `compute_weights` from the s=0 cells; the trivial module needs no
+    /// input (its one cell is the weight-0 unit).
+    #[tracing::instrument(
+        skip(module, save_dir),
+        fields(max = %max, compute = tracing::field::Empty, cached = tracing::field::Empty)
+    )]
+    pub fn with_module(
+        module: Arc<FDModule<CTauAlgebra>>,
+        max: Bidegree,
+        save_dir: Option<PathBuf>,
+    ) -> Self {
+        let algebra = module.algebra();
+        let cc: Arc<FiniteChainComplex<FDModule<CTauAlgebra>>> =
+            Arc::new(FiniteChainComplex::ccdz(module));
+        let resolution = Arc::new(
+            Resolution::new_with_save(cc, save_dir.clone())
+                .expect("failed to open the resolution save directory"),
+        );
+        // Resolve the report box **plus exactly one stem** with
+        // `compute_through_stem`. Ext at `(s, t)` is `H(δ)`, and δ maps `(s, t) →
+        // (s-1, t)` — same internal degree, one lower Novikov filtration, hence
+        // stem `n → n+1`. So computing Ext at stem `n` needs the δ *out of* stem
+        // `n`, whose targets are the generators at stem `n+1`; those must exist
+        // (`delta_star_rank` reads `num_gens` there). That is the whole margin: a
+        // hard, structural `+1`, not a fudge.
+        //
+        // Nothing at stem `n+2` is needed, and `compute_through_stem` gives the
+        // `n+1` strip cheaply: at its edge it records only *kernels* one stem out
+        // (`resolution.rs`), never resolving generators there. The lift of the
+        // stem-`(n+1)` boundary generators therefore can't emit δ-terms into
+        // stem `n+2` (those generators don't exist), and such a term would land in
+        // internal degree `> n+s` anyway — invisible to every stem-`n` composite.
+        // So `+1` is provably sufficient; `MOT_MARGIN` is only an escape hatch.
+        let margin: i32 = std::env::var("MOT_MARGIN")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(1);
+        let compute = Bidegree::n_s(max.n() + margin, max.s());
+        tracing::Span::current().record("compute", tracing::field::display(compute));
+        let profile = std::env::var("MOT_PROFILE").is_ok();
+        let t0 = std::time::Instant::now();
+        resolution.compute_through_stem(compute);
+        if profile {
+            eprintln!("[profile] resolution: {:?}", t0.elapsed());
+        }
+
+        let mut this = Self {
+            algebra,
+            resolution,
+            weights: Arc::new(HashMap::new()),
+            lifted: HashMap::new(),
+            max,
+            compute,
+        };
+        // Load the weights + lifted differentials from disk if a matching cache
+        // exists; otherwise compute them and save.
+        let cached = this.load_lift(&save_dir);
+        tracing::Span::current().record("cached", cached);
+        if cached {
+            if profile {
+                eprintln!("[profile] lift:       loaded from disk");
+            }
+        } else {
+            let t1 = std::time::Instant::now();
+            this.compute_weights();
+            if profile {
+                eprintln!("[profile] weights:    {:?}", t1.elapsed());
+            }
+            let t2 = std::time::Instant::now();
+            this.lift();
+            if profile {
+                eprintln!("[profile] lift:       {:?}", t2.elapsed());
+            }
+            this.save_lift(&save_dir);
+        }
+        this
+    }
+
+    /// The mod-$\tau$ resolution (the Phase 1 model).
+    pub fn resolution(&self) -> &CTauResolution {
+        &self.resolution
+    }
+
+    /// The box results are reported/trusted in.
+    pub fn max(&self) -> Bidegree {
+        self.max
+    }
+
+    /// The algebraic Novikov $E_2$ rank at `(s, t)` — set $\tau = 0$: the number
+    /// of generators (with $\delta \equiv 0 \bmod \tau$, `Ext = generators`).
+    pub fn algebraic_novikov_rank(&self, s: i32, t: i32) -> usize {
+        self.num_gens(s, t)
+    }
+
+    /// The maximum homological degree computed.
+    fn max_s(&self) -> i32 {
+        self.max.s()
+    }
+
+    /// The free module $F_s$.
+    fn module(&self, s: i32) -> Arc<FreeModule<CTauAlgebra>> {
+        self.resolution.module(s)
+    }
+
+    /// The motivic weight of a generator (panics if out of the computed range or
+    /// if the generator's weight could not be determined).
+    pub fn generator_weight(&self, g: Gen) -> i32 {
+        self.weights[&g]
+    }
+
+    /// The number of generators in bidegree `(s, t)`.
+    fn num_gens(&self, s: i32, t: i32) -> usize {
+        self.module(s).number_of_gens_in_degree(t)
+    }
+
+    /// The weight of an $F_s$ basis element `bidx` in degree `t`: decode it into
+    /// `operation ⊗ generator` and add the operation's weight to the generator's.
+    fn entry_weight(&self, s: i32, t: i32, bidx: usize) -> i32 {
+        let module = self.module(s);
+        let og = module.index_to_op_gen(t, bidx);
+        let op_w = self.algebra.weight(og.operation_degree, og.operation_index);
+        let gen_w = self.weights[&Gen {
+            s,
+            t: og.generator_degree,
+            idx: og.generator_index,
+        }];
+        op_w + gen_w
+    }
+
+    /// Lift every differential to $A_C$. Processed with `s` ascending so that
+    /// `d_{s-1}` is finalized before `d_s` is corrected against it.
+    ///
+    /// `d_1` needs no correction: `d_0 d_1 = 0` already, since `d_0` is the
+    /// augmentation into the trivial module and `d_1`'s entries lie in the
+    /// augmentation ideal. For `s ≥ 2` we start from the mod-$\tau$ support and
+    /// cancel the $\tau$-divisible remainder of `d_{s-1} d_s`.
+    #[tracing::instrument(skip(self), fields(max = %self.max, num_lifted = tracing::field::Empty))]
+    fn lift(&mut self) {
+        // Wavefront over `s`: correcting a generator reads only its `s-1`
+        // neighbors (the mod-τ targets at stem ≤ n and the δ-targets at stem
+        // n+1), and runs its own weight-loop locally. So `s` is a sequential
+        // barrier, but at each `s` every generator is independent — fan them out.
+        for s in 1..=self.max_s() {
+            let t_max = self.compute.n() + s;
+            let gens: Vec<Gen> = (0..=t_max)
+                .flat_map(|t| (0..self.num_gens(s, t)).map(move |idx| Gen { s, t, idx }))
+                .collect();
+            let _span = tracing::info_span!("lift_s", s, num_gens = gens.len()).entered();
+            let lifted: Vec<(Gen, BTreeSet<usize>)> = gens
+                .into_maybe_par_iter()
+                .map(|g| (g, self.lift_generator(g)))
+                .collect();
+            self.lifted.extend(lifted);
+        }
+        tracing::Span::current().record("num_lifted", self.lifted.len());
+    }
+
+    /// Lift a single generator's differential to `A_C`. Parallel-safe: it reads
+    /// only already-finalized `s-1` data (and the shared, thread-safe product
+    /// cache), writing nothing.
+    ///
+    /// The correction is the [`TauLift`] driver applied to the differential cell
+    /// (via [`DifferentialCells`]); it runs only for generators whose δ-correction
+    /// cone stays inside the padded box. The cone of a generator at stem `n` reaches
+    /// up to stem `n + s` (each augmentation correction pushes one stem out), so a
+    /// generator with stem `> report.n + report.s` cannot converge — and it is never
+    /// referenced by the report cohomology (differentials go to stem ≤ n, δ-terms to
+    /// n+1, and the report cone is bounded by report.n + report.s). Leaving those as
+    /// their mod-τ support is correct.
+    fn lift_generator(&self, g: Gen) -> BTreeSet<usize> {
+        let cells = DifferentialCells(self);
+        let stem = g.t - g.s;
+        let in_cone = stem <= self.max.n() + self.max.s();
+        if g.s >= 2 && in_cone && self.weights.contains_key(&g) {
+            cells.lift_cell(g)
+        } else {
+            cells.seed(g)
+        }
+    }
+
+    /// XOR the contribution of a single `d_s(g_k)` support element `bidx` (a basis
+    /// element of $F_{s-1}$ in degree `t`) into a running `d_{s-1} d_s` parity
+    /// vector over the $F_{s-2}$ basis in degree `t`.
+    ///
+    /// `composite` is mod-2 linear in the support and each output basis element's
+    /// $\tau$-power is a function of that element alone (weight-homogeneity), so
+    /// this per-term atom is all both [`Self::composite`] and the incremental
+    /// the correction step needs: toggling a term in or out of the support is exactly
+    /// one call here (XOR is its own inverse).
+    #[allow(clippy::too_many_arguments)]
+    fn accumulate_term(
+        &self,
+        s: i32,
+        t: i32,
+        f_sm1: &FreeModule<CTauAlgebra>,
+        f_sm2: &FreeModule<CTauAlgebra>,
+        _engine: &MotivicMilnorAlgebra,
+        bidx: usize,
+        parity: &mut FpVector,
+    ) {
+        // The differential's own composite: compose with `d = self.lifted`
+        // (degree-preserving, so inner_shift_t = 0).
+        self.compose_into(f_sm1, t, s - 1, &self.lifted, 0, f_sm2, bidx, parity);
+    }
+
+    /// The shared atom of every τ-adic lift: compose the outer basis element `bidx`
+    /// of `outer_mod` (internal degree `outer_t`, generators at homological degree
+    /// `outer_s`) with the lifted map `inner` (whose value on a generator lives in
+    /// `inner_out_mod`), XORing the resulting $A_C$ products into `parity`.
+    ///
+    /// `bidx` decodes to `m ⊗ gⱼ`; `inner[gⱼ]` to `m′ ⊗ gₗ`; the term contributed is
+    /// `(m·m′) ⊗ gₗ` (all $\tau$-powers of the $A_C$ product `m·m′`, since the
+    /// forced power of each output basis element is fixed by weight-homogeneity and
+    /// recovered later). For the differential `inner = d` (`self.lifted`); for a
+    /// product chain map `inner = φₐ`. A generator absent from `inner` contributes 0.
+    #[allow(clippy::too_many_arguments)]
+    fn compose_into(
+        &self,
+        outer_mod: &FreeModule<CTauAlgebra>,
+        outer_t: i32,
+        outer_s: i32,
+        inner: &HashMap<Gen, BTreeSet<usize>>,
+        inner_shift_t: i32,
+        inner_out_mod: &FreeModule<CTauAlgebra>,
+        bidx: usize,
+        parity: &mut FpVector,
+    ) {
+        let engine = self.algebra.engine();
+        let og = outer_mod.index_to_op_gen(outer_t, bidx);
+        let (m_deg, m_idx) = (og.operation_degree, og.operation_index);
+        let gj = Gen {
+            s: outer_s,
+            t: og.generator_degree,
+            idx: og.generator_index,
+        };
+        let Some(gj_inner) = inner.get(&gj) else {
+            return; // inner map is zero on gⱼ (e.g. outside φₐ's range) ⇒ no term
+        };
+        // `inner[gⱼ]` lives at degree `gⱼ.t − inner_shift_t` (0 for the
+        // degree-preserving differential, aₜ for the chain map φₐ).
+        let inner_t = gj.t - inner_shift_t;
+        for &bidx2 in gj_inner {
+            let og2 = inner_out_mod.index_to_op_gen(inner_t, bidx2);
+            let (mp_deg, mp_idx) = (og2.operation_degree, og2.operation_index);
+            let (gl_deg, gl_idx) = (og2.generator_degree, og2.generator_index);
+            let z_deg = m_deg + mp_deg;
+            engine.product_indexed_with(m_deg, m_idx, mp_deg, mp_idx, |terms| {
+                for &z_idx in terms {
+                    let fidx =
+                        inner_out_mod.operation_generator_to_index(z_deg, z_idx, gl_deg, gl_idx);
+                    parity.add_basis_element(fidx, 1); // XOR at p = 2
+                }
+            });
+        }
+    }
+
+    /// The composite `d_{s-1} d_s(g_k)` over `A_C`, as a map from $F_{s-2}$ basis
+    /// element (in degree `g_k.t`) to its forced $\tau$-power. Only odd-parity
+    /// (surviving) terms are returned. The `A_C` products `m · m'` are where the
+    /// $\tau$-divisible terms are generated.
+    fn composite(&self, g_k: Gen, support: &BTreeSet<usize>) -> BTreeMap<usize, i32> {
+        let s = g_k.s;
+        let t = g_k.t;
+        let w_k = self.weights[&g_k];
+        let f_sm1 = self.module(s - 1);
+        let f_sm2 = self.module(s - 2);
+        let engine = self.algebra.engine();
+
+        let mut parity = FpVector::new(TWO, f_sm2.dimension(t));
+        for &bidx in support {
+            self.accumulate_term(s, t, &f_sm1, &f_sm2, engine, bidx, &mut parity);
+        }
+
+        parity
+            .iter_nonzero()
+            .map(|(fidx, _)| {
+                // Every path to `fidx` has the same τ-power = W(fidx) − W(g_k)
+                // (weight-homogeneity), so the parity above is well-defined.
+                let power = self.entry_weight(s - 2, t, fidx) - w_k;
+                (fidx, power)
+            })
+            .collect()
+    }
+
+    /// Assign a motivic weight to every generator by descending its differential:
+    /// weight-homogeneity forces `w(g) = w(m) + w(g')` for every term `m ⊗ g'` of
+    /// `d(g)`. The unit generator has weight 0; higher weights propagate. Panics
+    /// if any generator turns out weight-inhomogeneous (which would violate the
+    /// bigraded structure and break the valuation representation).
+    #[tracing::instrument(skip(self), fields(num_weights = tracing::field::Empty))]
+    fn compute_weights(&mut self) {
+        // Built locally, then `Arc`-shared into `self.weights` (and the Ext DGA) — no copy.
+        let mut weights: HashMap<Gen, i32> = HashMap::new();
+        // s = 0: the single generator is the unit, weight 0.
+        weights.insert(Gen { s: 0, t: 0, idx: 0 }, 0);
+
+        for s in 1..=self.max_s() {
+            let d = self.resolution.differential(s);
+            let target = self.module(s - 1);
+            let t_max = self.compute.n() + s;
+            for t in 0..=t_max {
+                for idx in 0..self.num_gens(s, t) {
+                    let out = d.output(t, idx);
+                    let mut weight: Option<i32> = None;
+                    for (bidx, v) in out.iter_nonzero() {
+                        if v == 0 {
+                            continue;
+                        }
+                        let og = target.index_to_op_gen(t, bidx);
+                        let op_w = self.algebra.weight(og.operation_degree, og.operation_index);
+                        let tgt = Gen {
+                            s: s - 1,
+                            t: og.generator_degree,
+                            idx: og.generator_index,
+                        };
+                        let Some(&tgt_w) = weights.get(&tgt) else {
+                            continue;
+                        };
+                        let w = op_w + tgt_w;
+                        match weight {
+                            None => weight = Some(w),
+                            Some(w0) => assert_eq!(
+                                w0, w,
+                                "weight-inhomogeneous generator at (s={s}, t={t}, idx={idx})"
+                            ),
+                        }
+                    }
+                    if let Some(w) = weight {
+                        weights.insert(Gen { s, t, idx }, w);
+                    }
+                }
+            }
+        }
+        tracing::Span::current().record("num_weights", weights.len());
+        self.weights = Arc::new(weights);
+    }
+
+    /// The $\delta$-entries out of generator `g`: the identity-operation
+    /// (augmentation) part of the lifted differential `d_s(g)`. Each entry is a
+    /// target generator `g'` (at the same internal degree `t`, homological degree
+    /// `s-1`) together with the $\tau$-power on the unit operation.
+    ///
+    /// This is the datum Phase 3 takes cohomology of: `δ` is a differential on the
+    /// free $\mathbb{F}_2[\tau]$-modules of generators, and `Ext_{A_C} = H(δ)`
+    /// (the motivic Adams $E_2$). Over a field the augmentation part of a minimal
+    /// differential vanishes; here the $\tau$-power corrections create it.
+    pub fn delta(&self, g: Gen) -> Vec<(Gen, u32)> {
+        let module = self.module(g.s - 1);
+        let w_k = self.weights[&g];
+        let mut out = Vec::new();
+        for &bidx in &self.lifted[&g] {
+            let og = module.index_to_op_gen(g.t, bidx);
+            // The identity operation is the unit: degree 0, index 0.
+            if og.operation_degree == 0 {
+                let gj = Gen {
+                    s: g.s - 1,
+                    t: og.generator_degree,
+                    idx: og.generator_index,
+                };
+                let power = (self.weights[&gj] - w_k) as u32;
+                out.push((gj, power));
+            }
+        }
+        out
+    }
+
+    // ---- Phase 3: the cohomology H(δ) = the motivic Adams E₂ ----
+    //
+    // δ is a differential on the free F₂[τ]-modules of generators (fixed internal
+    // degree `t`), with δ↓: gens(s,t) → gens(s−1,t) given by [`delta`]. Because
+    // everything is weight-graded and τ is the only homogeneous prime, `Ext = H(δ)`
+    // is a graded F₂[τ]-module: free ⊕ F₂[τ]/τᵏ. δ↓ raises the weight, so
+    // `{weight ≤ cap}` is a subcomplex — and taking that cohomology (free rank at
+    // cap = ∞, torsion exposed at lower caps) is now the job of the [`ExtAlgebra`]
+    // built by [`Self::build_ext`], via [`MotivicCoboundary`] as its differential.
+
+    /// The mod-$\tau$ support of `d_s(g)`: the lifted terms whose forced
+    /// $\tau$-power is $0$. These should reproduce the engine's $\bar d_s$ exactly.
+    fn mod_tau_support(&self, g: Gen) -> BTreeSet<usize> {
+        let w = self.weights[&g];
+        self.lifted[&g]
+            .iter()
+            .copied()
+            .filter(|&bidx| w - self.entry_weight(g.s - 1, g.t, bidx) == 0)
+            .collect()
+    }
+
+    /// Verify `d_{s-1} d_s = 0` over `A_C` for every generator in range: the
+    /// defining property of the lifted resolution.
+    pub fn verify_d_squared_zero(&self) {
+        for s in 2..=self.max_s() {
+            for t in 0..=(self.max.n() + s) {
+                for idx in 0..self.num_gens(s, t) {
+                    let g = Gen { s, t, idx };
+                    let err = self.composite(g, &self.lifted[&g]);
+                    assert!(
+                        err.is_empty(),
+                        "d² ≠ 0 at (s={s}, t={t}, idx={idx}): {} surviving terms",
+                        err.len()
+                    );
+                }
+            }
+        }
+    }
+
+    /// Verify that reducing every lifted differential mod $\tau$ recovers the
+    /// original mod-$\tau$ resolution the engine computed.
+    pub fn verify_mod_tau_reduction(&self) {
+        for s in 1..=self.max_s() {
+            for t in 0..=(self.max.n() + s) {
+                for idx in 0..self.num_gens(s, t) {
+                    let g = Gen { s, t, idx };
+                    let engine_support: BTreeSet<usize> = self
+                        .resolution
+                        .differential(s)
+                        .output(t, idx)
+                        .iter_nonzero()
+                        .filter(|(_, v)| *v != 0)
+                        .map(|(i, _)| i)
+                        .collect();
+                    assert_eq!(
+                        self.mod_tau_support(g),
+                        engine_support,
+                        "mod-τ reduction differs from the model at (s={s}, t={t}, idx={idx})"
+                    );
+                }
+            }
+        }
+    }
+}
+
+/// The shared τ-adic lifting problem, in the style of [`crate::secondary::SecondaryLift`].
+///
+/// Every "make it motivic" step in this module has the same shape: a map given over
+/// the mod-τ algebra $A_C/\tau$ must be lifted to an honest map over $A_C$
+/// (coefficients in $\mathbb{F}_2[\tau]$). The lift starts from the mod-τ datum (the
+/// $\tau^0$ part) and cancels the τ-divisible *defect* — the amount by which the
+/// defining equation fails over $A_C$ — one weight-order at a time, solving each
+/// order with the quasi-inverse of the target complex's mod-τ differential.
+/// Weight-homogeneity forces every correction to a single τ-power, so the
+/// order-by-order cancellation converges.
+///
+/// The differential lift ($d^2 = 0$, [`DifferentialCells`]) is the first instance;
+/// the product lift ($d\varphi = \varphi d$) and — eventually — the chain-homotopy
+/// lift (Massey products) are the same driver with a different *defect*. An
+/// implementor supplies the object-specific hooks and inherits [`Self::lift_cell`].
+trait TauLift {
+    /// The weight the defect is graded against — the source generator's weight.
+    fn source_weight(&self, g: Gen) -> i32;
+
+    /// The mod-τ ($\tau^0$) support to start from, as basis-element indices of the
+    /// output module (where the lifted support and the corrections live).
+    fn seed(&self, g: Gen) -> BTreeSet<usize>;
+
+    /// The defect module `(module, t)` — where the error `e` lives — used to size
+    /// the running parity vector.
+    fn defect_module(&self, g: Gen) -> (Arc<FreeModule<CTauAlgebra>>, i32);
+
+    /// The weight of defect-module basis element `bidx`.
+    fn defect_weight(&self, g: Gen, bidx: usize) -> i32;
+
+    /// Seed the running defect with the part that does not depend on the output
+    /// support (e.g. the `φ(dg)` term of a chain map). Default: none — the
+    /// differential's `d²` is entirely a function of its support.
+    fn seed_constant(&self, _g: Gen, _parity: &mut FpVector) {}
+
+    /// XOR into `parity` the defect contribution of output-support element `bidx`.
+    fn accumulate(&self, g: Gen, bidx: usize, parity: &mut FpVector);
+
+    /// Solve `d̄(c) = e` for a correction `c` in the output module, via the target's
+    /// mod-τ quasi-inverse. `None` when the quasi-inverse is unavailable (a cell just
+    /// past the padded box) — the driver then leaves the mod-τ seed uncorrected.
+    fn solve(&self, g: Gen, e: &FpVector) -> Option<FpVector>;
+
+    /// The shared driver: cancel the τ-divisible defect one weight-order at a time.
+    /// Returns the lifted support — the seed if there is nothing to correct, or a
+    /// partial lift if a cell outside the report cone does not converge (those are
+    /// never read by the report cohomology).
+    fn lift_cell(&self, g: Gen) -> BTreeSet<usize> {
+        let (def_mod, def_t) = self.defect_module(g);
+        let def_dim = def_mod.dimension(def_t);
+        let w_k = self.source_weight(g);
+
+        // Maintain the defect incrementally: it is mod-2 linear in the support, so we
+        // keep a running parity vector and XOR in only each term we toggle.
+        let mut support = self.seed(g);
+        let mut parity = FpVector::new(TWO, def_dim);
+        self.seed_constant(g, &mut parity);
+        for &bidx in support.iter() {
+            self.accumulate(g, bidx, &mut parity);
+        }
+
+        for _ in 0..256 {
+            // The lowest τ-order among the surviving error terms.
+            let Some(min_power) = parity
+                .iter_nonzero()
+                .map(|(fidx, _)| self.defect_weight(g, fidx) - w_k)
+                .min()
+            else {
+                return support; // defect fully cancelled
+            };
+            assert!(
+                min_power >= 1,
+                "mod-τ defect ≠ 0 at (s={}, t={}, idx={}) — the model is not a complex",
+                g.s,
+                g.t,
+                g.idx
+            );
+
+            // The error at that lowest τ-order, as a defect-module vector.
+            let mut e = FpVector::new(TWO, def_dim);
+            for (fidx, _) in parity.iter_nonzero() {
+                if self.defect_weight(g, fidx) - w_k == min_power {
+                    e.set_entry(fidx, 1);
+                }
+            }
+
+            // Solve d̄(c) = e and toggle c into the support, updating the running
+            // parity in lockstep. Each correction term is forced (by weight) to
+            // τ-power min_power, cancelling this order.
+            let Some(c) = self.solve(g, &e) else {
+                return support; // out of range: leave the partial lift
+            };
+            for (idx, v) in c.iter_nonzero() {
+                if v == 0 {
+                    continue;
+                }
+                if !support.insert(idx) {
+                    support.remove(&idx);
+                }
+                self.accumulate(g, idx, &mut parity);
+            }
+        }
+        // Non-convergence within the cap: only outside the report cone (report-cone
+        // cells converge). Never read by the report cohomology, so leave the partial.
+        tracing::debug!(
+            "motivic lift did not converge at (s={}, t={}, idx={}); leaving partial (outside \
+             report cone)",
+            g.s,
+            g.t,
+            g.idx
+        );
+        support
+    }
+}
+
+/// The differential-lift instance of [`TauLift`]: lift `d_s(g)` so that
+/// `d_{s-1} d_s(g) = 0` over `A_C`. Output module `F_{s-1}`, defect module
+/// `F_{s-2}`, defect the composite `d_{s-1} d_s(g)` (accumulated by
+/// [`MotivicResolution::accumulate_term`]); `d̄_{s-1}`'s quasi-inverse solves the
+/// corrections.
+struct DifferentialCells<'a>(&'a MotivicResolution);
+
+impl TauLift for DifferentialCells<'_> {
+    fn source_weight(&self, g: Gen) -> i32 {
+        self.0.weights[&g]
+    }
+
+    fn seed(&self, g: Gen) -> BTreeSet<usize> {
+        self.0
+            .resolution
+            .differential(g.s)
+            .output(g.t, g.idx)
+            .iter_nonzero()
+            .filter(|(_, v)| *v != 0)
+            .map(|(i, _)| i)
+            .collect()
+    }
+
+    fn defect_module(&self, g: Gen) -> (Arc<FreeModule<CTauAlgebra>>, i32) {
+        (self.0.module(g.s - 2), g.t)
+    }
+
+    fn defect_weight(&self, g: Gen, bidx: usize) -> i32 {
+        self.0.entry_weight(g.s - 2, g.t, bidx)
+    }
+
+    fn accumulate(&self, g: Gen, bidx: usize, parity: &mut FpVector) {
+        let f_sm1 = self.0.module(g.s - 1);
+        let f_sm2 = self.0.module(g.s - 2);
+        self.0.accumulate_term(
+            g.s,
+            g.t,
+            &f_sm1,
+            &f_sm2,
+            self.0.algebra.engine(),
+            bidx,
+            parity,
+        );
+    }
+
+    fn solve(&self, g: Gen, e: &FpVector) -> Option<FpVector> {
+        let d_prev = self.0.resolution.differential(g.s - 1);
+        let qi = d_prev.quasi_inverse(g.t)?;
+        let mut c = FpVector::new(TWO, self.0.module(g.s - 1).dimension(g.t));
+        qi.apply(c.as_slice_mut(), 1, e.as_slice());
+        Some(c)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    #[test]
+    fn module_descriptor_auto_extends_composite_operations() {
+        // The `.json` path now goes through the standard `FDModule::from_json`, backed
+        // by the `GeneratedAlgebra` impl of A_C/τ: a descriptor lists only *generator*
+        // actions and the action of every composite operation is extended from them.
+        // Here x₀ --P(0,1)--> x₂ --Q₀--> x₃; the composite operation `Q_0 P(0, 1)` (a
+        // non-generator basis element in degree 3) is never listed, yet must act
+        // x₀ ↦ x₃ — the parity win over an explicit-actions-only loader.
+        let descriptor = serde_json::json!({
+            "gens": { "x0": 0, "x2": 2, "x3": 3 },
+            "actions": ["P(0, 1) x0 = x2", "Q_0 x2 = x3"],
+        });
+        let module = MotivicResolution::module_from_json(&descriptor).unwrap();
+        let algebra = module.algebra();
+        let (_, q0) = algebra.basis_element_from_string("Q_0").unwrap();
+        let (_, p01) = algebra.basis_element_from_string("P(0, 1)").unwrap();
+
+        // The two-step generator action Q₀(P(0,1)·x₀) = Q₀·x₂ = x₃.
+        let mut x2 = FpVector::new(TWO, module.dimension(2));
+        module.act_on_basis(x2.as_slice_mut(), 1, 2, p01, 0, 0);
+        let mut two_step = FpVector::new(TWO, module.dimension(3));
+        module.act(two_step.as_slice_mut(), 1, 1, q0, 2, x2.as_slice());
+        let mut x3 = FpVector::new(TWO, module.dimension(3));
+        x3.add_basis_element(0, 1);
+        assert_eq!(two_step, x3, "Q₀(P(0,1)·x₀) should be x₃");
+
+        // The single-step action by the algebra product Q₀·P(0,1) = Q₁ + Q₀P(0,1)
+        // (both degree-3 non-generators, extended not listed) must agree — the module
+        // axiom that composite auto-extension is responsible for.
+        let mut product = FpVector::new(TWO, algebra.dimension(3));
+        algebra.multiply_basis_elements(product.as_slice_mut(), 1, 1, q0, 2, p01);
+        assert!(
+            product.iter_nonzero().count() >= 2,
+            "Q₀·P(0,1) is a genuine composite"
+        );
+        let mut one_step = FpVector::new(TWO, module.dimension(3));
+        for (b, _) in product.iter_nonzero() {
+            module.act_on_basis(one_step.as_slice_mut(), 1, 3, b, 0, 0);
+        }
+        assert_eq!(
+            one_step, two_step,
+            "acting by the extended composite Q₀·P(0,1) must match the two-step action"
+        );
+    }
+
+    #[test]
+    fn module_descriptor_rejects_inconsistent_actions() {
+        // A descriptor whose generator actions violate a Steenrod relation is rejected
+        // by `check_validity`, using `GeneratedAlgebra::generating_relations`. Here
+        // Q₀ x₀ = x₁ and Q₀ x₁ = x₂ would force Q₀² x₀ = x₂ ≠ 0, but Q₀² = 0 in A_C/τ.
+        let descriptor = serde_json::json!({
+            "gens": { "x0": 0, "x1": 1, "x2": 2 },
+            "actions": ["Q_0 x0 = x1", "Q_0 x1 = x2"],
+        });
+        let err = match MotivicResolution::module_from_json(&descriptor) {
+            Err(e) => e,
+            Ok(_) => panic!("Q₀² = 0 must reject this descriptor"),
+        };
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("Relation failed") && msg.contains("Q_0"),
+            "expected a Q_0² relation failure, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn lift_is_a_complex_and_reduces_correctly() {
+        // Build once (expensive: the padded resolution plus the lift), then check
+        // everything: every generator in the report box has a weight; reducing
+        // each lifted differential mod τ recovers the Phase 1 model; and d² = 0
+        // over A_C (the corrections worked).
+        let max = Bidegree::n_s(8, 5);
+        let res = MotivicResolution::new(max);
+
+        // The unit has weight 0, and every generator in range has a weight.
+        assert_eq!(res.generator_weight(Gen { s: 0, t: 0, idx: 0 }), 0);
+        let mut count = 0;
+        for s in 0..=res.max_s() {
+            for t in 0..=(max.n() + s) {
+                for idx in 0..res.num_gens(s, t) {
+                    let _ = res.generator_weight(Gen { s, t, idx });
+                    count += 1;
+                }
+            }
+        }
+        assert!(count > 15, "expected many generators, got {count}");
+
+        res.verify_mod_tau_reduction();
+        res.verify_d_squared_zero();
+
+        // The lift must create a nontrivial augmentation part δ (the τ-power
+        // corrections on the unit operation) — this is what Phase 3 takes
+        // cohomology of. Every δ-entry carries a positive τ-power.
+        let mut delta_entries = 0;
+        for s in 1..=res.max_s() {
+            for t in 0..=(max.n() + s) {
+                for idx in 0..res.num_gens(s, t) {
+                    for (_target, power) in res.delta(Gen { s, t, idx }) {
+                        assert!(power >= 1, "δ entry with non-positive τ-power");
+                        delta_entries += 1;
+                    }
+                }
+            }
+        }
+        assert!(
+            delta_entries > 0,
+            "the lift produced no δ (augmentation) terms"
+        );
+    }
+}

--- a/ext/src/motivic/persist.rs
+++ b/ext/src/motivic/persist.rs
@@ -1,0 +1,134 @@
+//! Disk cache for the Phase 2 lift: the motivic weights and the lifted $A_C$
+//! differentials, keyed by the `(max, compute)` box so a stale cache is never
+//! loaded. Written alongside the mod-$\tau$ resolution's own save directory (see
+//! [`MotivicResolution::with_module`]).
+
+use std::{
+    collections::{BTreeSet, HashMap},
+    path::PathBuf,
+    sync::Arc,
+};
+
+use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
+
+use super::{Gen, MotivicResolution};
+
+impl MotivicResolution {
+    /// Path of the weights + lifted-differential cache within `save_dir`.
+    fn lift_cache_path(save_dir: &Option<PathBuf>) -> Option<PathBuf> {
+        save_dir.as_ref().map(|d| d.join("motivic-lift.bin"))
+    }
+
+    /// Save the weights and lifted differentials to `save_dir/motivic-lift.bin`,
+    /// tagged with the compute box so a stale cache is never loaded. No-op if
+    /// `save_dir` is `None`.
+    pub(super) fn save_lift(&self, save_dir: &Option<PathBuf>) {
+        let Some(path) = Self::lift_cache_path(save_dir) else {
+            return;
+        };
+        let Ok(file) = std::fs::File::create(&path) else {
+            return;
+        };
+        let mut w = std::io::BufWriter::new(file);
+        let write = |w: &mut std::io::BufWriter<std::fs::File>| -> std::io::Result<()> {
+            // Header: magic + the (max, compute) box this lift was computed for.
+            w.write_u32::<LittleEndian>(0x004D_0004)?;
+            for v in [
+                self.max.n(),
+                self.max.s(),
+                self.compute.n(),
+                self.compute.s(),
+            ] {
+                w.write_i32::<LittleEndian>(v)?;
+            }
+            // Weights: (s, t, idx, weight).
+            w.write_u64::<LittleEndian>(self.weights.len() as u64)?;
+            for (g, &wt) in self.weights.iter() {
+                w.write_i32::<LittleEndian>(g.s)?;
+                w.write_i32::<LittleEndian>(g.t)?;
+                w.write_u64::<LittleEndian>(g.idx as u64)?;
+                w.write_i32::<LittleEndian>(wt)?;
+            }
+            // Lifted differentials: (s, t, idx, len, [indices]).
+            w.write_u64::<LittleEndian>(self.lifted.len() as u64)?;
+            for (g, support) in &self.lifted {
+                w.write_i32::<LittleEndian>(g.s)?;
+                w.write_i32::<LittleEndian>(g.t)?;
+                w.write_u64::<LittleEndian>(g.idx as u64)?;
+                w.write_u64::<LittleEndian>(support.len() as u64)?;
+                for &b in support {
+                    w.write_u64::<LittleEndian>(b as u64)?;
+                }
+            }
+            Ok(())
+        };
+        let _ = write(&mut w);
+    }
+
+    /// Load the weights and lifted differentials from the cache, returning whether a
+    /// valid cache for this exact `(max, compute)` box was found and read.
+    pub(super) fn load_lift(&mut self, save_dir: &Option<PathBuf>) -> bool {
+        let Some(path) = Self::lift_cache_path(save_dir) else {
+            return false;
+        };
+        let Ok(file) = std::fs::File::open(&path) else {
+            return false;
+        };
+        let mut r = std::io::BufReader::new(file);
+        let read = |r: &mut std::io::BufReader<std::fs::File>| -> std::io::Result<
+            Option<(HashMap<Gen, i32>, HashMap<Gen, BTreeSet<usize>>)>,
+        > {
+            if r.read_u32::<LittleEndian>()? != 0x004D_0004 {
+                return Ok(None);
+            }
+            let hdr = [
+                r.read_i32::<LittleEndian>()?,
+                r.read_i32::<LittleEndian>()?,
+                r.read_i32::<LittleEndian>()?,
+                r.read_i32::<LittleEndian>()?,
+            ];
+            if hdr
+                != [
+                    self.max.n(),
+                    self.max.s(),
+                    self.compute.n(),
+                    self.compute.s(),
+                ]
+            {
+                return Ok(None); // cache is for a different box
+            }
+            let mut weights = HashMap::new();
+            for _ in 0..r.read_u64::<LittleEndian>()? {
+                let g = Gen {
+                    s: r.read_i32::<LittleEndian>()?,
+                    t: r.read_i32::<LittleEndian>()?,
+                    idx: r.read_u64::<LittleEndian>()? as usize,
+                };
+                weights.insert(g, r.read_i32::<LittleEndian>()?);
+            }
+            let mut lifted = HashMap::new();
+            for _ in 0..r.read_u64::<LittleEndian>()? {
+                let g = Gen {
+                    s: r.read_i32::<LittleEndian>()?,
+                    t: r.read_i32::<LittleEndian>()?,
+                    idx: r.read_u64::<LittleEndian>()? as usize,
+                };
+                let len = r.read_u64::<LittleEndian>()?;
+                let mut support = BTreeSet::new();
+                for _ in 0..len {
+                    support.insert(r.read_u64::<LittleEndian>()? as usize);
+                }
+                lifted.insert(g, support);
+            }
+            Ok(Some((weights, lifted)))
+        };
+        match read(&mut r) {
+            Ok(Some((weights, lifted))) => {
+                self.weights = Arc::new(weights);
+                self.lifted = lifted;
+                true
+            }
+            _ => false,
+        }
+    }
+}


### PR DESCRIPTION
Draft — third tranche of the motivic stack. Cumulative: contains the resolution tranche below it, so review only the top commit until that one lands.

## What this is

Assemble the lifted differential into a trigraded spectral sequence (stem `n`, filtration `s`, weight `w`):

- $E_1 = \mathrm{Ext}_{A_C/\tau}$, grouped by weight, with $d_1$ the **weight-1 part of δ**.
- higher $d_r$ by the **τ-Bockstein zig-zag**: push $\delta(\tilde x)$ up in weight one order at a time, correcting each intermediate order against $d_1$'s stored quasi-inverse, and read the weight-$(w+r)$ part.
- inverting τ gives the classical Adams $E_2$; finite-page deaths are the motivic τ-torsion.

Adds `classical_ext_rank` and the `chart_motivic` example.

## Stack

- Below: the resolution + τ-lift tranche, and #266.
- Above: the Ext-side cohomology, products and Massey tranche.

## Deferred

`deformation_products` goes with the products tranche — it reads multiplication off the Ext DGA, so it needs the cohomology layer (and #267) rather than anything here.

## Status

Build/clippy/fmt clean. 6 motivic tests pass, including the anchor: **inverting τ reproduces the classical Adams $E_2$** over the tested range.


---
_Generated by [Claude Code](https://claude.ai/code/session_013ePtYD7Bt4iPeCtmqtqvZE)_