### PR TITLE
algebra: extract the Milnor product and derive `generic` from the prime

### DIFF
--- a/ext/crates/algebra/src/algebra/milnor_algebra.rs
+++ b/ext/crates/algebra/src/algebra/milnor_algebra.rs
@@ -414,8 +414,6 @@ impl std::fmt::Display for MilnorBasisElement {
 pub struct MilnorAlgebra {
     profile: MilnorProfile,
     p: ValidPrime,
-    #[cfg(feature = "odd-primes")]
-    generic: bool,
 
     unstable_enabled: bool,
 
@@ -455,8 +453,6 @@ impl MilnorAlgebra {
         assert!(profile.is_valid());
         Self {
             p,
-            #[cfg(feature = "odd-primes")]
-            generic: p != 2,
             unstable_enabled,
             profile,
             ppart_table: OnceVec::new(),
@@ -468,17 +464,13 @@ impl MilnorAlgebra {
         }
     }
 
+    /// Whether the algebra has an exterior part, which is the case exactly at odd primes.
+    ///
+    /// Without the `odd-primes` feature [`ValidPrime`] is the zero-sized type $2$, so this folds
+    /// to a constant `false`.
     #[inline]
     pub fn generic(&self) -> bool {
-        #[cfg(feature = "odd-primes")]
-        {
-            self.generic
-        }
-
-        #[cfg(not(feature = "odd-primes"))]
-        {
-            false
-        }
+        self.p != 2
     }
 
     pub fn q(&self) -> i32 {
@@ -1195,62 +1187,6 @@ impl MilnorAlgebra {
         self.try_beps_pn(e, x).unwrap()
     }
 
-    fn multiply_qpart(&self, m1: MilnorBasisElement, f: u32) -> Vec<(u32, MilnorBasisElement)> {
-        let mut new_result: Vec<(u32, MilnorBasisElement)> = vec![(1, m1)];
-        let mut old_result: Vec<(u32, MilnorBasisElement)> = Vec::new();
-
-        for k in BitflagIterator::set_bit_iterator(f as u64) {
-            let k = k as u32;
-            let pk = self.p.pow(k);
-            std::mem::swap(&mut new_result, &mut old_result);
-            new_result.clear();
-
-            // We implement the formula
-            // P(R) Q_k = Q_k P^R + Q_{k+1} P(R - p^k e_1) + Q_{k+2} P(R - p^k e_2) +
-            // ... + Q_{k + i} P(R - p^k e_i) + ...
-            // where e_i is the vector with value 1 in entry i and 0 otherwise (in the above
-            // formula, the first xi is xi_1, hence the offset below). If R - p^k e_i has a
-            // negative entry, the term is 0.
-            //
-            // We also use the fact that Q_k Q_j = -Q_j Q_k
-            for (coef, term) in &old_result {
-                for i in 0..=term.p_part.len() {
-                    // If there is already Q_{k+i} on the other side, the result is 0
-                    if term.q_part & (1 << (k + i as u32)) != 0 {
-                        continue;
-                    }
-                    let mut new_p = term.p_part;
-                    if i > 0 {
-                        // Check if R - p^k e_i < 0. Only do this from the first term onwards.
-                        let entry = new_p.get(i - 1);
-                        if entry < pk {
-                            continue;
-                        }
-                        new_p.set(i - 1, entry - pk);
-                    }
-
-                    // Now calculate the number of Q's we are moving past
-                    let larger_q = (term.q_part >> (k + i as u32 + 1)).count_ones();
-
-                    // Now put everything together
-                    let m = MilnorBasisElement {
-                        p_part: new_p,
-                        q_part: term.q_part | (1 << (k + i as u32)),
-                        degree: 0, // we don't really care about the degree here. The final degree of the whole calculation is known a priori
-                    };
-                    let c = if larger_q.is_multiple_of(2) {
-                        *coef
-                    } else {
-                        *coef * (self.prime() - 1)
-                    };
-
-                    new_result.push((c, m));
-                }
-            }
-        }
-        new_result
-    }
-
     pub fn multiply(
         &self,
         res: FpSliceMut,
@@ -1270,48 +1206,16 @@ impl MilnorAlgebra {
         m1: MilnorBasisElement,
         m2: MilnorBasisElement,
         excess: i32,
-        mut allocation: PPartAllocation,
+        allocation: PPartAllocation,
     ) -> PPartAllocation {
         let target_deg = m1.degree + m2.degree;
-        if self.generic() {
-            let m1f = self.multiply_qpart(m1, m2.q_part);
-            for (cc, basis) in m1f {
-                let mut multiplier = PPartMultiplier::<false>::new_from_allocation(
-                    self.prime(),
-                    basis.p_part,
-                    m2.p_part,
-                    allocation,
-                    basis.q_part,
-                    target_deg,
-                );
-
-                while let Some(c) = multiplier.next() {
-                    let idx = self.basis_element_to_index(&multiplier.ans);
-                    if idx < self.dimension_unstable(target_deg, excess) {
-                        res.add_basis_element(idx, c * cc * coef);
-                    }
-                }
-                allocation = multiplier.into_allocation()
+        let dim = self.dimension_unstable(target_deg, excess);
+        milnor_product(self.prime(), m1, m2, allocation, |c, ans| {
+            let idx = self.basis_element_to_index(ans);
+            if idx < dim {
+                res.add_basis_element(idx, c * coef);
             }
-        } else {
-            let mut multiplier = PPartMultiplier::<false>::new_from_allocation(
-                self.prime(),
-                m1.p_part,
-                m2.p_part,
-                allocation,
-                0,
-                target_deg,
-            );
-
-            while let Some(c) = multiplier.next() {
-                let idx = self.basis_element_to_index(&multiplier.ans);
-                if idx < self.dimension_unstable(target_deg, excess) {
-                    res.add_basis_element(idx, c * coef);
-                }
-            }
-            allocation = multiplier.into_allocation()
-        }
-        allocation
+        })
     }
 
     pub fn multiply_basis_by_element(
@@ -1450,6 +1354,103 @@ impl PPartAllocation {
 pub const fn next_disjoint(sum: PPartEntry, k: PPartEntry) -> PPartEntry {
     debug_assert!(k & sum == 0, "next_disjoint needs k disjoint from sum");
     ((k | sum) + 1) & !sum
+}
+
+fn multiply_qpart(p: ValidPrime, m1: MilnorBasisElement, f: u32) -> Vec<(u32, MilnorBasisElement)> {
+    let mut new_result: Vec<(u32, MilnorBasisElement)> = vec![(1, m1)];
+    let mut old_result: Vec<(u32, MilnorBasisElement)> = Vec::new();
+
+    for k in BitflagIterator::set_bit_iterator(f as u64) {
+        let k = k as u32;
+        let pk = p.pow(k);
+        std::mem::swap(&mut new_result, &mut old_result);
+        new_result.clear();
+
+        // We implement the formula
+        // P(R) Q_k = Q_k P^R + Q_{k+1} P(R - p^k e_1) + Q_{k+2} P(R - p^k e_2) +
+        // ... + Q_{k + i} P(R - p^k e_i) + ...
+        // where e_i is the vector with value 1 in entry i and 0 otherwise (in the above
+        // formula, the first xi is xi_1, hence the offset below). If R - p^k e_i has a
+        // negative entry, the term is 0.
+        //
+        // We also use the fact that Q_k Q_j = -Q_j Q_k
+        for (coef, term) in &old_result {
+            for i in 0..=term.p_part.len() {
+                // If there is already Q_{k+i} on the other side, the result is 0
+                if term.q_part & (1 << (k + i as u32)) != 0 {
+                    continue;
+                }
+                let mut new_p = term.p_part;
+                if i > 0 {
+                    // Check if R - p^k e_i < 0. Only do this from the first term onwards.
+                    let entry = new_p.get(i - 1);
+                    if entry < pk {
+                        continue;
+                    }
+                    new_p.set(i - 1, entry - pk);
+                }
+
+                // Now calculate the number of Q's we are moving past
+                let larger_q = (term.q_part >> (k + i as u32 + 1)).count_ones();
+
+                // Now put everything together
+                let m = MilnorBasisElement {
+                    p_part: new_p,
+                    q_part: term.q_part | (1 << (k + i as u32)),
+                    degree: 0, // we don't really care about the degree here. The final degree of the whole calculation is known a priori
+                };
+                let c = if larger_q.is_multiple_of(2) {
+                    *coef
+                } else {
+                    *coef * (p - 1)
+                };
+
+                new_result.push((c, m));
+            }
+        }
+    }
+    new_result
+}
+
+/// Multiply two Milnor basis elements, reporting each `(coefficient, basis element)` of the result.
+///
+/// The exterior part of `m2` is commuted leftwards past `m1` by `multiply_qpart`, and each
+/// resulting polynomial part is expanded by a single [`PPartMultiplier`] walk. When `m2` has no
+/// exterior part there is nothing to commute, and this is the walk alone: the classical $p = 2$
+/// product.
+pub fn milnor_product(
+    p: ValidPrime,
+    m1: MilnorBasisElement,
+    m2: MilnorBasisElement,
+    mut allocation: PPartAllocation,
+    mut f: impl FnMut(u32, &MilnorBasisElement),
+) -> PPartAllocation {
+    let target_deg = m1.degree + m2.degree;
+    let mut walk = |cc: u32, basis: &MilnorBasisElement, allocation| {
+        let mut multiplier = PPartMultiplier::<false>::new_from_allocation(
+            p,
+            basis.p_part,
+            m2.p_part,
+            allocation,
+            basis.q_part,
+            target_deg,
+        );
+        while let Some(c) = multiplier.next() {
+            f(c * cc, &multiplier.ans);
+        }
+        multiplier.into_allocation()
+    };
+
+    // An empty exterior part commutes past `m1` trivially, so skip the `multiply_qpart` buffer and
+    // its allocation. This is every product at $p = 2$.
+    if m2.q_part == 0 {
+        return walk(1, &m1, allocation);
+    }
+
+    for (cc, basis) in multiply_qpart(p, m1, m2.q_part) {
+        allocation = walk(cc, &basis, allocation);
+    }
+    allocation
 }
 
 #[allow(non_snake_case)]


### PR DESCRIPTION
Pure refactor of the Milnor product path — no behaviour change, no new API surface beyond one free function.

### Extract `milnor_product`

`multiply_with_allocation` branched on `generic()`, but the two arms were the same computation. `multiply_qpart(m1, 0)` returns `[(1, m1)]` — `BitflagIterator::set_bit_iterator(0)` yields nothing — so the classical arm is the generic arm with an empty exterior part. The two are collapsed into one free function:

```rust
pub fn milnor_product(
    p: ValidPrime,
    m1: MilnorBasisElement,
    m2: MilnorBasisElement,
    allocation: PPartAllocation,
    f: impl FnMut(u32, &MilnorBasisElement),
) -> PPartAllocation
```

which reports each `(coefficient, basis element)` through a callback, leaving the index lookup and excess filter to the caller. `multiply_qpart` becomes free too; it only ever read `self.p`. `MilnorAlgebra::multiply_with_allocation` is now a thin wrapper.

The motivation is downstream: $A_C/\tau \cong \mathbb{F}_2[\xi_i] \otimes E(\tau_i)$ has the odd-primary dual's shape with $2^i$ in place of $p^i$, so its product is the same commutation rule plus one `PPartMultiplier` walk. Sharing this function rather than reimplementing it keeps one algorithm under test instead of two.

### Derive `generic` from the prime

The field was written once by the constructor as `p != 2` and never mutated — a cached derivation, not state. `generic()` now computes it.

That also drops its `#[cfg(feature = "odd-primes")]` gate. Without the feature `ValidPrime` is the zero-sized type $2$, so `self.p != 2` folds to a constant `false` on its own; the cfg was doing nothing the type system wasn't already doing.

Removing the field also closes a latent trap. A hand-constructed `p = 2, generic = true` algebra has exactly the graded dimensions of $A_C/\tau$ (41 degrees checked, 0 differ), which makes it tempting as a shortcut — but `generators()` finds $Q_k$ via `factor_pk(p, degree + 1) == (k, 2)`, the odd-primary $|Q_k| = 2p^k - 1$. At $p = 2$, `factor_pk(2, 2^{k+1}) = (k+1, 1)`, so every $Q_k$ past $Q_0$ silently vanishes from the generating set. Correct at odd primes, unreachable through the constructor today, and now unreachable by construction.

### Checks

`cargo test -p algebra` (63 pass), `cargo fmt --check`, `cargo clippy --all-targets`, `cargo check --no-default-features`, and `just docs` under CI's `RUSTFLAGS`/`RUSTDOCFLAGS: -D warnings` — all clean.

### Relationship to the motivic work

Independent of #266 — the two touch disjoint regions of `milnor_algebra.rs` and rebase past each other in either order. Only the follow-up $A_C/\tau$ PR needs both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F25ZVbsP7ULg41iY3MP6FX


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a public Milnor product operation for multiplying Milnor basis elements with allocation support.

* **Improvements**
  * Unified multiplication behavior across supported prime configurations.
  * Improved handling of exterior and polynomial components during multiplication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->